### PR TITLE
[REMANIEMENT] Modifie le typage du diagnostic

### DIFF
--- a/mon-aide-cyber-api/src/api/routesAPIDiagnostic.ts
+++ b/mon-aide-cyber-api/src/api/routesAPIDiagnostic.ts
@@ -14,7 +14,7 @@ export const routesAPIDiagnostic = (configuration: ConfigurationServeur) => {
       configuration.adaptateurReferentiel,
       configuration.entrepots,
     )
-      .cree()
+      .lance()
       .then((diagnostic) => {
         reponse.status(201);
         reponse.appendHeader(

--- a/mon-aide-cyber-api/src/diagnostic/Diagnostic.ts
+++ b/mon-aide-cyber-api/src/diagnostic/Diagnostic.ts
@@ -47,4 +47,9 @@ const initialiseDiagnostic = (r: Referentiel): Diagnostic => {
   };
 };
 
-export { Diagnostic, EntrepotDiagnostic, initialiseDiagnostic };
+export {
+  Diagnostic,
+  EntrepotDiagnostic,
+  QuestionDiagnostic,
+  initialiseDiagnostic,
+};

--- a/mon-aide-cyber-api/src/diagnostic/Diagnostic.ts
+++ b/mon-aide-cyber-api/src/diagnostic/Diagnostic.ts
@@ -1,9 +1,50 @@
-import * as crypto from "crypto";
-import { Referentiel } from "./Referentiel";
+import crypto from "crypto";
+import { Question, Referentiel } from "./Referentiel";
 import { Entrepot } from "../domaine/Entrepot";
 
-export type Diagnostic = {
-  identifiant: crypto.UUID;
-  referentiel: Referentiel;
+type Thematique = string;
+
+type ReponseDonnee = {
+  valeur: string | null;
 };
-export type EntrepotDiagnostic = Entrepot<Diagnostic>;
+type QuestionDiagnostic = Question & {
+  reponseDonnee: ReponseDonnee;
+};
+
+type QuestionsThematiqueDiagnostic = {
+  questions: QuestionDiagnostic[];
+};
+
+type ReferentielDiagnostic = {
+  [clef: Thematique]: QuestionsThematiqueDiagnostic;
+};
+
+type Diagnostic = {
+  identifiant: crypto.UUID;
+  referentiel: ReferentielDiagnostic;
+};
+type EntrepotDiagnostic = Entrepot<Diagnostic>;
+const initialiseDiagnostic = (r: Referentiel): Diagnostic => {
+  const referentiel: {
+    [clef: Thematique]: QuestionsThematiqueDiagnostic;
+  } = Object.entries(r).reduce((accumulateur, [clef, questions]) => {
+    return {
+      ...accumulateur,
+      [clef as Thematique]: {
+        questions: questions.questions.map(
+          (q) =>
+            ({
+              ...q,
+              reponseDonnee: { valeur: null },
+            }) as QuestionDiagnostic,
+        ),
+      },
+    };
+  }, {});
+  return {
+    identifiant: crypto.randomUUID(),
+    referentiel,
+  };
+};
+
+export { Diagnostic, EntrepotDiagnostic, initialiseDiagnostic };

--- a/mon-aide-cyber-api/src/diagnostic/Referentiel.ts
+++ b/mon-aide-cyber-api/src/diagnostic/Referentiel.ts
@@ -3,7 +3,7 @@ type ReponseComplementaire = Omit<
   "question" | "reponsesComplementaires"
 >;
 
-type QuestionATiroir = Omit<Question, "reponsesPossibles" | "reponseDonnee"> & {
+type QuestionATiroir = Omit<Question, "reponsesPossibles"> & {
   reponsesPossibles: Omit<
     ReponsePossible,
     "question" | "reponsesComplementaires"
@@ -20,15 +20,10 @@ type ReponsePossible = {
 
 type TypeQuestion = "choixMultiple" | "choixUnique";
 
-type ReponseDonnee = {
-  valeur: string;
-};
-
 type Question = {
   identifiant: string;
   libelle: string;
   type: TypeQuestion;
-  reponseDonnee?: ReponseDonnee | undefined;
   reponsesPossibles: ReponsePossible[];
 };
 
@@ -56,7 +51,6 @@ export {
   QuestionChoixMultiple,
   Referentiel,
   ReponseComplementaire,
-  ReponseDonnee,
   ReponsePossible,
   TypeQuestion,
 };

--- a/mon-aide-cyber-api/src/diagnostic/ServiceDiagnostic.ts
+++ b/mon-aide-cyber-api/src/diagnostic/ServiceDiagnostic.ts
@@ -1,4 +1,4 @@
-import { Diagnostic } from "./Diagnostic";
+import { Diagnostic, initialiseDiagnostic } from "./Diagnostic";
 import * as crypto from "crypto";
 import { AdaptateurReferentiel } from "../adaptateurs/AdaptateurReferentiel";
 import { Entrepots } from "../domaine/Entrepots";
@@ -18,12 +18,9 @@ export class ServiceDiagnostic {
   diagnostic = async (id: crypto.UUID): Promise<Diagnostic> =>
     this.entrepots.diagnostic().lis(id);
 
-  cree = async (): Promise<Diagnostic> => {
-    return this.adaptateurReferentiel.lis().then((referentiel) => {
-      const diagnostic: Diagnostic = {
-        identifiant: crypto.randomUUID(),
-        referentiel,
-      };
+  lance = async (): Promise<Diagnostic> => {
+    return this.adaptateurReferentiel.lis().then((r) => {
+      const diagnostic = initialiseDiagnostic(r);
       this.entrepots.diagnostic().persiste(diagnostic);
       return Promise.resolve(diagnostic);
     });

--- a/mon-aide-cyber-api/test/constructeurs/constructeurDiagnostic.ts
+++ b/mon-aide-cyber-api/test/constructeurs/constructeurDiagnostic.ts
@@ -1,20 +1,21 @@
 import { Constructeur } from "./constructeur";
 import { unReferentiel } from "./constructeurReferentiel";
-import { fakerFR as faker } from "@faker-js/faker";
-import crypto from "crypto";
-import { Diagnostic } from "../../src/diagnostic/Diagnostic";
+import {
+  Diagnostic,
+  initialiseDiagnostic,
+} from "../../src/diagnostic/Diagnostic";
 import { Referentiel } from "../../src/diagnostic/Referentiel";
 
 class ConstructeurDiagnostic implements Constructeur<Diagnostic> {
   private referentiel: Referentiel = unReferentiel().construis();
-  private identifiant = faker.string.uuid() as crypto.UUID;
+
   avecUnReferentiel(referentiel: Referentiel): ConstructeurDiagnostic {
     this.referentiel = referentiel;
     return this;
   }
 
   construis(): Diagnostic {
-    return { identifiant: this.identifiant, referentiel: this.referentiel };
+    return initialiseDiagnostic(this.referentiel);
   }
 }
 


### PR DESCRIPTION
Afin de découpler le référentiel, qui contient le corps des questions, du diagnostic qui comprend les questions avec leurs réponses.

NB: Lorsqu’on lance un diagnostic pour la première fois, les réponses données sont valorisées à null