### PR TITLE
[DIAGNOSTIC] Ajoute un bouton pour lancer un diagnostic

### DIFF
--- a/mon-aide-cyber-ui/src/App.tsx
+++ b/mon-aide-cyber-ui/src/App.tsx
@@ -1,10 +1,13 @@
 import "./assets/styles/App.scss";
+import { ComposantLancerDiagnostic } from "./composants/diagnostic/ComposantLancerDiagnostic.tsx";
 
 function App() {
   return (
     <>
       <div>
         <h2>MonAideCyber</h2>
+
+        <ComposantLancerDiagnostic />
       </div>
     </>
   );

--- a/mon-aide-cyber-ui/src/composants/diagnostic/ComposantDiagnostique.tsx
+++ b/mon-aide-cyber-ui/src/composants/diagnostic/ComposantDiagnostique.tsx
@@ -2,13 +2,13 @@ import { PropsWithChildren, useContext, useEffect, useReducer } from "react";
 import {
   Question,
   ReponsePossible,
-} from "../domaine/diagnostique/Referentiel.ts";
-import { FournisseurEntrepots } from "../fournisseurs/FournisseurEntrepot.ts";
-import { UUID } from "../types/Types.ts";
+} from "../../domaine/diagnostique/Referentiel.ts";
+import { FournisseurEntrepots } from "../../fournisseurs/FournisseurEntrepot.ts";
+import { UUID } from "../../types/Types.ts";
 import {
   diagnostiqueCharge,
   reducteurDiagnostique,
-} from "../domaine/diagnostique/reducteurs.ts";
+} from "../../domaine/diagnostique/reducteurs.ts";
 import { useErrorBoundary } from "react-error-boundary";
 
 type ProprietesComposantQuestion = {

--- a/mon-aide-cyber-ui/src/composants/diagnostic/ComposantLancerDiagnostic.tsx
+++ b/mon-aide-cyber-ui/src/composants/diagnostic/ComposantLancerDiagnostic.tsx
@@ -1,0 +1,19 @@
+import { useCallback, useContext } from "react";
+import { FournisseurEntrepots } from "../../fournisseurs/FournisseurEntrepot.ts";
+import { useErrorBoundary } from "react-error-boundary";
+import { useNavigate } from "react-router-dom";
+
+export const ComposantLancerDiagnostic = () => {
+  const entrepots = useContext(FournisseurEntrepots);
+  const { showBoundary } = useErrorBoundary();
+  const navigate = useNavigate();
+
+  const lancerDiagnostic = useCallback(async () => {
+    return await entrepots
+      .diagnostique()
+      .lancer()
+      .then((lien) => navigate(lien.route()))
+      .catch((erreur) => showBoundary(erreur));
+  }, [entrepots, showBoundary, navigate]);
+  return <button onClick={lancerDiagnostic}>Lancer un diagnostic</button>;
+};

--- a/mon-aide-cyber-ui/src/domaine/Entrepots.ts
+++ b/mon-aide-cyber-ui/src/domaine/Entrepots.ts
@@ -1,6 +1,7 @@
 import { EntrepotDiagnostique } from "./diagnostique/Diagnostique.ts";
+import { Aggregat } from "./Aggregat.ts";
 
-export interface Entrepot<T> {
+export interface Entrepot<T extends Aggregat> {
   lis(identifiant: string): Promise<T>;
 }
 

--- a/mon-aide-cyber-ui/src/domaine/Entrepots.ts
+++ b/mon-aide-cyber-ui/src/domaine/Entrepots.ts
@@ -1,6 +1,15 @@
 import { EntrepotDiagnostique } from "./diagnostique/Diagnostique.ts";
 import { Aggregat } from "./Aggregat.ts";
 
+export type FormatLien = `/api/${string}`;
+export class Lien {
+  constructor(private readonly lien: FormatLien) {}
+
+  route(): string {
+    return this.lien.slice(this.lien.indexOf("/api") + 4);
+  }
+}
+
 export interface Entrepot<T extends Aggregat> {
   lis(identifiant: string): Promise<T>;
 }

--- a/mon-aide-cyber-ui/src/domaine/diagnostique/Diagnostique.ts
+++ b/mon-aide-cyber-ui/src/domaine/diagnostique/Diagnostique.ts
@@ -1,9 +1,11 @@
 import { Referentiel } from "./Referentiel.ts";
 import { Aggregat } from "../Aggregat.ts";
 
-import { Entrepot } from "../Entrepots.ts";
+import { Entrepot, Lien } from "../Entrepots.ts";
 
 export type Diagnostique = Aggregat & {
   referentiel: Referentiel;
 };
-export type EntrepotDiagnostique = Entrepot<Diagnostique>;
+export interface EntrepotDiagnostique extends Entrepot<Diagnostique> {
+  lancer(): Promise<Lien>;
+}

--- a/mon-aide-cyber-ui/src/infrastructure/entrepots/EntrepotsAPI.ts
+++ b/mon-aide-cyber-ui/src/infrastructure/entrepots/EntrepotsAPI.ts
@@ -2,14 +2,27 @@ import {
   Diagnostique,
   EntrepotDiagnostique,
 } from "../../domaine/diagnostique/Diagnostique.ts";
+import { Entrepot } from "../../domaine/Entrepots.ts";
+import { Aggregat } from "../../domaine/Aggregat.ts";
 
-export class APIEntrepotDiagnostique implements EntrepotDiagnostique {
-  lis(identifiant: string): Promise<Diagnostique> {
-    return fetch(`/api/diagnostique/${identifiant}`).then((reponse) => {
+abstract class APIEntrepot<T extends Aggregat> implements Entrepot<T> {
+  protected constructor(private readonly chemin: string) {}
+
+  lis(identifiant: string): Promise<T> {
+    return fetch(`/api/${this.chemin}/${identifiant}`).then((reponse) => {
       if (!reponse.ok) {
         return reponse.json().then((reponse) => Promise.reject(reponse));
       }
       return reponse.json();
     });
+  }
+}
+
+export class APIEntrepotDiagnostique
+  extends APIEntrepot<Diagnostique>
+  implements EntrepotDiagnostique
+{
+  constructor() {
+    super("diagnostique");
   }
 }

--- a/mon-aide-cyber-ui/src/infrastructure/entrepots/EntrepotsAPI.ts
+++ b/mon-aide-cyber-ui/src/infrastructure/entrepots/EntrepotsAPI.ts
@@ -2,7 +2,7 @@ import {
   Diagnostique,
   EntrepotDiagnostique,
 } from "../../domaine/diagnostique/Diagnostique.ts";
-import { Entrepot } from "../../domaine/Entrepots.ts";
+import { Entrepot, FormatLien, Lien } from "../../domaine/Entrepots.ts";
 import { Aggregat } from "../../domaine/Aggregat.ts";
 
 abstract class APIEntrepot<T extends Aggregat> implements Entrepot<T> {
@@ -16,6 +16,10 @@ abstract class APIEntrepot<T extends Aggregat> implements Entrepot<T> {
       return reponse.json();
     });
   }
+
+  persiste() {
+    return fetch(`/api/${this.chemin}`, { method: "POST" });
+  }
 }
 
 export class APIEntrepotDiagnostique
@@ -24,5 +28,11 @@ export class APIEntrepotDiagnostique
 {
   constructor() {
     super("diagnostique");
+  }
+
+  lancer(): Promise<Lien> {
+    return super
+      .persiste()
+      .then((reponse) => new Lien(reponse.headers.get("Link") as FormatLien));
   }
 }

--- a/mon-aide-cyber-ui/src/main.tsx
+++ b/mon-aide-cyber-ui/src/main.tsx
@@ -6,12 +6,18 @@ import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { FournisseurEntrepots } from "./fournisseurs/FournisseurEntrepot.ts";
 import { ComposantIntercepteur } from "./composants/intercepteurs/ComposantIntercepteur.tsx";
 import { APIEntrepotDiagnostique } from "./infrastructure/entrepots/EntrepotsAPI.ts";
-import { ComposantDiagnostique } from "./composants/ComposantDiagnostique.tsx";
+import { ComposantDiagnostique } from "./composants/diagnostic/ComposantDiagnostique.tsx";
+import { ComposantAffichageErreur } from "./composants/erreurs/ComposantAffichageErreur.tsx";
+import { ErrorBoundary } from "react-error-boundary";
 
 const routeur = createBrowserRouter([
   {
     path: "/",
-    element: <App />,
+    element: (
+      <ErrorBoundary FallbackComponent={ComposantAffichageErreur}>
+        <App />
+      </ErrorBoundary>
+    ),
   },
   {
     path: "diagnostique/:idDiagnostique",

--- a/mon-aide-cyber-ui/src/stories/Diagnostique.stories.tsx
+++ b/mon-aide-cyber-ui/src/stories/Diagnostique.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { waitFor, within } from "@storybook/testing-library";
-import { ComposantDiagnostique } from "../composants/ComposantDiagnostique.tsx";
+import { ComposantDiagnostique } from "../composants/diagnostic/ComposantDiagnostique.tsx";
 import { expect } from "@storybook/jest";
 import { FournisseurEntrepots } from "../fournisseurs/FournisseurEntrepot.ts";
 import { EntrepotDiagnostiqueMemoire } from "../../test/infrastructure/entrepots/EntrepotsMemoire.ts";

--- a/mon-aide-cyber-ui/src/stories/ErreurDiagnostique.stories.tsx
+++ b/mon-aide-cyber-ui/src/stories/ErreurDiagnostique.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { waitFor, within } from "@storybook/testing-library";
-import { ComposantDiagnostique } from "../composants/ComposantDiagnostique.tsx";
+import { ComposantDiagnostique } from "../composants/diagnostic/ComposantDiagnostique.tsx";
 import { expect } from "@storybook/jest";
 import { FournisseurEntrepots } from "../fournisseurs/FournisseurEntrepot.ts";
 import { EntrepotDiagnostiqueMemoire } from "../../test/infrastructure/entrepots/EntrepotsMemoire.ts";

--- a/mon-aide-cyber-ui/test/infrastructure/entrepots/EntrepotsMemoire.ts
+++ b/mon-aide-cyber-ui/test/infrastructure/entrepots/EntrepotsMemoire.ts
@@ -3,7 +3,8 @@ import {
   Diagnostique,
   EntrepotDiagnostique,
 } from "../../../src/domaine/diagnostique/Diagnostique";
-import { Entrepot } from "../../../src/domaine/Entrepots";
+import { Entrepot, Lien } from "../../../src/domaine/Entrepots";
+import { unDiagnostique } from "../../consructeurs/constructeurDiagnostique.ts";
 
 class EntrepotMemoire<T extends Aggregat> implements Entrepot<T> {
   private entites: T[] = [];
@@ -25,4 +26,12 @@ class EntrepotMemoire<T extends Aggregat> implements Entrepot<T> {
 
 export class EntrepotDiagnostiqueMemoire
   extends EntrepotMemoire<Diagnostique>
-  implements EntrepotDiagnostique {}
+  implements EntrepotDiagnostique
+{
+  lancer(): Promise<Lien> {
+    const diagnostic = unDiagnostique().construis();
+    return this.persiste(diagnostic).then(
+      () => new Lien(`/api/diagnostique/${diagnostic.identifiant}`),
+    );
+  }
+}


### PR DESCRIPTION
En cliquant sur le bouton `Lancer un diagnostic`, l'API lance le diagnostic et l'utilisateur est redirigé vers le diagnostic correspondant