### PR TITLE
[REMANIEMENT] Corrige la signature de la méthode 'lis' de l'adaptateur référentiel

### DIFF
--- a/mon-aide-cyber-api/src/adaptateurs/AdaptateurReferentiel.ts
+++ b/mon-aide-cyber-api/src/adaptateurs/AdaptateurReferentiel.ts
@@ -1,3 +1,5 @@
+import { Referentiel } from "../diagnostique/Referentiel";
+
 export interface AdaptateurReferentiel {
-  lis(): Promise<object>;
+  lis(): Promise<Referentiel>;
 }

--- a/mon-aide-cyber-api/src/diagnostique/ServiceDiagnostique.ts
+++ b/mon-aide-cyber-api/src/diagnostique/ServiceDiagnostique.ts
@@ -11,9 +11,9 @@ export class ServiceDiagnostique {
   ) {}
 
   diagnostique = async (id: crypto.UUID): Promise<Diagnostique> =>
-    this.adaptateurReferentiel.lis().then((contenu) => ({
+    this.adaptateurReferentiel.lis().then((referentiel) => ({
       identifiant: id,
-      referentiel: (contenu as Diagnostique).referentiel,
+      referentiel,
     }));
 
   cree(): Promise<Diagnostique> {

--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurReferentielMAC.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurReferentielMAC.ts
@@ -1,6 +1,7 @@
 import { AdaptateurReferentiel } from "../../adaptateurs/AdaptateurReferentiel";
 import { referentiel } from "../../diagnostique/donneesReferentiel";
+import { Referentiel } from "../../diagnostique/Referentiel";
 
 export class AdaptateurReferentielMAC implements AdaptateurReferentiel {
-  lis = (): Promise<object> => Promise.resolve({ referentiel });
+  lis = (): Promise<Referentiel> => Promise.resolve(referentiel);
 }

--- a/mon-aide-cyber-api/test/adaptateurs/AdaptateurReferentielDeTest.ts
+++ b/mon-aide-cyber-api/test/adaptateurs/AdaptateurReferentielDeTest.ts
@@ -1,13 +1,16 @@
 import { AdaptateurReferentiel } from "../../src/adaptateurs/AdaptateurReferentiel";
+import { Referentiel } from "../../src/diagnostique/Referentiel";
 
 export class AdaptateurReferentielDeTest implements AdaptateurReferentiel {
-  private contenu = {};
+  private referentiel: Referentiel | undefined = undefined;
 
-  lis(): Promise<object> {
-    return Promise.resolve(this.contenu);
+  lis(): Promise<Referentiel> {
+    return this.referentiel !== undefined
+      ? Promise.resolve(this.referentiel)
+      : Promise.reject("Referentiel non connu");
   }
 
-  ajoute(contenu: object) {
-    this.contenu = { ...this.contenu, ...contenu };
+  ajoute(referentiel: Referentiel) {
+    this.referentiel = referentiel;
   }
 }

--- a/mon-aide-cyber-api/test/api/testRouteDiagnostique.spec.ts
+++ b/mon-aide-cyber-api/test/api/testRouteDiagnostique.spec.ts
@@ -17,7 +17,7 @@ describe("le serveur MAC sur les routes /api/diagnostiques/", () => {
       const diagnostique = unDiagnostique()
         .avecUnReferentiel(unReferentiel().construis())
         .construis();
-      testeurMAC.adaptateurDonnees.ajoute(diagnostique);
+      testeurMAC.adaptateurDonnees.ajoute(diagnostique.referentiel);
 
       const reponse = await fetch(
         `http://localhost:1234/api/diagnostiques/${id}`,

--- a/mon-aide-cyber-api/test/diagnostique/ServiceDiagnostique.spec.ts
+++ b/mon-aide-cyber-api/test/diagnostique/ServiceDiagnostique.spec.ts
@@ -47,7 +47,7 @@ describe("Le service de diagnostique", () => {
             .construis(),
         )
         .construis();
-      adaptateurReferentiel.ajoute(diagnostique);
+      adaptateurReferentiel.ajoute(diagnostique.referentiel);
       const serviceDiagnostique = new ServiceDiagnostique(
         adaptateurReferentiel,
         new EntrepotsMemoire(),


### PR DESCRIPTION
`AdaptateurReferentiel::lis()` retournait un `object`, il retourne maintenant un `Referentiel`