### PR TITLE
[DIAGNOSTIC] Persiste la réponse donnée pour une question à choix unique

### DIFF
--- a/mon-aide-cyber-api/package.json
+++ b/mon-aide-cyber-api/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest --config vitest.config.ts --ui --reporter verbose"
   },
   "dependencies": {
+    "body-parser": "^1.20.2",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-rate-limit": "^6.7.0",

--- a/mon-aide-cyber-api/src/diagnostic/Referentiel.ts
+++ b/mon-aide-cyber-api/src/diagnostic/Referentiel.ts
@@ -12,20 +12,24 @@ type ReponsePossible = {
 
 type TypeQuestion = "choixMultiple" | "choixUnique";
 
+type ReponseDonnee = {
+  valeur: string;
+};
+
 type Question = {
   identifiant: string;
   libelle: string;
   type: TypeQuestion;
+  reponseDonnee?: ReponseDonnee;
+  reponsesPossibles: ReponsePossible[];
 };
 
 type QuestionChoixUnique = Question & {
   type: Exclude<TypeQuestion, "choixMultiple">;
-  reponsesPossibles: ReponsePossible[];
 };
 
 type QuestionChoixMultiple = Question & {
   type: Exclude<TypeQuestion, "choixUnique">;
-  reponsesPossibles: ReponsePossible[];
 };
 
 type Contexte = {

--- a/mon-aide-cyber-api/src/diagnostic/ServiceDiagnostic.ts
+++ b/mon-aide-cyber-api/src/diagnostic/ServiceDiagnostic.ts
@@ -3,6 +3,12 @@ import * as crypto from "crypto";
 import { AdaptateurReferentiel } from "../adaptateurs/AdaptateurReferentiel";
 import { Entrepots } from "../domaine/Entrepots";
 
+export type CorpsReponse = {
+  chemin: "contexte";
+  identifiant: string;
+  reponse: string;
+};
+
 export class ServiceDiagnostic {
   constructor(
     private readonly adaptateurReferentiel: AdaptateurReferentiel,
@@ -12,7 +18,7 @@ export class ServiceDiagnostic {
   diagnostic = async (id: crypto.UUID): Promise<Diagnostic> =>
     this.entrepots.diagnostic().lis(id);
 
-  cree(): Promise<Diagnostic> {
+  cree = async (): Promise<Diagnostic> => {
     return this.adaptateurReferentiel.lis().then((referentiel) => {
       const diagnostic: Diagnostic = {
         identifiant: crypto.randomUUID(),
@@ -21,5 +27,22 @@ export class ServiceDiagnostic {
       this.entrepots.diagnostic().persiste(diagnostic);
       return Promise.resolve(diagnostic);
     });
-  }
+  };
+
+  ajouteLaReponse = async (
+    id: crypto.UUID,
+    corspsReponse: CorpsReponse,
+  ): Promise<void> => {
+    return this.entrepots
+      .diagnostic()
+      .lis(id)
+      .then((diagnostic) => {
+        const questionTrouvee = diagnostic.referentiel[
+          corspsReponse.chemin
+        ].questions.find((q) => q.identifiant === corspsReponse.identifiant);
+        if (questionTrouvee !== undefined) {
+          questionTrouvee.reponseDonnee = { valeur: corspsReponse.reponse };
+        }
+      });
+  };
 }

--- a/mon-aide-cyber-api/test/api/executeurRequete.ts
+++ b/mon-aide-cyber-api/test/api/executeurRequete.ts
@@ -1,7 +1,15 @@
 export const executeRequete = (
-  verbe: "GET" | "POST",
+  verbe: "GET" | "POST" | "PATCH",
   chemin: string,
   port: number,
+  corps: object | null = null,
 ): Promise<Response> => {
-  return fetch(`http://localhost:${port}${chemin}`, { method: verbe });
+  const requeteInit: RequestInit = {
+    method: verbe,
+    headers: { "Content-Type": "application/json" },
+  };
+  if (corps !== null) {
+    requeteInit["body"] = JSON.stringify(corps);
+  }
+  return fetch(`http://localhost:${port}${chemin}`, requeteInit);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,13 @@
         "mon-aide-cyber-ui"
       ],
       "devDependencies": {
-        "@faker-js/faker": "^8.0.2",
-        "storybook-addon-react-router-v6": "^1.0.2"
+        "@faker-js/faker": "^8.0.2"
       }
     },
     "mon-aide-cyber-api": {
       "version": "0.0.0",
       "dependencies": {
+        "body-parser": "^1.20.2",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-rate-limit": "^6.7.0",
@@ -34,6 +34,43 @@
         "eslint": "^8.43.0",
         "nodemon": "^2.0.22",
         "vitest": "^0.32.2"
+      }
+    },
+    "mon-aide-cyber-api/node_modules/body-parser": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "mon-aide-cyber-api/node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "mon-aide-cyber-ui": {
@@ -71,6 +108,7 @@
         "prop-types": "^15.8.1",
         "sass": "^1.63.6",
         "storybook": "^7.0.24",
+        "storybook-addon-react-router-v6": "^1.0.2",
         "typescript": "^5.0.2",
         "vite": "^4.3.9",
         "vitest": "^0.32.2"
@@ -2613,7 +2651,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2630,7 +2667,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2647,7 +2683,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2664,7 +2699,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2681,7 +2715,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2698,7 +2731,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2715,7 +2747,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2732,7 +2763,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2749,7 +2779,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2766,7 +2795,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2783,7 +2811,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2800,7 +2827,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2817,7 +2843,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2834,7 +2859,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2851,7 +2875,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2868,7 +2891,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2885,7 +2907,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2902,7 +2923,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2919,7 +2939,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2936,7 +2955,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2953,7 +2971,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2970,7 +2987,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -20337,7 +20353,6 @@
       "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },


### PR DESCRIPTION
On peut envoyer une réponse pour une question à choix unique qui se trouve à la racine d’une thématique du référentiel