### PR TITLE
[REMANIEMENT] Intercepteur composant générique

### DIFF
--- a/mon-aide-cyber-ui/src/composants/ComposantDiagnostique.tsx
+++ b/mon-aide-cyber-ui/src/composants/ComposantDiagnostique.tsx
@@ -67,11 +67,11 @@ const ComposantQuestion = ({ question }: ProprietesComposantQuestion) => {
 };
 
 type ProprietesComposantDiagnostique = {
-  identifiant: UUID;
+  idDiagnostique: UUID;
 };
 
 export const ComposantDiagnostique = ({
-  identifiant,
+  idDiagnostique,
 }: ProprietesComposantDiagnostique) => {
   const [referentiel, setReferentiel] = useState<Referentiel | undefined>(
     undefined,
@@ -82,9 +82,9 @@ export const ComposantDiagnostique = ({
   useEffect(() => {
     entrepots
       .diagnostique()
-      .lis(identifiant)
+      .lis(idDiagnostique)
       .then((diagnostique) => setReferentiel(diagnostique.referentiel));
-  }, [entrepots, identifiant]);
+  }, [entrepots, idDiagnostique]);
 
   return (
     <>

--- a/mon-aide-cyber-ui/src/composants/intercepteurs/ComposantDiagnostiqueIntercepteur.tsx
+++ b/mon-aide-cyber-ui/src/composants/intercepteurs/ComposantDiagnostiqueIntercepteur.tsx
@@ -1,9 +1,0 @@
-import { useParams } from "react-router-dom";
-import { ComposantDiagnostique } from "../ComposantDiagnostique.tsx";
-import { UUID } from "../../types/Types.ts";
-
-export const ComposantDiagnostiqueIntercepteur = () => {
-  const { idDiagnostique } = useParams();
-
-  return <ComposantDiagnostique identifiant={idDiagnostique! as UUID} />;
-};

--- a/mon-aide-cyber-ui/src/composants/intercepteurs/ComposantIntercepteur.tsx
+++ b/mon-aide-cyber-ui/src/composants/intercepteurs/ComposantIntercepteur.tsx
@@ -1,0 +1,31 @@
+import { useParams } from "react-router-dom";
+import React from "react";
+import { UUID } from "../../types/Types.ts";
+
+type CommePropriete<C extends React.ElementType> = {
+  composant?: C;
+};
+
+type ProprietesAOmettre<
+  C extends React.ElementType,
+  P,
+> = keyof (CommePropriete<C> & P);
+
+type ProprietesComposantIntercepteur<
+  C extends React.ElementType,
+  Proprietes = unknown,
+> = React.PropsWithChildren<Proprietes & CommePropriete<C>> &
+  Omit<React.ComponentPropsWithoutRef<C>, ProprietesAOmettre<C, Proprietes>>;
+
+type ProprietesComposant = {
+  idDiagnostique?: UUID;
+};
+
+export const ComposantIntercepteur = <C extends React.ElementType = "div">({
+  composant,
+}: ProprietesComposantIntercepteur<C, ProprietesComposant>) => {
+  const Composant = composant || "div";
+  const params = useParams();
+
+  return <Composant {...params} />;
+};

--- a/mon-aide-cyber-ui/src/main.tsx
+++ b/mon-aide-cyber-ui/src/main.tsx
@@ -4,8 +4,9 @@ import App from "./App.tsx";
 import "./assets/styles/index.scss";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { FournisseurEntrepots } from "./fournisseurs/FournisseurEntrepot.ts";
-import { ComposantDiagnostiqueIntercepteur } from "./composants/intercepteurs/ComposantDiagnostiqueIntercepteur.tsx";
+import { ComposantIntercepteur } from "./composants/intercepteurs/ComposantIntercepteur.tsx";
 import { APIEntrepotDiagnostique } from "./infrastructure/entrepots/EntrepotsAPI.ts";
+import { ComposantDiagnostique } from "./composants/ComposantDiagnostique.tsx";
 
 const routeur = createBrowserRouter([
   {
@@ -14,7 +15,7 @@ const routeur = createBrowserRouter([
   },
   {
     path: "diagnostique/:idDiagnostique",
-    element: <ComposantDiagnostiqueIntercepteur />,
+    element: <ComposantIntercepteur composant={ComposantDiagnostique} />,
   },
 ]);
 

--- a/mon-aide-cyber-ui/src/stories/Diagnostique.stories.tsx
+++ b/mon-aide-cyber-ui/src/stories/Diagnostique.stories.tsx
@@ -68,7 +68,7 @@ type Story = StoryObj<typeof meta>;
 
 export const AfficheQuestionDiagnostique: Story = {
   name: "Affiche une question du diagnostique",
-  args: { identifiant: identifiantUneQuestion },
+  args: { idDiagnostique: identifiantUneQuestion },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -89,7 +89,7 @@ export const AfficheQuestionDiagnostique: Story = {
 
 export const AfficheQuestionDiagnostiqueAvecChampsSaisie: Story = {
   name: "Affiche une question avec plusieurs réponses dont un champs de saisie pour la réponse",
-  args: { identifiant: identifiantChampsDeSaise },
+  args: { idDiagnostique: identifiantChampsDeSaise },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -100,7 +100,7 @@ export const AfficheQuestionDiagnostiqueAvecChampsSaisie: Story = {
 };
 export const AfficheDiagnostiqueAvecPlusieursQuestions: Story = {
   name: "Affiche plusieurs questions",
-  args: { identifiant: identifiantPlusieursQuestions },
+  args: { idDiagnostique: identifiantPlusieursQuestions },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 


### PR DESCRIPTION
Charge les composants depuis le routeur React sans avoir de dépendance à `React-Router` au sein de nos composants