### PR TITLE
[DIAGNOSTIC] Prends en compte les réponses uniques pour les questions à tiroir

### DIFF
--- a/mon-aide-cyber-ui/src/composants/diagnostic/ComposantDiagnostic.tsx
+++ b/mon-aide-cyber-ui/src/composants/diagnostic/ComposantDiagnostic.tsx
@@ -154,15 +154,15 @@ const ComposantQuestion = ({
     [envoie],
   );
 
-  const repondChoixMultiple = useCallback(
+  const repondQuestionTiroir = useCallback(
     (
       identifiantReponse: string,
-      elementReponseMultiple: {
+      elementReponse: {
         identifiantReponse: string;
-        elementReponse: string;
+        reponse: string;
       },
     ) => {
-      envoie(reponseChangee(identifiantReponse, elementReponseMultiple));
+      envoie(reponseChangee(identifiantReponse, elementReponse));
     },
     [envoie],
   );
@@ -208,9 +208,9 @@ const ComposantQuestion = ({
                         (reponse) => reponse.reponses.has(rep.identifiant),
                       )}
                       onChange={(identifiantReponse) =>
-                        repondChoixMultiple(reponse.identifiant, {
+                        repondQuestionTiroir(reponse.identifiant, {
                           identifiantReponse: questionTiroir.identifiant,
-                          elementReponse: identifiantReponse,
+                          reponse: identifiantReponse,
                         })
                       }
                     />

--- a/mon-aide-cyber-ui/test/domaine/diagnostic/constructeurEtaReponse.ts
+++ b/mon-aide-cyber-ui/test/domaine/diagnostic/constructeurEtaReponse.ts
@@ -4,50 +4,35 @@ import {
   EtatReponseStatut,
 } from "../../../src/domaine/diagnostic/reducteurReponse";
 import {
+  Question,
   ReponseDonnee,
-  ReponsePossible,
 } from "../../../src/domaine/diagnostic/Referentiel";
 
 class ConstructeurEtaReponse {
   private reponse: () => Reponse | null = () => null;
   private statut: EtatReponseStatut = EtatReponseStatut.CHARGEE;
-  private reponseDonnee: ReponseDonnee = {
-    valeur: null,
-    reponses: [],
-  };
   private valeur: () => string | undefined = () => undefined;
 
-  constructor(private readonly identifiantQuestion: string) {}
+  constructor(private readonly question: Question) {}
 
   reponseChargee(): ConstructeurEtaReponse {
     this.statut = EtatReponseStatut.CHARGEE;
     return this;
   }
-
-  avecUneReponseDonnee(reponse: {
-    reponse: ReponsePossible;
-    reponses: { identifiant: string; reponses: string[] }[];
-  }): ConstructeurEtaReponse {
-    this.reponseDonnee = {
-      valeur: reponse.reponse.identifiant,
-      reponses: reponse.reponses.map((rep) => ({
-        identifiant: rep.identifiant,
-        reponses: new Set(rep.reponses),
-      })),
-    };
-    return this;
-  }
-
   construis(): EtatReponse {
+    const reponseDonnee: ReponseDonnee = {
+      valeur: this.question.reponseDonnee.valeur,
+      reponses: this.question.reponseDonnee.reponses,
+    };
     return {
-      identifiantQuestion: this.identifiantQuestion,
+      question: this.question,
       reponse: this.reponse,
-      reponseDonnee: this.reponseDonnee,
+      reponseDonnee,
       statut: this.statut,
       valeur: this.valeur,
     };
   }
 }
 
-export const unEtatDeReponse = (identifiantQuestion: string) =>
-  new ConstructeurEtaReponse(identifiantQuestion);
+export const unEtatDeReponse = (question: Question) =>
+  new ConstructeurEtaReponse(question);


### PR DESCRIPTION
Pour les questions à tiroir nécessitant une réponse unique (cf capture ci-dessous), on s'assure de n'envoyer qu'une seule réponse.
<img width="806" alt="Capture d’écran 2023-09-11 à 09 57 36" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/9a884eea-bbaa-4764-b3fa-d8d7831021c9">
