### PR TITLE
[CORRECTION] Évite l’appel à l’API pour ajouter des réponses au chargement du diagnostic

### DIFF
--- a/mon-aide-cyber-ui/src/composants/diagnostic/ComposantDiagnostic.tsx
+++ b/mon-aide-cyber-ui/src/composants/diagnostic/ComposantDiagnostic.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../domaine/diagnostic/reducteurDiagnostic.ts";
 import { FournisseurEntrepots } from "../../fournisseurs/FournisseurEntrepot.ts";
 import {
+  EtatReponseStatut,
   reducteurReponse,
   reponseChangee,
 } from "../../domaine/diagnostic/reducteurReponse.ts";
@@ -138,6 +139,7 @@ const ComposantQuestionListe = ({
 }: ProprietesComposantQuestion) => {
   const [etatReponse, envoie] = useReducer(reducteurReponse, {
     reponseDonnee: question.reponseDonnee,
+    statut: EtatReponseStatut.EN_COURS_DE_CHARGEMENT,
   });
   const entrepots = useContext(FournisseurEntrepots);
 
@@ -149,11 +151,11 @@ const ComposantQuestionListe = ({
   );
 
   useEffect(() => {
-    if (etatReponse.reponseDonnee !== undefined) {
+    if (etatReponse.statut === EtatReponseStatut.MODIFIE) {
       const action = actions?.find((a) => a.action === "repondre");
       if (action !== undefined) {
         entrepots.diagnostic().repond(action, {
-          reponseDonnee: etatReponse.reponseDonnee.valeur,
+          reponseDonnee: etatReponse.reponseDonnee!.valeur,
           identifiantQuestion: question.identifiant,
         });
       }
@@ -166,7 +168,11 @@ const ComposantQuestionListe = ({
       id={question.identifiant}
       name={question.identifiant}
       onChange={repond}
-      value={etatReponse.reponseDonnee?.valeur}
+      value={
+        etatReponse.reponseDonnee?.valeur !== null
+          ? etatReponse.reponseDonnee?.valeur
+          : undefined
+      }
     >
       {question.reponsesPossibles.map((reponse) => {
         return (
@@ -213,6 +219,7 @@ const ComposantQuestion = ({
 }: ProprietesComposantQuestion) => {
   const [etatReponse, envoie] = useReducer(reducteurReponse, {
     reponseDonnee: question.reponseDonnee,
+    statut: EtatReponseStatut.EN_COURS_DE_CHARGEMENT,
   });
   const entrepots = useContext(FournisseurEntrepots);
 
@@ -224,11 +231,11 @@ const ComposantQuestion = ({
   );
 
   useEffect(() => {
-    if (etatReponse.reponseDonnee !== undefined) {
+    if (etatReponse.statut === EtatReponseStatut.MODIFIE) {
       const action = actions?.find((a) => a.action === "repondre");
       if (action !== undefined) {
         entrepots.diagnostic().repond(action, {
-          reponseDonnee: etatReponse.reponseDonnee.valeur,
+          reponseDonnee: etatReponse.reponseDonnee!.valeur,
           identifiantQuestion: question.identifiant,
         });
       }

--- a/mon-aide-cyber-ui/src/domaine/diagnostic/Diagnostic.ts
+++ b/mon-aide-cyber-ui/src/domaine/diagnostic/Diagnostic.ts
@@ -13,7 +13,7 @@ export type Diagnostic = Aggregat & {
   referentiel: Referentiel;
 };
 export type Reponse = {
-  reponseDonnee: string;
+  reponseDonnee: string | null;
   identifiantQuestion: string;
 };
 export interface EntrepotDiagnostic extends Entrepot<Diagnostic> {

--- a/mon-aide-cyber-ui/src/domaine/diagnostic/Referentiel.ts
+++ b/mon-aide-cyber-ui/src/domaine/diagnostic/Referentiel.ts
@@ -18,7 +18,7 @@ export type ReponseComplementaire = Omit<
   "question" | "reponsesComplementaires"
 >;
 export type ReponseDonnee = {
-  valeur: string;
+  valeur: string | null;
 };
 export type ReponsePossible = {
   identifiant: string;

--- a/mon-aide-cyber-ui/src/domaine/diagnostic/reducteurReponse.ts
+++ b/mon-aide-cyber-ui/src/domaine/diagnostic/reducteurReponse.ts
@@ -5,8 +5,14 @@ enum TypeActionReponse {
   REPONSE_CHANGEE = "REPONSE_CHANGEE",
 }
 
+export enum EtatReponseStatut {
+  EN_COURS_DE_CHARGEMENT = "EN_COURS_DE_CHARGEMENT",
+  MODIFIE = "MODIFIE",
+}
+
 type EtatReponse = {
   reponseDonnee?: ReponseDonnee | undefined;
+  statut: EtatReponseStatut;
 };
 
 type ActionReponse =
@@ -24,7 +30,11 @@ export const reducteurReponse = (
 ): EtatReponse => {
   switch (action.type) {
     case TypeActionReponse.REPONSE_CHANGEE:
-      return { ...etat, reponseDonnee: { valeur: action.reponse } };
+      return {
+        ...etat,
+        reponseDonnee: { valeur: action.reponse },
+        statut: EtatReponseStatut.MODIFIE,
+      };
     case TypeActionReponse.REPONSE_DONNEE:
       return { ...etat, reponseDonnee: action.reponseDonnee };
   }

--- a/mon-aide-cyber-ui/src/stories/AfficheDiagnostic.stories.tsx
+++ b/mon-aide-cyber-ui/src/stories/AfficheDiagnostic.stories.tsx
@@ -228,6 +228,9 @@ export const QuestionDiagnostic: Story = {
         canvas.getByLabelText("Entreprise privée (ex. TPE, PME, ETI)"),
       ),
     ).toBeInTheDocument();
+    expect(await entrepotDiagnosticMemoire.verifieReponseNonEnvoyee()).toBe(
+      true,
+    );
   },
 };
 
@@ -285,6 +288,9 @@ export const AfficheDiagnosticQuestionListeDeroulante: Story = {
     expect(
       await waitFor(() => canvas.getByRole("option", { name: /réponse c/i })),
     ).toBeInTheDocument();
+    expect(await entrepotDiagnosticMemoire.verifieReponseNonEnvoyee()).toBe(
+      true,
+    );
   },
 };
 

--- a/mon-aide-cyber-ui/src/stories/ReponsesDonneesAuDiagnostic.stories.tsx
+++ b/mon-aide-cyber-ui/src/stories/ReponsesDonneesAuDiagnostic.stories.tsx
@@ -25,6 +25,7 @@ const diagnosticAvecUneQuestionAChoixUnique = unDiagnostic()
   .avecIdentifiant(identifiantQuestionAChoixUnique)
   .avecUnReferentiel(
     unReferentiel()
+      .sansAction()
       .ajouteAction(actionRepondre)
       .avecUneQuestion(
         uneQuestionAChoixUnique()
@@ -49,6 +50,7 @@ const diagnosticAvecQuestionSousFormeDeListeDeroulante = unDiagnostic()
   .avecIdentifiant(identifiantQuestionListeDeroulante)
   .avecUnReferentiel(
     unReferentiel()
+      .sansAction()
       .ajouteAction(actionRepondre)
       .avecUneQuestion(
         uneQuestionAChoixUnique()

--- a/mon-aide-cyber-ui/test/consructeurs/constructeurReferentiel.ts
+++ b/mon-aide-cyber-ui/test/consructeurs/constructeurReferentiel.ts
@@ -8,10 +8,11 @@ import {
 import { Constructeur } from "./Constructeur.ts";
 import { uneReponsePossible } from "./constructeurReponsePossible.ts";
 import { ActionDiagnostic } from "../../src/domaine/diagnostic/Diagnostic.ts";
+import { uneAction } from "./constructeurActionDiagnostic.ts";
 
 class ConstructeurReferentiel implements Constructeur<Referentiel> {
   private questions: Question[] = [];
-  private actions: ActionDiagnostic[] = [];
+  private actions: ActionDiagnostic[] = [uneAction().contexte().construis()];
 
   avecUneQuestionEtDesReponses(
     question: {
@@ -41,8 +42,14 @@ class ConstructeurReferentiel implements Constructeur<Referentiel> {
     this.questions.push(question);
     return this;
   }
+
   ajouteAction(action: ActionDiagnostic): ConstructeurReferentiel {
     this.actions.push(action);
+    return this;
+  }
+
+  sansAction(): ConstructeurReferentiel {
+    this.actions = [];
     return this;
   }
 

--- a/mon-aide-cyber-ui/test/domaine/diagnostic/reducteurReponse.spec.ts
+++ b/mon-aide-cyber-ui/test/domaine/diagnostic/reducteurReponse.spec.ts
@@ -1,21 +1,26 @@
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
+  EtatReponseStatut,
   reducteurReponse,
   reponseChangee,
 } from "../../../src/domaine/diagnostic/reducteurReponse";
 import { uneReponsePossible } from "../../consructeurs/constructeurReponsePossible";
 
 describe("Le réducteur de réponse", () => {
-  it("change la réponse donnée", () => {
+  it("change la réponse donnée et modifie le statut", () => {
     const nouvelleReponse = uneReponsePossible().construis();
 
     const etatReponse = reducteurReponse(
-      { reponseDonnee: undefined },
+      {
+        reponseDonnee: undefined,
+        statut: EtatReponseStatut.EN_COURS_DE_CHARGEMENT,
+      },
       reponseChangee(nouvelleReponse.identifiant),
     );
 
-    expect(etatReponse.reponseDonnee).toMatchObject({
-      valeur: nouvelleReponse.identifiant,
+    expect(etatReponse).toStrictEqual({
+      reponseDonnee: { valeur: nouvelleReponse.identifiant },
+      statut: EtatReponseStatut.MODIFIE,
     });
   });
 });

--- a/mon-aide-cyber-ui/test/infrastructure/entrepots/EntrepotsMemoire.ts
+++ b/mon-aide-cyber-ui/test/infrastructure/entrepots/EntrepotsMemoire.ts
@@ -37,6 +37,7 @@ export class EntrepotDiagnosticMemoire
 {
   private actionRepondre: ActionDiagnostic | undefined = undefined;
   private reponseDonnee: Reponse | undefined = undefined;
+  private reponseEnvoyee = false;
   lancer(): Promise<LienRoutage> {
     const diagnostic = unDiagnostic().construis();
     return this.persiste(diagnostic).then(
@@ -47,6 +48,7 @@ export class EntrepotDiagnosticMemoire
   repond(action: ActionDiagnostic, reponseDonnee: Reponse): Promise<void> {
     this.actionRepondre = action;
     this.reponseDonnee = reponseDonnee;
+    this.reponseEnvoyee = true;
     return Promise.resolve();
   }
 
@@ -54,14 +56,16 @@ export class EntrepotDiagnosticMemoire
     actionRepondre: ActionDiagnostic,
     reponseDonnee: Reponse,
   ) {
-    console.log(this.actionRepondre, actionRepondre);
-    console.log(this.reponseDonnee, reponseDonnee);
     return (
       Object.entries(this.actionRepondre!).toString() ===
         Object.entries(actionRepondre).toString() &&
       Object.entries(this.reponseDonnee!).toString() ===
         Object.entries(reponseDonnee).toString()
     );
+  }
+
+  async verifieReponseNonEnvoyee() {
+    return Promise.resolve(!this.reponseEnvoyee);
   }
 }
 


### PR DESCRIPTION
**Contexte:**

Afficher la page d’un diagnostic

**Étapes pour reproduire:**

- Ouvrir la console développeur de son navigateur
- Aller dans l’onglet réseau de la console
- Aller sur la page d’un diagnostic

**Résultat constaté:**

Il y a de multiples requêtes de réponse au diagnostic dans l’onglet réseau

**Résultat attendu:**

On ne doit voir que la requête de récupération du diagnostic au chargement du diagnostic