### PR TITLE
[CORRECTION] Fixe la représentation des questions à tiroir à choix unique

### DIFF
--- a/mon-aide-cyber-api/src/api/representateurs/representateurDiagnostic.ts
+++ b/mon-aide-cyber-api/src/api/representateurs/representateurDiagnostic.ts
@@ -9,7 +9,7 @@ import {
   QuestionATranscrire,
   ReponseATranscrire,
   RepresentationDiagnostic,
-  RepresentationQuestionChoixMultiple,
+  RepresentationQuestion,
   RepresentationReponseComplementaire,
   RepresentationReponsePossible,
   Transcripteur,
@@ -52,7 +52,7 @@ const questionTiroirATranscrire = (
   question: QuestionChoixUnique | QuestionChoixMultiple | undefined,
   transcripteur: Transcripteur,
   identifiantQuestion: string | undefined,
-): RepresentationQuestionChoixMultiple | undefined => {
+): RepresentationQuestion | undefined => {
   if (question !== undefined) {
     const questionTiroirATranscrire: QuestionATranscrire | undefined =
       trouveQuestionATranscrire(
@@ -71,11 +71,14 @@ const questionTiroirATranscrire = (
         );
       return {
         ...question,
-        type: questionTiroirATranscrire.type,
+        type: question.type,
         identifiant: questionTiroirATranscrire.identifiant,
         reponsesPossibles,
-      } as RepresentationQuestionChoixMultiple;
+      } as RepresentationQuestion;
     }
+    return {
+      ...question,
+    } as RepresentationQuestion;
   }
   return undefined;
 };

--- a/mon-aide-cyber-api/src/api/representateurs/types.ts
+++ b/mon-aide-cyber-api/src/api/representateurs/types.ts
@@ -19,14 +19,14 @@ export type RepresentationReponsePossible = {
   reponsesComplementaires?: RepresentationReponseComplementaire[] | undefined;
   type?: { type: TypeDeSaisie; format: Format } | undefined;
 };
-type RepresentationQuestion = {
+export type RepresentationQuestion = {
   identifiant: string;
   libelle: string;
   reponsesPossibles: RepresentationReponsePossible[];
   type?: TypeDeSaisie | undefined;
 };
 export type RepresentationQuestionChoixMultiple = RepresentationQuestion & {
-  type?: Exclude<TypeDeSaisie, "choixSimple"> | undefined;
+  type?: Exclude<TypeDeSaisie, "choixUnique"> | undefined;
 };
 type RepresentationQuestionChoixUnique = RepresentationQuestion & {
   type?: Exclude<TypeDeSaisie, "choixMultiple"> | undefined;

--- a/mon-aide-cyber-api/src/diagnostic/donneesReferentiel.ts
+++ b/mon-aide-cyber-api/src/diagnostic/donneesReferentiel.ts
@@ -295,7 +295,7 @@ const referentiel: Referentiel = {
                   ordre: 2,
                 },
               ],
-              type: "choixMultiple",
+              type: "choixUnique",
             },
             reponsesComplementaires: [
               {

--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/adaptateurTranscripteur.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/adaptateurTranscripteur.ts
@@ -22,18 +22,6 @@ export const adaptateurTranscripteur = () =>
               type: "liste",
             },
             {
-              identifiant: "cyberAttaqueSubie",
-              reponses: [
-                {
-                  identifiant: "cyberAttaqueSubie-oui",
-                  question: {
-                    identifiant: "cyberAttaqueSubieTiroir",
-                    type: "choixMultiple",
-                  },
-                },
-              ],
-            },
-            {
               identifiant: "usageCloud",
               reponses: [
                 {

--- a/mon-aide-cyber-api/test/api/representateurs/transcripteursDeTest.ts
+++ b/mon-aide-cyber-api/test/api/representateurs/transcripteursDeTest.ts
@@ -123,7 +123,6 @@ const transcripteurQuestionTiroir = {
                   type: { type: "saisieLibre", format: "texte" },
                 },
               ],
-              type: "choixMultiple",
             },
           },
         ],
@@ -142,7 +141,6 @@ const transcripteurMultipleTiroir = {
             identifiant: "reponse-1",
             question: {
               identifiant: "question-11",
-              type: "choixMultiple",
             },
           },
         ],
@@ -154,7 +152,6 @@ const transcripteurMultipleTiroir = {
             identifiant: "reponse-2",
             question: {
               identifiant: "question-21",
-              type: "choixMultiple",
             },
           },
         ],

--- a/mon-aide-cyber-ui/src/composants/diagnostic/ComposantDiagnostic.tsx
+++ b/mon-aide-cyber-ui/src/composants/diagnostic/ComposantDiagnostic.tsx
@@ -129,6 +129,29 @@ const ComposantQuestionListe = ({ question }: ProprietesComposantQuestion) => {
   );
 };
 
+const ComposantQuestionTiroir = ({ question }: ProprietesComposantQuestion) => {
+  return (
+    <div className="question-tiroir">
+      <br />
+      <label>{question?.libelle}</label>
+      <br />
+      {question?.reponsesPossibles.map((reponse) => {
+        const typeDeSaisie =
+          question.type === "choixMultiple" ? "checkbox" : "radio";
+
+        return (
+          <ComposantReponsePossible
+            key={reponse.identifiant}
+            reponsePossible={reponse}
+            identifiantQuestion={question.identifiant}
+            typeDeSaisie={typeDeSaisie}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
 const ComposantQuestion = ({ question }: ProprietesComposantQuestion) => {
   return (
     <>
@@ -140,22 +163,8 @@ const ComposantQuestion = ({ question }: ProprietesComposantQuestion) => {
             identifiantQuestion={question.identifiant}
             typeDeSaisie="radio"
           >
-            {reponse.question?.type === "choixMultiple" ? (
-              <div className="question-tiroir">
-                <br />
-                <label>{reponse.question?.libelle}</label>
-                <br />
-                {reponse.question.reponsesPossibles.map((reponse) => {
-                  return (
-                    <ComposantReponsePossible
-                      key={reponse.identifiant}
-                      reponsePossible={reponse}
-                      identifiantQuestion={question.identifiant}
-                      typeDeSaisie="checkbox"
-                    />
-                  );
-                })}
-              </div>
+            {reponse.question !== undefined ? (
+              <ComposantQuestionTiroir question={reponse.question} />
             ) : (
               ""
             )}
@@ -165,6 +174,7 @@ const ComposantQuestion = ({ question }: ProprietesComposantQuestion) => {
     </>
   );
 };
+
 type ProprietesComposantDiagnostic = {
   idDiagnostic: UUID;
 };

--- a/mon-aide-cyber-ui/src/domaine/diagnostic/Referentiel.ts
+++ b/mon-aide-cyber-ui/src/domaine/diagnostic/Referentiel.ts
@@ -4,7 +4,11 @@ export type Contexte = {
 export type Referentiel = {
   contexte: Contexte;
 };
-export type TypeDeSaisie = "choixMultiple" | "saisieLibre" | "liste";
+export type TypeDeSaisie =
+  | "choixMultiple"
+  | "choixUnique"
+  | "saisieLibre"
+  | "liste";
 export type Format = "texte" | "nombre" | undefined;
 export type ReponseComplementaire = Omit<
   ReponsePossible,

--- a/mon-aide-cyber-ui/src/stories/Diagnostic.stories.tsx
+++ b/mon-aide-cyber-ui/src/stories/Diagnostic.stories.tsx
@@ -10,6 +10,7 @@ import {
 import {
   uneQuestion,
   uneQuestionAChoixMultiple,
+  uneQuestionAChoixUnique,
 } from "../../test/consructeurs/constructeurQuestions.ts";
 import { uneReponsePossible } from "../../test/consructeurs/constructeurReponsePossible.ts";
 import { ComposantAffichageErreur } from "../composants/erreurs/ComposantAffichageErreur.tsx";
@@ -141,6 +142,34 @@ const diagnosticAvecReponseComplementaire = unDiagnostic()
   )
   .construis();
 
+const identifiantDiagnosticAvecQuestionTiroirAChoixUnique =
+  "ba4cbe4d-dbcb-418c-8b8e-98aea21de323";
+const unDiagnosticAvecQuestionTiroirAChoixUnique = unDiagnostic()
+  .avecIdentifiant(identifiantDiagnosticAvecQuestionTiroirAChoixUnique)
+  .avecUnReferentiel(
+    unReferentiel()
+      .avecUneQuestion(
+        uneQuestion()
+          .avecDesReponses([
+            uneReponsePossible()
+              .avecUneQuestion(
+                uneQuestionAChoixUnique()
+                  .avecLibelle("un libelle de question à choix unique")
+                  .avecDesReponses([
+                    uneReponsePossible()
+                      .avecLibelle("un libelle de réponse possible")
+                      .construis(),
+                  ])
+                  .construis(),
+              )
+              .construis(),
+          ])
+          .construis(),
+      )
+      .construis(),
+  )
+  .construis();
+
 await entrepotDiagnosticMemoire.persiste(diagnosticAvecUneQuestion);
 await entrepotDiagnosticMemoire.persiste(diagnosticAvecUnChampsDeSaisie);
 await entrepotDiagnosticMemoire.persiste(diagnosticAvecPlusieursQuestions);
@@ -151,6 +180,9 @@ await entrepotDiagnosticMemoire.persiste(
   diagnosticAvecReponseEntrainantQuestion,
 );
 await entrepotDiagnosticMemoire.persiste(diagnosticAvecReponseComplementaire);
+await entrepotDiagnosticMemoire.persiste(
+  unDiagnosticAvecQuestionTiroirAChoixUnique,
+);
 
 const meta = {
   title: "Diagnostic",
@@ -295,6 +327,25 @@ export const AfficheDiagnosticAvecReponsesComplementaires: Story = {
     ).toBeInTheDocument();
     expect(
       await waitFor(() => canvas.getByRole("textbox")),
+    ).toBeInTheDocument();
+  },
+};
+
+export const AfficheDiagnosticAvecQuestionTiroirAChoixUnique: Story = {
+  name: "Affiche la question avec réponses à choix unique sous forme de boutton radio",
+  args: { idDiagnostic: identifiantDiagnosticAvecQuestionTiroirAChoixUnique },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(
+      await waitFor(() =>
+        canvas.getByText("un libelle de question à choix unique"),
+      ),
+    ).toBeInTheDocument();
+    expect(
+      await waitFor(() =>
+        canvas.getByRole("radio", { name: /un libelle de réponse possible/i }),
+      ),
     ).toBeInTheDocument();
   },
 };

--- a/mon-aide-cyber-ui/test/consructeurs/constructeurQuestions.ts
+++ b/mon-aide-cyber-ui/test/consructeurs/constructeurQuestions.ts
@@ -18,10 +18,15 @@ class ConstructeurQuestion implements Constructeur<Question> {
     return this;
   }
 
-  avecNReponses(nombreReponses: number): ConstructeurQuestionAChoixMultiple {
+  avecNReponses(nombreReponses: number): ConstructeurQuestion {
     for (let i = 0; i < nombreReponses; i++) {
       this.reponsesPossibles.push(uneReponsePossible().construis());
     }
+    return this;
+  }
+
+  avecLibelle(libelle: string): ConstructeurQuestion {
+    this.libelle = libelle;
     return this;
   }
 
@@ -42,7 +47,17 @@ class ConstructeurQuestionAChoixMultiple extends ConstructeurQuestion {
   }
 }
 
+class ConstructeurQuestionAChoixUnique extends ConstructeurQuestion {
+  constructor() {
+    super();
+    this.type = "choixUnique";
+  }
+}
+
 export const uneQuestionAChoixMultiple = () =>
   new ConstructeurQuestionAChoixMultiple();
+
+export const uneQuestionAChoixUnique = () =>
+  new ConstructeurQuestionAChoixUnique();
 
 export const uneQuestion = () => new ConstructeurQuestion();


### PR DESCRIPTION
La question sur la `cyberattaque` contient une question à tiroir à choix unique (`Si "Oui": avez-vous déposé plainte ou réalisé un signalement auprès d'un service judiciaire ?`). 
Dans la capture ci-dessous, on peut voir que les réponses à cette question sont des cases à cocher alors qu’elles devraient être des boutons radio.
<img width="809" alt="Capture d’écran 2023-07-18 à 12 47 59" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/ec7702c6-a50f-41de-99f5-cbf3fee56b86">

