### PR TITLE
[DIAGNOSTIC] Envoie une réponse à une question à choix unique depuis l’UI

### DIFF
--- a/mon-aide-cyber-api/src/api/representateurs/representateurDiagnostic.ts
+++ b/mon-aide-cyber-api/src/api/representateurs/representateurDiagnostic.ts
@@ -188,6 +188,16 @@ export function representeLeDiagnosticPourLeClient(
             type: questionATranscrire?.type || question.type,
           };
         }),
+        actions: [
+          {
+            action: "repondre",
+            chemin: "contexte",
+            ressource: {
+              url: `/api/diagnostic/${diagnostic.identifiant}`,
+              methode: "PATCH",
+            },
+          },
+        ],
       },
     },
   };

--- a/mon-aide-cyber-api/src/api/representateurs/types.ts
+++ b/mon-aide-cyber-api/src/api/representateurs/types.ts
@@ -1,5 +1,10 @@
 import crypto from "crypto";
 
+type ActionDiagnostic = {
+  action: "repondre";
+  chemin: "contexte";
+  ressource: { url: string; methode: "PATCH" };
+};
 export type RepresentationDiagnostic = {
   identifiant: crypto.UUID;
   referentiel: RepresentationReferentiel;
@@ -32,6 +37,7 @@ type RepresentationQuestionChoixUnique = RepresentationQuestion & {
   type?: Exclude<TypeDeSaisie, "choixMultiple"> | undefined;
 };
 type RepresentationContexte = {
+  actions: ActionDiagnostic[];
   questions: (
     | RepresentationQuestionChoixUnique
     | RepresentationQuestionChoixMultiple

--- a/mon-aide-cyber-api/test/api/representateurs/representateurDiagnostic.spec.ts
+++ b/mon-aide-cyber-api/test/api/representateurs/representateurDiagnostic.spec.ts
@@ -9,6 +9,7 @@ import { unDiagnostic } from "../../constructeurs/constructeurDiagnostic";
 import { representeLeDiagnosticPourLeClient } from "../../../src/api/representateurs/representateurDiagnostic";
 import {
   fabriqueTranscripteur,
+  fabriqueTranscripteurVide,
   transcripteurAvecSaisiesLibres,
   TranscripteurDeQuestion,
   TranscripteurDeReponse,
@@ -18,338 +19,38 @@ import {
 } from "./transcripteursDeTest";
 
 describe("Le représentateur de diagnostic", () => {
-  it("définit le type de saisie que doit faire l'utilisateur", () => {
-    const question = uneQuestion()
-      .aChoixUnique("Quelle est la question?", [
-        { identifiant: "reponse1", libelle: "réponse 1" },
-        { identifiant: "reponse2", libelle: "réponse 2" },
-        { identifiant: "reponse3", libelle: "réponse 3" },
-      ])
-      .construis();
-    const diagnostic = unDiagnostic()
-      .avecUnReferentiel(
-        unReferentielAuContexteVide()
-          .ajouteUneQuestionAuContexte(question)
-          .construis(),
-      )
-      .construis();
+  describe("Afin de fournir les actions possibles pour un client", () => {
+    it("fournit l’action ’repondre’ dans la réponse", () => {
+      const diagnostic = unDiagnostic().construis();
 
-    const diagnosticRepresente = representeLeDiagnosticPourLeClient(
-      diagnostic,
-      transcripteurAvecSaisiesLibres,
-    );
+      const representationDiagnostic = representeLeDiagnosticPourLeClient(
+        diagnostic,
+        fabriqueTranscripteurVide(),
+      );
 
-    const questionRetournee =
-      diagnosticRepresente.referentiel.contexte.questions[0];
-    const reponsesPossibles = questionRetournee.reponsesPossibles;
-    expect(questionRetournee.type).toBe("choixUnique");
-    expect(reponsesPossibles[0].type).toStrictEqual({
-      type: "saisieLibre",
-      format: "texte",
-    });
-    expect(reponsesPossibles[1].type).toStrictEqual({
-      type: "saisieLibre",
-      format: "nombre",
-    });
-    expect(reponsesPossibles[2].type).toBeUndefined();
-  });
-
-  it("définit la manière dont est présentée la question sous forme de liste", () => {
-    const diagnostic = unDiagnostic()
-      .avecUnReferentiel(
-        unReferentielAuContexteVide()
-          .ajouteUneQuestionAuContexte(
-            uneQuestion().aChoixUnique("Question liste?").construis(),
-          )
-          .construis(),
-      )
-      .construis();
-    const diagnosticRepresente = representeLeDiagnosticPourLeClient(
-      diagnostic,
-      {
-        contexte: {
-          questions: [
-            { identifiant: "question-liste", type: "liste", reponses: [] },
-          ],
-        },
-      },
-    );
-
-    const question = diagnosticRepresente.referentiel.contexte.questions[0];
-    expect(question.type).toBe("liste");
-  });
-
-  describe("Lorsqu'il contient des réponses avec des questions tiroirs", () => {
-    describe("définit la manière dont est présentée la question et ses réponses", () => {
-      it("avec une seule question et une seule réponse", () => {
-        const reponse = uneReponsePossible()
-          .avecLibelle("Réponse 1")
-          .construis();
-        const reponsePossible = uneReponsePossible()
-          .avecLibelle("Réponse 0")
-          .avecQuestionATiroir(
-            uneQuestion()
-              .aChoixMultiple("Question tiroir?")
-              .avecReponsesPossibles([reponse])
-              .construis(),
-          )
-          .construis();
-        const diagnostic = unDiagnostic()
-          .avecUnReferentiel(
-            unReferentielAuContexteVide().ajouteUneQuestionAuContexte(
-              uneQuestion()
-                .aChoixUnique("Question avec réponse tiroir?")
-                .avecReponsesPossibles([reponsePossible])
-                .construis(),
-            ),
-          )
-          .construis();
-
-        const diagnosticRepresente = representeLeDiagnosticPourLeClient(
-          diagnostic,
-          transcripteurQuestionTiroir,
-        );
-
-        expect(
-          diagnosticRepresente.referentiel.contexte.questions,
-        ).toMatchObject([
-          {
-            identifiant: "question-avec-reponse-tiroir",
-            libelle: "Question avec réponse tiroir?",
-            reponsesPossibles: [
-              {
-                identifiant: "reponse-0",
-                libelle: "Réponse 0",
-                ordre: reponsePossible.ordre,
-                question: {
-                  identifiant: "question-tiroir",
-                  libelle: "Question tiroir?",
-                  reponsesPossibles: [
-                    {
-                      identifiant: "reponse-1",
-                      libelle: "Réponse 1",
-                      ordre: reponse.ordre,
-                    },
-                  ],
-                  type: "choixMultiple",
-                },
-              },
-            ],
-            type: "choixUnique",
+      expect(
+        representationDiagnostic.referentiel.contexte.actions,
+      ).toMatchObject([
+        {
+          action: "repondre",
+          chemin: "contexte",
+          ressource: {
+            url: `/api/diagnostic/${diagnostic.identifiant}`,
+            methode: "PATCH",
           },
-        ]);
-      });
-
-      it("avec une seule question et plusieurs réponses", () => {
-        const reponse3 = uneReponsePossible()
-          .avecLibelle("Réponse 3")
-          .construis();
-        const diagnostic = unDiagnostic()
-          .avecUnReferentiel(
-            unReferentielAuContexteVide().ajouteUneQuestionAuContexte(
-              uneQuestion()
-                .aChoixUnique("Question avec réponse tiroir?")
-                .avecReponsesPossibles([
-                  uneReponsePossible()
-                    .avecLibelle("Réponse 0")
-                    .avecQuestionATiroir(
-                      uneQuestion()
-                        .aChoixMultiple("Question tiroir?")
-                        .avecReponsesPossibles([
-                          uneReponsePossible().construis(),
-                          uneReponsePossible().construis(),
-                          reponse3,
-                        ])
-                        .construis(),
-                    )
-                    .construis(),
-                ])
-                .construis(),
-            ),
-          )
-          .construis();
-
-        const diagnosticRepresente = representeLeDiagnosticPourLeClient(
-          diagnostic,
-          transcripteurQuestionTiroir,
-        );
-
-        const questionTiroir =
-          diagnosticRepresente.referentiel.contexte.questions[0]
-            .reponsesPossibles[0];
-        expect(questionTiroir?.question?.identifiant).toBe("question-tiroir");
-        expect(questionTiroir?.question?.libelle).toBe("Question tiroir?");
-        expect(questionTiroir?.question?.type).toBe("choixMultiple");
-        expect(questionTiroir?.question?.reponsesPossibles[2]).toMatchObject({
-          identifiant: "reponse-3",
-          libelle: "Réponse 3",
-          ordre: reponse3.ordre,
-          type: { type: "saisieLibre", format: "texte" },
-        });
-      });
-
-      it("avec plusieurs questions", () => {
-        const reponse = uneReponsePossible()
-          .avecLibelle("Réponse 3")
-          .construis();
-        const diagnostic = unDiagnostic()
-          .avecUnReferentiel(
-            unReferentielAuContexteVide()
-              .ajouteUneQuestionAuContexte(uneQuestion().construis())
-              .ajouteUneQuestionAuContexte(
-                uneQuestion()
-                  .aChoixUnique("Question avec réponse tiroir?")
-                  .avecReponsesPossibles([
-                    uneReponsePossible()
-                      .avecQuestionATiroir(
-                        uneQuestion()
-                          .aChoixMultiple("Question tiroir?")
-                          .avecReponsesPossibles([reponse])
-                          .construis(),
-                      )
-                      .construis(),
-                  ])
-                  .construis(),
-              ),
-          )
-          .construis();
-
-        const diagnosticRepresente = representeLeDiagnosticPourLeClient(
-          diagnostic,
-          transcripteurQuestionTiroir,
-        );
-
-        const questionTiroir =
-          diagnosticRepresente.referentiel.contexte.questions[1]
-            .reponsesPossibles[0]?.question;
-        expect(questionTiroir?.reponsesPossibles[0]).toMatchObject({
-          identifiant: "reponse-3",
-          libelle: "Réponse 3",
-          ordre: reponse.ordre,
-          type: { type: "saisieLibre", format: "texte" },
-        });
-      });
-      it("avec plusieurs questions à tiroir", () => {
-        const reponse1 = uneReponsePossible()
-          .avecLibelle("Réponse 11")
-          .construis();
-        const reponse2 = uneReponsePossible()
-          .avecLibelle("Réponse 21")
-          .construis();
-        const premiereQuestion = uneQuestion()
-          .aChoixUnique("Première question?")
-          .avecReponsesPossibles([
-            uneReponsePossible()
-              .avecLibelle("Réponse 1")
-              .avecQuestionATiroir(
-                uneQuestion()
-                  .aChoixMultiple("Question 11")
-                  .avecReponsesPossibles([reponse1])
-                  .construis(),
-              )
-              .construis(),
-          ])
-          .construis();
-        const secondeQuestion = uneQuestion()
-          .aChoixUnique("Deuxième question?")
-          .avecReponsesPossibles([
-            uneReponsePossible()
-              .avecLibelle("Réponse 2")
-              .avecQuestionATiroir(
-                uneQuestion()
-                  .aChoixMultiple("Question 21")
-                  .avecReponsesPossibles([reponse2])
-                  .construis(),
-              )
-              .construis(),
-          ])
-          .construis();
-        const diagnostic = unDiagnostic()
-          .avecUnReferentiel(
-            unReferentielAuContexteVide()
-              .ajouteUneQuestionAuContexte(premiereQuestion)
-              .ajouteUneQuestionAuContexte(secondeQuestion)
-              .construis(),
-          )
-          .construis();
-
-        const representationDiagnostic = representeLeDiagnosticPourLeClient(
-          diagnostic,
-          transcripteurMultipleTiroir,
-        );
-
-        const premiereQuestionTiroir =
-          representationDiagnostic.referentiel.contexte.questions[0]
-            .reponsesPossibles[0]?.question;
-        expect(premiereQuestionTiroir?.reponsesPossibles[0]).toMatchObject({
-          identifiant: "reponse-11",
-          libelle: "Réponse 11",
-          ordre: reponse1.ordre,
-        });
-        const deuxiemeQuestionTiroir =
-          representationDiagnostic.referentiel.contexte.questions[1]
-            .reponsesPossibles[0]?.question;
-        expect(deuxiemeQuestionTiroir?.reponsesPossibles[0]).toMatchObject({
-          identifiant: "reponse-21",
-          libelle: "Réponse 21",
-          ordre: reponse2.ordre,
-        });
-      });
-
-      it("avec les questions telles que décrites dans le référentiel sans transcripteur spécifique", () => {
-        const diagnostic = unDiagnostic()
-          .avecUnReferentiel(
-            unReferentielAuContexteVide()
-              .ajouteUneQuestionAuContexte(
-                uneQuestion()
-                  .aChoixUnique("Une question à choix unique ?")
-                  .avecReponsesPossibles([
-                    uneReponsePossible()
-                      .avecQuestionATiroir(
-                        uneQuestion()
-                          .aChoixUnique("Une question tiroir à choix unique?")
-                          .construis(),
-                      )
-                      .construis(),
-                  ])
-                  .construis(),
-              )
-              .construis(),
-          )
-          .construis();
-
-        const representationDiagnostic = representeLeDiagnosticPourLeClient(
-          diagnostic,
-          fabriqueTranscripteur([]),
-        );
-
-        const question =
-          representationDiagnostic.referentiel.contexte.questions[0];
-        expect(question).toMatchObject({
-          identifiant: "une-question-a-choix-unique-",
-          libelle: "Une question à choix unique ?",
-          type: "choixUnique",
-        });
-        expect(question.reponsesPossibles[0].question).toMatchObject({
-          identifiant: "une-question-tiroir-a-choix-unique",
-          libelle: "Une question tiroir à choix unique?",
-          type: "choixUnique",
-        });
-      });
+        },
+      ]);
     });
+  });
 
-    it("retourne les réponses complémentaires si il y en a", () => {
-      const reponseComplementaire = uneReponseComplementaire().construis();
-      const secondeReponseComplementaire =
-        uneReponseComplementaire().construis();
-      const reponsePossible = uneReponsePossible()
-        .avecDesReponsesComplementaires([
-          reponseComplementaire,
-          secondeReponseComplementaire,
-        ])
-        .construis();
+  describe("Afin de représenter l’affichage de la saisie pour le client", () => {
+    it("définit le type de saisie que doit faire l'utilisateur", () => {
       const question = uneQuestion()
-        .avecReponsesPossibles([reponsePossible])
+        .aChoixUnique("Quelle est la question?", [
+          { identifiant: "reponse1", libelle: "réponse 1" },
+          { identifiant: "reponse2", libelle: "réponse 2" },
+          { identifiant: "reponse3", libelle: "réponse 3" },
+        ])
         .construis();
       const diagnostic = unDiagnostic()
         .avecUnReferentiel(
@@ -359,47 +60,373 @@ describe("Le représentateur de diagnostic", () => {
         )
         .construis();
 
-      const transcripteurs = new TranscripteurDeQuestion(
-        question,
-      ).ajouteUnTranscripteurDeReponse(
-        new TranscripteurDeReponse(reponsePossible)
-          .ajouteUnTranscripteurDeReponseComplementaire(
-            new TranscripteurDeReponseComplementaire(
-              secondeReponseComplementaire,
-            ),
-          )
-          .ajouteUnTranscripteurDeReponseComplementaire(
-            new TranscripteurDeReponseComplementaire(reponseComplementaire),
-          ),
-      );
-      const representationDiagnostic = representeLeDiagnosticPourLeClient(
+      const diagnosticRepresente = representeLeDiagnosticPourLeClient(
         diagnostic,
-        fabriqueTranscripteur([transcripteurs]),
+        transcripteurAvecSaisiesLibres,
       );
 
-      const questionRepresentee =
-        representationDiagnostic.referentiel.contexte.questions[0];
-      expect(
-        questionRepresentee.reponsesPossibles[0]?.reponsesComplementaires?.[0]
-          .libelle,
-      ).toBe(reponseComplementaire.libelle);
-      expect(
-        questionRepresentee.reponsesPossibles[0]?.reponsesComplementaires?.[0]
-          .type,
-      ).toMatchObject({
+      const questionRetournee =
+        diagnosticRepresente.referentiel.contexte.questions[0];
+      const reponsesPossibles = questionRetournee.reponsesPossibles;
+      expect(questionRetournee.type).toBe("choixUnique");
+      expect(reponsesPossibles[0].type).toStrictEqual({
         type: "saisieLibre",
         format: "texte",
       });
-      expect(
-        questionRepresentee.reponsesPossibles[0]?.reponsesComplementaires?.[1]
-          .libelle,
-      ).toBe(secondeReponseComplementaire.libelle);
-      expect(
-        questionRepresentee.reponsesPossibles[0]?.reponsesComplementaires?.[1]
-          .type,
-      ).toMatchObject({
+      expect(reponsesPossibles[1].type).toStrictEqual({
         type: "saisieLibre",
-        format: "texte",
+        format: "nombre",
+      });
+      expect(reponsesPossibles[2].type).toBeUndefined();
+    });
+
+    it("définit la manière dont est présentée la question sous forme de liste", () => {
+      const diagnostic = unDiagnostic()
+        .avecUnReferentiel(
+          unReferentielAuContexteVide()
+            .ajouteUneQuestionAuContexte(
+              uneQuestion().aChoixUnique("Question liste?").construis(),
+            )
+            .construis(),
+        )
+        .construis();
+      const diagnosticRepresente = representeLeDiagnosticPourLeClient(
+        diagnostic,
+        {
+          contexte: {
+            questions: [
+              { identifiant: "question-liste", type: "liste", reponses: [] },
+            ],
+          },
+        },
+      );
+
+      const question = diagnosticRepresente.referentiel.contexte.questions[0];
+      expect(question.type).toBe("liste");
+    });
+
+    describe("Lorsqu'il contient des réponses avec des questions tiroirs", () => {
+      describe("définit la manière dont est présentée la question et ses réponses", () => {
+        it("avec une seule question et une seule réponse", () => {
+          const reponse = uneReponsePossible()
+            .avecLibelle("Réponse 1")
+            .construis();
+          const reponsePossible = uneReponsePossible()
+            .avecLibelle("Réponse 0")
+            .avecQuestionATiroir(
+              uneQuestion()
+                .aChoixMultiple("Question tiroir?")
+                .avecReponsesPossibles([reponse])
+                .construis(),
+            )
+            .construis();
+          const diagnostic = unDiagnostic()
+            .avecUnReferentiel(
+              unReferentielAuContexteVide().ajouteUneQuestionAuContexte(
+                uneQuestion()
+                  .aChoixUnique("Question avec réponse tiroir?")
+                  .avecReponsesPossibles([reponsePossible])
+                  .construis(),
+              ),
+            )
+            .construis();
+
+          const diagnosticRepresente = representeLeDiagnosticPourLeClient(
+            diagnostic,
+            transcripteurQuestionTiroir,
+          );
+
+          expect(
+            diagnosticRepresente.referentiel.contexte.questions,
+          ).toMatchObject([
+            {
+              identifiant: "question-avec-reponse-tiroir",
+              libelle: "Question avec réponse tiroir?",
+              reponsesPossibles: [
+                {
+                  identifiant: "reponse-0",
+                  libelle: "Réponse 0",
+                  ordre: reponsePossible.ordre,
+                  question: {
+                    identifiant: "question-tiroir",
+                    libelle: "Question tiroir?",
+                    reponsesPossibles: [
+                      {
+                        identifiant: "reponse-1",
+                        libelle: "Réponse 1",
+                        ordre: reponse.ordre,
+                      },
+                    ],
+                    type: "choixMultiple",
+                  },
+                },
+              ],
+              type: "choixUnique",
+            },
+          ]);
+        });
+
+        it("avec une seule question et plusieurs réponses", () => {
+          const reponse3 = uneReponsePossible()
+            .avecLibelle("Réponse 3")
+            .construis();
+          const diagnostic = unDiagnostic()
+            .avecUnReferentiel(
+              unReferentielAuContexteVide().ajouteUneQuestionAuContexte(
+                uneQuestion()
+                  .aChoixUnique("Question avec réponse tiroir?")
+                  .avecReponsesPossibles([
+                    uneReponsePossible()
+                      .avecLibelle("Réponse 0")
+                      .avecQuestionATiroir(
+                        uneQuestion()
+                          .aChoixMultiple("Question tiroir?")
+                          .avecReponsesPossibles([
+                            uneReponsePossible().construis(),
+                            uneReponsePossible().construis(),
+                            reponse3,
+                          ])
+                          .construis(),
+                      )
+                      .construis(),
+                  ])
+                  .construis(),
+              ),
+            )
+            .construis();
+
+          const diagnosticRepresente = representeLeDiagnosticPourLeClient(
+            diagnostic,
+            transcripteurQuestionTiroir,
+          );
+
+          const questionTiroir =
+            diagnosticRepresente.referentiel.contexte.questions[0]
+              .reponsesPossibles[0];
+          expect(questionTiroir?.question?.identifiant).toBe("question-tiroir");
+          expect(questionTiroir?.question?.libelle).toBe("Question tiroir?");
+          expect(questionTiroir?.question?.type).toBe("choixMultiple");
+          expect(questionTiroir?.question?.reponsesPossibles[2]).toMatchObject({
+            identifiant: "reponse-3",
+            libelle: "Réponse 3",
+            ordre: reponse3.ordre,
+            type: { type: "saisieLibre", format: "texte" },
+          });
+        });
+
+        it("avec plusieurs questions", () => {
+          const reponse = uneReponsePossible()
+            .avecLibelle("Réponse 3")
+            .construis();
+          const diagnostic = unDiagnostic()
+            .avecUnReferentiel(
+              unReferentielAuContexteVide()
+                .ajouteUneQuestionAuContexte(uneQuestion().construis())
+                .ajouteUneQuestionAuContexte(
+                  uneQuestion()
+                    .aChoixUnique("Question avec réponse tiroir?")
+                    .avecReponsesPossibles([
+                      uneReponsePossible()
+                        .avecQuestionATiroir(
+                          uneQuestion()
+                            .aChoixMultiple("Question tiroir?")
+                            .avecReponsesPossibles([reponse])
+                            .construis(),
+                        )
+                        .construis(),
+                    ])
+                    .construis(),
+                ),
+            )
+            .construis();
+
+          const diagnosticRepresente = representeLeDiagnosticPourLeClient(
+            diagnostic,
+            transcripteurQuestionTiroir,
+          );
+
+          const questionTiroir =
+            diagnosticRepresente.referentiel.contexte.questions[1]
+              .reponsesPossibles[0]?.question;
+          expect(questionTiroir?.reponsesPossibles[0]).toMatchObject({
+            identifiant: "reponse-3",
+            libelle: "Réponse 3",
+            ordre: reponse.ordre,
+            type: { type: "saisieLibre", format: "texte" },
+          });
+        });
+        it("avec plusieurs questions à tiroir", () => {
+          const reponse1 = uneReponsePossible()
+            .avecLibelle("Réponse 11")
+            .construis();
+          const reponse2 = uneReponsePossible()
+            .avecLibelle("Réponse 21")
+            .construis();
+          const premiereQuestion = uneQuestion()
+            .aChoixUnique("Première question?")
+            .avecReponsesPossibles([
+              uneReponsePossible()
+                .avecLibelle("Réponse 1")
+                .avecQuestionATiroir(
+                  uneQuestion()
+                    .aChoixMultiple("Question 11")
+                    .avecReponsesPossibles([reponse1])
+                    .construis(),
+                )
+                .construis(),
+            ])
+            .construis();
+          const secondeQuestion = uneQuestion()
+            .aChoixUnique("Deuxième question?")
+            .avecReponsesPossibles([
+              uneReponsePossible()
+                .avecLibelle("Réponse 2")
+                .avecQuestionATiroir(
+                  uneQuestion()
+                    .aChoixMultiple("Question 21")
+                    .avecReponsesPossibles([reponse2])
+                    .construis(),
+                )
+                .construis(),
+            ])
+            .construis();
+          const diagnostic = unDiagnostic()
+            .avecUnReferentiel(
+              unReferentielAuContexteVide()
+                .ajouteUneQuestionAuContexte(premiereQuestion)
+                .ajouteUneQuestionAuContexte(secondeQuestion)
+                .construis(),
+            )
+            .construis();
+
+          const representationDiagnostic = representeLeDiagnosticPourLeClient(
+            diagnostic,
+            transcripteurMultipleTiroir,
+          );
+
+          const premiereQuestionTiroir =
+            representationDiagnostic.referentiel.contexte.questions[0]
+              .reponsesPossibles[0]?.question;
+          expect(premiereQuestionTiroir?.reponsesPossibles[0]).toMatchObject({
+            identifiant: "reponse-11",
+            libelle: "Réponse 11",
+            ordre: reponse1.ordre,
+          });
+          const deuxiemeQuestionTiroir =
+            representationDiagnostic.referentiel.contexte.questions[1]
+              .reponsesPossibles[0]?.question;
+          expect(deuxiemeQuestionTiroir?.reponsesPossibles[0]).toMatchObject({
+            identifiant: "reponse-21",
+            libelle: "Réponse 21",
+            ordre: reponse2.ordre,
+          });
+        });
+
+        it("avec les questions telles que décrites dans le référentiel sans transcripteur spécifique", () => {
+          const diagnostic = unDiagnostic()
+            .avecUnReferentiel(
+              unReferentielAuContexteVide()
+                .ajouteUneQuestionAuContexte(
+                  uneQuestion()
+                    .aChoixUnique("Une question à choix unique ?")
+                    .avecReponsesPossibles([
+                      uneReponsePossible()
+                        .avecQuestionATiroir(
+                          uneQuestion()
+                            .aChoixUnique("Une question tiroir à choix unique?")
+                            .construis(),
+                        )
+                        .construis(),
+                    ])
+                    .construis(),
+                )
+                .construis(),
+            )
+            .construis();
+
+          const representationDiagnostic = representeLeDiagnosticPourLeClient(
+            diagnostic,
+            fabriqueTranscripteurVide(),
+          );
+
+          const question =
+            representationDiagnostic.referentiel.contexte.questions[0];
+          expect(question).toMatchObject({
+            identifiant: "une-question-a-choix-unique-",
+            libelle: "Une question à choix unique ?",
+            type: "choixUnique",
+          });
+          expect(question.reponsesPossibles[0].question).toMatchObject({
+            identifiant: "une-question-tiroir-a-choix-unique",
+            libelle: "Une question tiroir à choix unique?",
+            type: "choixUnique",
+          });
+        });
+      });
+
+      it("retourne les réponses complémentaires si il y en a", () => {
+        const reponseComplementaire = uneReponseComplementaire().construis();
+        const secondeReponseComplementaire =
+          uneReponseComplementaire().construis();
+        const reponsePossible = uneReponsePossible()
+          .avecDesReponsesComplementaires([
+            reponseComplementaire,
+            secondeReponseComplementaire,
+          ])
+          .construis();
+        const question = uneQuestion()
+          .avecReponsesPossibles([reponsePossible])
+          .construis();
+        const diagnostic = unDiagnostic()
+          .avecUnReferentiel(
+            unReferentielAuContexteVide()
+              .ajouteUneQuestionAuContexte(question)
+              .construis(),
+          )
+          .construis();
+
+        const transcripteurs = new TranscripteurDeQuestion(
+          question,
+        ).ajouteUnTranscripteurDeReponse(
+          new TranscripteurDeReponse(reponsePossible)
+            .ajouteUnTranscripteurDeReponseComplementaire(
+              new TranscripteurDeReponseComplementaire(
+                secondeReponseComplementaire,
+              ),
+            )
+            .ajouteUnTranscripteurDeReponseComplementaire(
+              new TranscripteurDeReponseComplementaire(reponseComplementaire),
+            ),
+        );
+        const representationDiagnostic = representeLeDiagnosticPourLeClient(
+          diagnostic,
+          fabriqueTranscripteur([transcripteurs]),
+        );
+
+        const questionRepresentee =
+          representationDiagnostic.referentiel.contexte.questions[0];
+        expect(
+          questionRepresentee.reponsesPossibles[0]?.reponsesComplementaires?.[0]
+            .libelle,
+        ).toBe(reponseComplementaire.libelle);
+        expect(
+          questionRepresentee.reponsesPossibles[0]?.reponsesComplementaires?.[0]
+            .type,
+        ).toMatchObject({
+          type: "saisieLibre",
+          format: "texte",
+        });
+        expect(
+          questionRepresentee.reponsesPossibles[0]?.reponsesComplementaires?.[1]
+            .libelle,
+        ).toBe(secondeReponseComplementaire.libelle);
+        expect(
+          questionRepresentee.reponsesPossibles[0]?.reponsesComplementaires?.[1]
+            .type,
+        ).toMatchObject({
+          type: "saisieLibre",
+          format: "texte",
+        });
       });
     });
   });

--- a/mon-aide-cyber-api/test/api/representateurs/transcripteursDeTest.ts
+++ b/mon-aide-cyber-api/test/api/representateurs/transcripteursDeTest.ts
@@ -170,8 +170,13 @@ const fabriqueTranscripteur = (
   return transcripteursDeTest.construis();
 };
 
+const fabriqueTranscripteurVide = (): Transcripteur => {
+  return new TranscripteursDeTest().construis();
+};
+
 export {
   fabriqueTranscripteur,
+  fabriqueTranscripteurVide,
   transcripteurAvecSaisiesLibres,
   transcripteurMultipleTiroir,
   transcripteurQuestionTiroir,

--- a/mon-aide-cyber-ui/src/domaine/diagnostic/Diagnostic.ts
+++ b/mon-aide-cyber-ui/src/domaine/diagnostic/Diagnostic.ts
@@ -4,9 +4,20 @@ import { Aggregat } from "../Aggregat.ts";
 import { Entrepot } from "../Entrepots.ts";
 import { LienRoutage } from "../LienRoutage.ts";
 
+export type ActionDiagnostic = {
+  action: "repondre";
+  chemin: string;
+  ressource: { url: string; methode: "PATCH" };
+};
 export type Diagnostic = Aggregat & {
   referentiel: Referentiel;
 };
+export type Reponse = {
+  reponseDonnee: string;
+  identifiantQuestion: string;
+};
 export interface EntrepotDiagnostic extends Entrepot<Diagnostic> {
   lancer(): Promise<LienRoutage>;
+
+  repond: (action: ActionDiagnostic, reponseDonnee: Reponse) => Promise<void>;
 }

--- a/mon-aide-cyber-ui/src/domaine/diagnostic/Referentiel.ts
+++ b/mon-aide-cyber-ui/src/domaine/diagnostic/Referentiel.ts
@@ -1,5 +1,8 @@
+import { ActionDiagnostic } from "./Diagnostic.ts";
+
 export type Contexte = {
   questions: Question[];
+  actions: ActionDiagnostic[];
 };
 export type Referentiel = {
   contexte: Contexte;

--- a/mon-aide-cyber-ui/src/domaine/diagnostic/reducteurReponse.ts
+++ b/mon-aide-cyber-ui/src/domaine/diagnostic/reducteurReponse.ts
@@ -2,22 +2,37 @@ import { ReponseDonnee } from "./Referentiel.ts";
 
 enum TypeActionReponse {
   REPONSE_DONNEE = "REPONSE_DONNEE",
+  REPONSE_CHANGEE = "REPONSE_CHANGEE",
 }
 
 type EtatReponse = {
   reponseDonnee?: ReponseDonnee | undefined;
 };
 
-type ActionReponse = {
-  reponseDonnee: ReponseDonnee;
-  type: TypeActionReponse.REPONSE_DONNEE;
-};
+type ActionReponse =
+  | {
+      reponseDonnee: ReponseDonnee;
+      type: TypeActionReponse.REPONSE_DONNEE;
+    }
+  | {
+      reponse: string;
+      type: TypeActionReponse.REPONSE_CHANGEE;
+    };
 export const reducteurReponse = (
   etat: EtatReponse,
   action: ActionReponse,
 ): EtatReponse => {
   switch (action.type) {
+    case TypeActionReponse.REPONSE_CHANGEE:
+      return { ...etat, reponseDonnee: { valeur: action.reponse } };
     case TypeActionReponse.REPONSE_DONNEE:
       return { ...etat, reponseDonnee: action.reponseDonnee };
   }
+};
+
+export const reponseChangee = (reponse: string): ActionReponse => {
+  return {
+    reponse: reponse,
+    type: TypeActionReponse.REPONSE_CHANGEE,
+  };
 };

--- a/mon-aide-cyber-ui/src/infrastructure/entrepots/EntrepotsAPI.ts
+++ b/mon-aide-cyber-ui/src/infrastructure/entrepots/EntrepotsAPI.ts
@@ -1,6 +1,8 @@
 import {
+  ActionDiagnostic,
   Diagnostic,
   EntrepotDiagnostic,
+  Reponse,
 } from "../../domaine/diagnostic/Diagnostic.ts";
 import { Aggregat } from "../../domaine/Aggregat.ts";
 import { FormatLien, LienRoutage } from "../../domaine/LienRoutage.ts";
@@ -53,6 +55,18 @@ export class APIEntrepotDiagnostic
           message: `Lors de la création ou de la récupération du diagnostic pour les raisons suivantes : '${erreur}'`,
         }),
       );
+  }
+
+  repond(action: ActionDiagnostic, reponseDonnee: Reponse): Promise<void> {
+    return fetch(action.ressource.url, {
+      method: action.ressource.methode,
+      body: JSON.stringify({
+        chemin: action.chemin,
+        identifiant: reponseDonnee.identifiantQuestion,
+        reponse: reponseDonnee.reponseDonnee,
+      }),
+      headers: { "Content-Type": "application/json" },
+    }).then();
   }
 }
 

--- a/mon-aide-cyber-ui/src/stories/ReponsesDonneesAuDiagnostic.stories.tsx
+++ b/mon-aide-cyber-ui/src/stories/ReponsesDonneesAuDiagnostic.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { FournisseurEntrepots } from "../fournisseurs/FournisseurEntrepot.ts";
 import { unDiagnostic } from "../../test/consructeurs/constructeurDiagnostic.ts";
-import { waitFor, within } from "@storybook/testing-library";
+import { userEvent, waitFor, within } from "@storybook/testing-library";
 import { expect } from "@storybook/jest";
 import {
   EntrepotDiagnosticMemoire,
@@ -14,8 +14,10 @@ import { ErrorBoundary } from "react-error-boundary";
 import { unReferentiel } from "../../test/consructeurs/constructeurReferentiel.ts";
 import { ComposantDiagnostic } from "../composants/diagnostic/ComposantDiagnostic.tsx";
 import { EntrepotDiagnostics } from "../domaine/diagnostic/Diagnostics.ts";
+import { uneAction } from "../../test/consructeurs/constructeurActionDiagnostic.ts";
 
 const entrepotDiagnosticMemoire = new EntrepotDiagnosticMemoire();
+const actionRepondre = uneAction().contexte().construis();
 
 const identifiantQuestionAChoixUnique = "6dadad14-8fa0-4be7-a8da-473d538eb6c1";
 const reponseDonneeChoixUnique = uneReponsePossible().construis();
@@ -23,13 +25,12 @@ const diagnosticAvecUneQuestionAChoixUnique = unDiagnostic()
   .avecIdentifiant(identifiantQuestionAChoixUnique)
   .avecUnReferentiel(
     unReferentiel()
+      .ajouteAction(actionRepondre)
       .avecUneQuestion(
         uneQuestionAChoixUnique()
           .avecLibelle("Quelle entreprise êtes-vous ?")
           .avecDesReponses([
-            uneReponsePossible()
-              .avecLibelle("Entreprise privée (ex. TPE, PME, ETI)")
-              .construis(),
+            uneReponsePossible().avecLibelle("Entreprise privée").construis(),
             uneReponsePossible().construis(),
           ])
           .avecLaReponseDonnee(reponseDonneeChoixUnique)
@@ -48,6 +49,7 @@ const diagnosticAvecQuestionSousFormeDeListeDeroulante = unDiagnostic()
   .avecIdentifiant(identifiantQuestionListeDeroulante)
   .avecUnReferentiel(
     unReferentiel()
+      .ajouteAction(actionRepondre)
       .avecUneQuestion(
         uneQuestionAChoixUnique()
           .avecLibelle("Une liste déroulante?")
@@ -97,46 +99,82 @@ type Story = StoryObj<typeof meta>;
 export const SelectionneReponseDiagnostic: Story = {
   name: "Coche la réponse donnée",
   args: { idDiagnostic: identifiantQuestionAChoixUnique },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    expect(
-      await waitFor(() =>
-        canvas.getByText(
-          diagnosticAvecUneQuestionAChoixUnique.referentiel.contexte
-            .questions[0].libelle,
+    await step("Lorsque le diagnostic est récupéré depuis l’API", async () => {
+      expect(
+        await waitFor(() =>
+          canvas.getByText(
+            diagnosticAvecUneQuestionAChoixUnique.referentiel.contexte
+              .questions[0].libelle,
+          ),
         ),
-      ),
-    ).toBeInTheDocument();
-    expect(
-      await waitFor(() =>
-        canvas.getByRole("radio", { name: reponseDonneeChoixUnique.libelle }),
-      ),
-    ).toBeChecked();
+      ).toBeInTheDocument();
+      expect(
+        await waitFor(() =>
+          canvas.getByRole("radio", { name: reponseDonneeChoixUnique.libelle }),
+        ),
+      ).toBeChecked();
+    });
+
+    await step("Lorsque l’utilisateur modifie la réponse", async () => {
+      await userEvent.click(
+        canvas.getByRole("radio", { name: /entreprise privée/i }),
+      );
+
+      expect(
+        canvas.getByRole("radio", { name: /entreprise privée/i }),
+      ).toBeChecked();
+      expect(
+        entrepotDiagnosticMemoire.verifieEnvoiReponse(actionRepondre, {
+          reponseDonnee: "entreprise-privee",
+          identifiantQuestion: "quelle-entreprise-etesvous-",
+        }),
+      ).toBeTruthy();
+    });
   },
 };
 
 export const SelectionneReponseDiagnosticDansUneListe: Story = {
   name: "Sélectionne la réponse donnée dans la liste",
   args: { idDiagnostic: identifiantQuestionListeDeroulante },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    expect(
-      await waitFor(() =>
-        canvas.getByText(
-          diagnosticAvecQuestionSousFormeDeListeDeroulante.referentiel.contexte
-            .questions[0].libelle,
+    await step("Lorsque le diagnostic est récupéré depuis l’API", async () => {
+      expect(
+        await waitFor(() =>
+          canvas.getByText(
+            diagnosticAvecQuestionSousFormeDeListeDeroulante.referentiel
+              .contexte.questions[0].libelle,
+          ),
         ),
-      ),
-    ).toBeInTheDocument();
-    expect(
-      await waitFor(() =>
-        canvas.getByRole("option", {
-          name: reponseSelectionnee.libelle,
-          selected: true,
+      ).toBeInTheDocument();
+      expect(
+        await waitFor(() =>
+          canvas.getByRole("option", {
+            name: reponseSelectionnee.libelle,
+            selected: true,
+          }),
+        ),
+      ).toBeInTheDocument();
+    });
+
+    await step("Lorsque l’utilisateur modifie la réponse", async () => {
+      await userEvent.selectOptions(canvas.getByRole("listbox"), "Réponse C");
+
+      expect(
+        await waitFor(() =>
+          canvas.getByRole("option", { name: /réponse c/i, selected: true }),
+        ),
+      ).toBeInTheDocument();
+      expect(
+        entrepotDiagnosticMemoire.verifieEnvoiReponse(actionRepondre, {
+          reponseDonnee: "reponse-c",
+          identifiantQuestion: "une-liste-deroulante",
         }),
-      ),
-    ).toBeInTheDocument();
+      ).toBeTruthy();
+    });
   },
 };

--- a/mon-aide-cyber-ui/test/consructeurs/constructeurActionDiagnostic.ts
+++ b/mon-aide-cyber-ui/test/consructeurs/constructeurActionDiagnostic.ts
@@ -1,0 +1,23 @@
+import { Constructeur } from "./Constructeur";
+import { ActionDiagnostic } from "../../src/domaine/diagnostic/Diagnostic";
+import { faker } from "@faker-js/faker/locale/fr";
+
+class ConstructeurActionDiagnostic implements Constructeur<ActionDiagnostic> {
+  private chemin = "contexte";
+  private action = "repondre" as const;
+  private url: string = faker.internet.url();
+  contexte(): ConstructeurActionDiagnostic {
+    this.chemin = "contexte";
+    return this;
+  }
+
+  construis(): ActionDiagnostic {
+    return {
+      action: this.action,
+      chemin: this.chemin,
+      ressource: { url: this.url, methode: "PATCH" },
+    };
+  }
+}
+
+export const uneAction = () => new ConstructeurActionDiagnostic();

--- a/mon-aide-cyber-ui/test/consructeurs/constructeurQuestions.ts
+++ b/mon-aide-cyber-ui/test/consructeurs/constructeurQuestions.ts
@@ -7,6 +7,7 @@ import {
   ReponsePossible,
   TypeDeSaisie,
 } from "../../src/domaine/diagnostic/Referentiel.ts";
+import { aseptise } from "../utilitaires/aseptise.ts";
 
 class ConstructeurQuestion implements Constructeur<Question> {
   protected identifiant = faker.string.alpha(10);
@@ -34,6 +35,7 @@ class ConstructeurQuestion implements Constructeur<Question> {
   }
 
   avecLibelle(libelle: string): ConstructeurQuestion {
+    this.identifiant = aseptise(libelle);
     this.libelle = libelle;
     return this;
   }

--- a/mon-aide-cyber-ui/test/consructeurs/constructeurReferentiel.ts
+++ b/mon-aide-cyber-ui/test/consructeurs/constructeurReferentiel.ts
@@ -7,9 +7,11 @@ import {
 } from "../../src/domaine/diagnostic/Referentiel.ts";
 import { Constructeur } from "./Constructeur.ts";
 import { uneReponsePossible } from "./constructeurReponsePossible.ts";
+import { ActionDiagnostic } from "../../src/domaine/diagnostic/Diagnostic.ts";
 
 class ConstructeurReferentiel implements Constructeur<Referentiel> {
   private questions: Question[] = [];
+  private actions: ActionDiagnostic[] = [];
 
   avecUneQuestionEtDesReponses(
     question: {
@@ -39,10 +41,15 @@ class ConstructeurReferentiel implements Constructeur<Referentiel> {
     this.questions.push(question);
     return this;
   }
+  ajouteAction(action: ActionDiagnostic): ConstructeurReferentiel {
+    this.actions.push(action);
+    return this;
+  }
 
   construis(): Referentiel {
     return {
       contexte: {
+        actions: this.actions,
         questions: this.questions,
       },
     };

--- a/mon-aide-cyber-ui/test/consructeurs/constructeurReponsePossible.ts
+++ b/mon-aide-cyber-ui/test/consructeurs/constructeurReponsePossible.ts
@@ -7,6 +7,7 @@ import {
   ReponsePossible,
   TypeDeSaisie,
 } from "../../src/domaine/diagnostic/Referentiel.ts";
+import { aseptise } from "../utilitaires/aseptise.ts";
 
 class ConstructeurReponsePossible implements Constructeur<ReponsePossible> {
   private identifiant = faker.string.alpha(10);
@@ -22,6 +23,7 @@ class ConstructeurReponsePossible implements Constructeur<ReponsePossible> {
   }
 
   avecLibelle(libelle: string): ConstructeurReponsePossible {
+    this.identifiant = aseptise(libelle);
     this.libelle = libelle;
     return this;
   }

--- a/mon-aide-cyber-ui/test/domaine/diagnostic/reducteurReponse.spec.ts
+++ b/mon-aide-cyber-ui/test/domaine/diagnostic/reducteurReponse.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it } from "vitest";
+import {
+  reducteurReponse,
+  reponseChangee,
+} from "../../../src/domaine/diagnostic/reducteurReponse";
+import { uneReponsePossible } from "../../consructeurs/constructeurReponsePossible";
+
+describe("Le réducteur de réponse", () => {
+  it("change la réponse donnée", () => {
+    const nouvelleReponse = uneReponsePossible().construis();
+
+    const etatReponse = reducteurReponse(
+      { reponseDonnee: undefined },
+      reponseChangee(nouvelleReponse.identifiant),
+    );
+
+    expect(etatReponse.reponseDonnee).toMatchObject({
+      valeur: nouvelleReponse.identifiant,
+    });
+  });
+});

--- a/mon-aide-cyber-ui/test/infrastructure/entrepots/EntrepotsMemoire.ts
+++ b/mon-aide-cyber-ui/test/infrastructure/entrepots/EntrepotsMemoire.ts
@@ -1,7 +1,9 @@
 import { Aggregat } from "../../../src/domaine/Aggregat";
 import {
+  ActionDiagnostic,
   Diagnostic,
   EntrepotDiagnostic,
+  Reponse,
 } from "../../../src/domaine/diagnostic/Diagnostic.ts";
 import { Entrepot } from "../../../src/domaine/Entrepots";
 import { unDiagnostic } from "../../consructeurs/constructeurDiagnostic.ts";
@@ -33,10 +35,32 @@ export class EntrepotDiagnosticMemoire
   extends EntrepotMemoire<Diagnostic>
   implements EntrepotDiagnostic
 {
+  private actionRepondre: ActionDiagnostic | undefined = undefined;
+  private reponseDonnee: Reponse | undefined = undefined;
   lancer(): Promise<LienRoutage> {
     const diagnostic = unDiagnostic().construis();
     return this.persiste(diagnostic).then(
       () => new LienRoutage(`/api/diagnostic/${diagnostic.identifiant}`),
+    );
+  }
+
+  repond(action: ActionDiagnostic, reponseDonnee: Reponse): Promise<void> {
+    this.actionRepondre = action;
+    this.reponseDonnee = reponseDonnee;
+    return Promise.resolve();
+  }
+
+  verifieEnvoiReponse(
+    actionRepondre: ActionDiagnostic,
+    reponseDonnee: Reponse,
+  ) {
+    console.log(this.actionRepondre, actionRepondre);
+    console.log(this.reponseDonnee, reponseDonnee);
+    return (
+      Object.entries(this.actionRepondre!).toString() ===
+        Object.entries(actionRepondre).toString() &&
+      Object.entries(this.reponseDonnee!).toString() ===
+        Object.entries(reponseDonnee).toString()
     );
   }
 }


### PR DESCRIPTION
- L’API renvoie l’action `repondre` dans la réponse d’une requête d’un diagnostic
- L’UI envoie la réponse 