### PR TITLE
[CORRECTION] Corrige la saisie des questions à réponses uniques 

### DIFF
--- a/mon-aide-cyber-ui/src/domaine/diagnostic/reducteurReponse.ts
+++ b/mon-aide-cyber-ui/src/domaine/diagnostic/reducteurReponse.ts
@@ -178,7 +178,19 @@ export const reducteurReponse = (
       };
     }
     case TypeActionReponse.REPONSE_TIROIR_UNIQUE_DONNEE: {
-      const reponses: ReponseMultiple[] = toutesLesReponses();
+      let reponses: ReponseMultiple[] = toutesLesReponses();
+      if (
+        !reponses
+          .map((rep) => rep.identifiant)
+          .some((rep) =>
+            etat.question.reponsesPossibles
+              .filter((rep) => rep.identifiant === action.reponse.valeur)
+              .flatMap((rep) => rep.questions?.map((q) => q.identifiant))
+              .includes(rep),
+          )
+      ) {
+        reponses = [];
+      }
       const elementReponse = action.reponse.elementReponse;
       const aDejaUneReponse = reponses.find(
         (rep) => rep.identifiant === elementReponse.identifiantReponse,

--- a/mon-aide-cyber-ui/src/stories/ReponsesDonneesAuDiagnostic.stories.tsx
+++ b/mon-aide-cyber-ui/src/stories/ReponsesDonneesAuDiagnostic.stories.tsx
@@ -102,8 +102,7 @@ const reponseAvecQuestionAChoixMultiple = uneReponsePossible()
         uneReponsePossible().avecLibelle("choix 4").construis(),
       ])
       .construis(),
-  )
-  .construis();
+  );
 const diagnosticAvecQuestionATiroir = unDiagnostic()
   .avecIdentifiant(identifiantQuestionATiroir)
   .avecUnReferentiel(
@@ -116,9 +115,9 @@ const diagnosticAvecQuestionATiroir = unDiagnostic()
           .avecDesReponses([
             uneReponsePossible().construis(),
             uneReponsePossible().avecLibelle("un seul choix").construis(),
-            reponseAvecQuestionAChoixMultiple,
+            reponseAvecQuestionAChoixMultiple.construis(),
           ])
-          .avecLaReponseDonnee(reponseAvecQuestionAChoixMultiple, [
+          .avecLaReponseDonnee(reponseAvecQuestionAChoixMultiple.construis(), [
             {
               identifiant: "la-question",
               reponses: new Set(["choix-2", "choix-4"]),
@@ -129,6 +128,119 @@ const diagnosticAvecQuestionATiroir = unDiagnostic()
       .construis(),
   )
   .construis();
+
+const identifiantQuestionATiroirAvecChoixUniqueEtChoixMultiple =
+  "df11a788-7375-449d-844f-2b3298546d36";
+const questionAChoixUnique = uneQuestionAChoixUnique()
+  .avecLibelle("Réponse unique")
+  .avecDesReponses([
+    uneReponsePossible().avecLibelle("rep unique 1").construis(),
+    uneReponsePossible().avecLibelle("rep unique 2").construis(),
+    uneReponsePossible().avecLibelle("rep unique 3").construis(),
+  ]);
+const diagnosticAvecQuestionATiroirAvecChoixUniqueEtChoixMultiple =
+  unDiagnostic()
+    .avecIdentifiant(identifiantQuestionATiroirAvecChoixUniqueEtChoixMultiple)
+    .avecUnReferentiel(
+      unReferentiel()
+        .sansAction()
+        .ajouteAction(actionRepondre)
+        .avecUneQuestion(
+          uneQuestionAChoixUnique()
+            .avecLibelle("Tiroir multiple et unique")
+            .avecDesReponses([
+              uneReponsePossible().avecLibelle("Non").construis(),
+              reponseAvecQuestionAChoixMultiple
+                .avecUneQuestion(questionAChoixUnique.construis())
+                .construis(),
+            ])
+            .avecLaReponseDonnee(
+              reponseAvecQuestionAChoixMultiple.construis(),
+              [
+                {
+                  identifiant: "la-question",
+                  reponses: new Set(["choix-2", "choix-4"]),
+                },
+                {
+                  identifiant: "reponse-unique",
+                  reponses: new Set(["rep-unique-2"]),
+                },
+              ],
+            )
+            .construis(),
+        )
+        .construis(),
+    )
+    .construis();
+
+const identifiantQuestionATiroirAvecPlusieursChoixUnique =
+  "0170b46d-16d2-4ec4-88e0-85356914388a";
+const premiereReponseAChoixUniqueATiroir = uneReponsePossible()
+  .avecLibelle("Première réponse unique à tiroir")
+  .avecUneQuestion(questionAChoixUnique.construis())
+  .avecUneQuestion(
+    uneQuestionAChoixUnique()
+      .avecLibelle("Autre réponse unique")
+      .avecDesReponses([
+        uneReponsePossible().avecLibelle("1 - autre rep unique 1").construis(),
+        uneReponsePossible().avecLibelle("1 - autre rep unique 2").construis(),
+        uneReponsePossible().avecLibelle("1 - autre rep unique 3").construis(),
+      ])
+      .construis(),
+  )
+  .construis();
+const secondeReponseAChoixUniqueATiroir = uneReponsePossible()
+  .avecLibelle("Seconde réponse unique à tiroir")
+  .avecUneQuestion(
+    uneQuestionAChoixUnique()
+      .avecLibelle("2 - Réponse unique")
+      .avecDesReponses([
+        uneReponsePossible().avecLibelle("2 - rep unique 1").construis(),
+        uneReponsePossible().avecLibelle("2 - rep unique 2").construis(),
+        uneReponsePossible().avecLibelle("2 - rep unique 3").construis(),
+      ])
+      .construis(),
+  )
+  .avecUneQuestion(
+    uneQuestionAChoixUnique()
+      .avecLibelle("2 - Autre réponse unique")
+      .avecDesReponses([
+        uneReponsePossible().avecLibelle("2 - autre rep unique 1").construis(),
+        uneReponsePossible().avecLibelle("2 - autre rep unique 2").construis(),
+        uneReponsePossible().avecLibelle("2 - autre rep unique 3").construis(),
+      ])
+      .construis(),
+  )
+  .construis();
+const diagnosticAvecUneQuestionAvecPlusieursQuestionsATiroirAChoixUnique =
+  unDiagnostic()
+    .avecIdentifiant(identifiantQuestionATiroirAvecPlusieursChoixUnique)
+    .avecUnReferentiel(
+      unReferentiel()
+        .sansAction()
+        .ajouteAction(actionRepondre)
+        .avecUneQuestion(
+          uneQuestionAChoixUnique()
+            .avecLibelle("Une question à choix unique à tiroir")
+            .avecDesReponses([
+              premiereReponseAChoixUniqueATiroir,
+              secondeReponseAChoixUniqueATiroir,
+            ])
+            .avecLaReponseDonnee(premiereReponseAChoixUniqueATiroir, [
+              {
+                identifiant: "reponse-unique",
+                reponses: new Set(["rep-unique-2"]),
+              },
+              {
+                identifiant: "autre-reponse-unique",
+                reponses: new Set(["1-autre-rep-unique-1"]),
+              },
+            ])
+            .construis(),
+        )
+        .construis(),
+    )
+    .construis();
 
 const identifiantQuestionAPlusieursTiroirs =
   "7e37b7fa-1ed6-434d-ba5b-d473928c08c2";
@@ -144,19 +256,8 @@ const diagnosticAvecQuestionsAPlusieursTiroirs = unDiagnostic()
           .avecDesReponses([
             uneReponsePossible().construis(),
             uneReponsePossible().avecLibelle("un seul choix").construis(),
-            uneReponsePossible()
+            reponseAvecQuestionAChoixMultiple
               .avecLibelle("Plusieurs tiroirs")
-              .avecUneQuestion(
-                uneQuestionTiroirAChoixMultiple()
-                  .avecLibelle("La question?")
-                  .avecDesReponses([
-                    uneReponsePossible().avecLibelle("choix 1").construis(),
-                    uneReponsePossible().avecLibelle("choix 2").construis(),
-                    uneReponsePossible().avecLibelle("choix 3").construis(),
-                    uneReponsePossible().avecLibelle("choix 4").construis(),
-                  ])
-                  .construis(),
-              )
               .avecUneQuestion(
                 uneQuestionTiroirAChoixMultiple()
                   .avecLibelle("second tiroir")
@@ -166,10 +267,9 @@ const diagnosticAvecQuestionsAPlusieursTiroirs = unDiagnostic()
                   ])
                   .construis(),
               )
-
               .construis(),
           ])
-          .avecLaReponseDonnee(reponseAvecQuestionAChoixMultiple, [
+          .avecLaReponseDonnee(reponseAvecQuestionAChoixMultiple.construis(), [
             {
               identifiant: "la-question",
               reponses: new Set(["choix-2", "choix-4"]),
@@ -213,7 +313,7 @@ const diagnosticAvecQuestionsATiroirsAvecReponseUnique = unDiagnostic()
               )
               .construis(),
           ])
-          .avecLaReponseDonnee(reponseAvecQuestionAChoixMultiple, [
+          .avecLaReponseDonnee(reponseAvecQuestionAChoixMultiple.construis(), [
             {
               identifiant: "le-choix-unique-",
               reponses: new Set(["choix-2"]),
@@ -257,6 +357,12 @@ await entrepotDiagnosticMemoire.persiste(
 );
 await entrepotDiagnosticMemoire.persiste(diagnosticAPlusieursThematiques);
 await entrepotDiagnosticMemoire.persiste(diagnosticAvecQuestionATiroir);
+await entrepotDiagnosticMemoire.persiste(
+  diagnosticAvecQuestionATiroirAvecChoixUniqueEtChoixMultiple,
+);
+await entrepotDiagnosticMemoire.persiste(
+  diagnosticAvecUneQuestionAvecPlusieursQuestionsATiroirAChoixUnique,
+);
 await entrepotDiagnosticMemoire.persiste(
   diagnosticAvecQuestionsAPlusieursTiroirs,
 );
@@ -621,6 +727,327 @@ export const SelectionneLesReponsesPourLesQuestionsAPlusieursTiroirs: Story = {
     });
   },
 };
+
+export const SelectionneLesReponsesPourLesQuestionsATiroirsAChoixMultipleEtAChoixUnique: Story =
+  {
+    name: "Sélectionne les réponses pour les questions à tiroirs à choix multiple et à choix unique",
+    args: {
+      idDiagnostic: identifiantQuestionATiroirAvecChoixUniqueEtChoixMultiple,
+    },
+    play: async ({ canvasElement, step }) => {
+      const canvas = within(canvasElement);
+
+      await step(
+        "Lorsque le diagnostic est récupéré depuis l’API",
+        async () => {
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("radio", {
+                name: /plusieurs choix?/i,
+              }),
+            ),
+          ).toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("checkbox", {
+                name: /choix 2/i,
+              }),
+            ),
+          ).toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("checkbox", {
+                name: /choix 4/i,
+              }),
+            ),
+          ).toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("radio", {
+                name: /rep unique 2/i,
+              }),
+            ),
+          ).toBeChecked();
+        },
+      );
+
+      await step("Lorsque l’utilisateur modifie la réponse", async () => {
+        await userEvent.click(
+          canvas.getByRole("radio", { name: /rep unique 1/i }),
+        );
+        await userEvent.click(
+          canvas.getByRole("checkbox", { name: /choix 3/i }),
+        );
+
+        expect(
+          await waitFor(() =>
+            canvas.getByRole("radio", { name: /plusieurs choix?/i }),
+          ),
+        ).toBeChecked();
+        expect(
+          await waitFor(() =>
+            canvas.getByRole("checkbox", {
+              name: /choix 2/i,
+            }),
+          ),
+        ).toBeChecked();
+        expect(
+          await waitFor(() =>
+            canvas.getByRole("checkbox", {
+              name: /choix 3/i,
+            }),
+          ),
+        ).toBeChecked();
+        expect(
+          await waitFor(() =>
+            canvas.getByRole("checkbox", {
+              name: /choix 4/i,
+            }),
+          ),
+        ).toBeChecked();
+        expect(
+          await waitFor(() =>
+            canvas.getByRole("radio", {
+              name: /rep unique 1/i,
+            }),
+          ),
+        ).toBeChecked();
+        expect(
+          await waitFor(() =>
+            canvas.getByRole("radio", {
+              name: /rep unique 2/i,
+            }),
+          ),
+        ).not.toBeChecked();
+        entrepotDiagnosticMemoire.verifieEnvoiReponse(actionRepondre, {
+          reponseDonnee: {
+            reponse: "plusieurs-choix",
+            questions: [
+              {
+                identifiant: "la-question",
+                reponses: ["choix-2", "choix-4", "choix-3"],
+              },
+              {
+                identifiant: "reponse-unique",
+                reponses: ["rep-unique-1"],
+              },
+            ],
+          },
+          identifiantQuestion: "tiroir-multiple-et-unique",
+        });
+      });
+
+      await step(
+        'Lorsque l\'utilisateur clique sur la réponse "Non" sans question tiroir',
+        async () => {
+          await userEvent.click(canvas.getByRole("radio", { name: /non/i }));
+
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("radio", { name: /plusieurs choix?/i }),
+            ),
+          ).not.toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("checkbox", {
+                name: /choix 1/i,
+              }),
+            ),
+          ).not.toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("checkbox", {
+                name: /choix 2/i,
+              }),
+            ),
+          ).not.toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("checkbox", {
+                name: /choix 3/i,
+              }),
+            ),
+          ).not.toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("checkbox", {
+                name: /choix 4/i,
+              }),
+            ),
+          ).not.toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("radio", {
+                name: /rep unique 1/i,
+              }),
+            ),
+          ).not.toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("radio", {
+                name: /rep unique 2/i,
+              }),
+            ),
+          ).not.toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("radio", {
+                name: /rep unique 3/i,
+              }),
+            ),
+          ).not.toBeChecked();
+          entrepotDiagnosticMemoire.verifieEnvoiReponse(actionRepondre, {
+            reponseDonnee: "non",
+            identifiantQuestion: "tiroir-multiple-et-unique",
+          });
+        },
+      );
+    },
+  };
+
+export const SelectionneLesReponsesPourLesQuestionsAPlusieursTiroirsAChoixUnique: Story =
+  {
+    name: "Sélectionne les réponses pour les questions à plusieurs tiroirs à choix unique",
+    args: {
+      idDiagnostic: identifiantQuestionATiroirAvecPlusieursChoixUnique,
+    },
+    play: async ({ canvasElement, step }) => {
+      const canvas = within(canvasElement);
+
+      await step(
+        "Lorsque le diagnostic est récupéré depuis l’API",
+        async () => {
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("radio", {
+                name: /première réponse unique à tiroir/i,
+              }),
+            ),
+          ).toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("radio", {
+                name: "rep unique 2",
+              }),
+            ),
+          ).toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("radio", {
+                name: /1 - autre rep unique 1/i,
+              }),
+            ),
+          ).toBeChecked();
+        },
+      );
+
+      await step("Lorsque l’utilisateur modifie la réponse", async () => {
+        await userEvent.click(
+          canvas.getByRole("radio", { name: /1 - autre rep unique 2/i }),
+        );
+
+        expect(
+          await waitFor(() =>
+            canvas.getByRole("radio", {
+              name: /première réponse unique à tiroir/i,
+            }),
+          ),
+        ).toBeChecked();
+        entrepotDiagnosticMemoire.verifieEnvoiReponse(actionRepondre, {
+          reponseDonnee: {
+            reponse: "premiere-reponse-unique-a-tiroir",
+            questions: [
+              {
+                identifiant: "reponse-unique",
+                reponses: ["rep-unique-2"],
+              },
+              {
+                identifiant: "autre-reponse-unique",
+                reponses: ["1-autre-rep-unique-2"],
+              },
+            ],
+          },
+          identifiantQuestion: "une-question-a-choix-unique-a-tiroir",
+        });
+      });
+
+      await step(
+        "Lorsque l'utilisateur clique sur une autre réponse avec question tiroir",
+        async () => {
+          await userEvent.click(
+            canvas.getByRole("radio", {
+              name: /seconde réponse unique à tiroir/i,
+            }),
+          );
+          await userEvent.click(
+            canvas.getByRole("radio", { name: /2 - rep unique 3/i }),
+          );
+          await userEvent.click(
+            canvas.getByRole("radio", { name: /2 - autre rep unique 1/i }),
+          );
+
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("radio", {
+                name: /première réponse unique à tiroir/i,
+              }),
+            ),
+          ).not.toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("radio", {
+                name: "rep unique 2",
+              }),
+            ),
+          ).not.toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("radio", {
+                name: /1 - autre rep unique 2/i,
+              }),
+            ),
+          ).not.toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("radio", {
+                name: /seconde réponse unique à tiroir/i,
+              }),
+            ),
+          ).toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("radio", {
+                name: /2 - rep unique 3/i,
+              }),
+            ),
+          ).toBeChecked();
+          expect(
+            await waitFor(() =>
+              canvas.getByRole("radio", {
+                name: /2 - autre rep unique 1/i,
+              }),
+            ),
+          ).toBeChecked();
+          entrepotDiagnosticMemoire.verifieEnvoiReponse(actionRepondre, {
+            reponseDonnee: {
+              reponse: "seconde-reponse-unique-a-tiroir",
+              questions: [
+                {
+                  identifiant: "2-reponse-unique",
+                  reponses: ["2-rep-unique-3"],
+                },
+                {
+                  identifiant: "2-autre-reponse-unique",
+                  reponses: ["2-autre-rep-unique-1"],
+                },
+              ],
+            },
+            identifiantQuestion: "une-question-a-choix-unique-a-tiroir",
+          });
+        },
+      );
+    },
+  };
 
 export const SelectionneLaReponsePourLaQuestionsATiroirAvecReponseUnique: Story =
   {

--- a/mon-aide-cyber-ui/test/domaine/diagnostic/reducteurReponse.spec.ts
+++ b/mon-aide-cyber-ui/test/domaine/diagnostic/reducteurReponse.spec.ts
@@ -13,6 +13,7 @@ import {
   uneQuestionAChoixMultiple,
   uneQuestionAChoixUnique,
   uneQuestionTiroirAChoixMultiple,
+  uneQuestionTiroirAChoixUnique,
 } from "../../constructeurs/constructeurQuestions";
 import { unEtatDeReponse } from "./constructeurEtaReponse";
 
@@ -309,6 +310,90 @@ describe("Le réducteur de réponse", () => {
           questions: [
             { identifiant: "tiroir-1", reponses: ["choix-12", "choix-13"] },
             { identifiant: "tiroir-2", reponses: ["choix-21", "choix-23"] },
+          ],
+        },
+      });
+      expect(etatReponse.statut).toBe(EtatReponseStatut.MODIFIE);
+    });
+
+    it("prend en compte les réponses à choix unique avec plusieurs questions à tiroir", () => {
+      const nouvelleReponse = uneReponsePossible()
+        .avecUneQuestion(
+          uneQuestionTiroirAChoixUnique()
+            .avecLibelle("tiroir 1")
+            .avecDesReponses([
+              uneReponsePossible().avecLibelle("choix 12").construis(),
+              uneReponsePossible().avecLibelle("choix 13").construis(),
+            ])
+            .construis(),
+        )
+        .construis();
+      const uneAutreReponse = uneReponsePossible()
+        .avecUneQuestion(
+          uneQuestionTiroirAChoixUnique()
+            .avecLibelle("tiroir 2")
+            .avecDesReponses([
+              uneReponsePossible().avecLibelle("choix 22").construis(),
+              uneReponsePossible().avecLibelle("choix 23").construis(),
+            ])
+            .construis(),
+        )
+        .avecUneQuestion(
+          uneQuestionTiroirAChoixUnique()
+            .avecLibelle("tiroir 3")
+            .avecDesReponses([
+              uneReponsePossible().avecLibelle("choix 32").construis(),
+              uneReponsePossible().avecLibelle("choix 33").construis(),
+            ])
+            .construis(),
+        )
+        .construis();
+      const question = uneQuestionAChoixUnique()
+        .avecLibelle("Une Question")
+        .avecDesReponses([nouvelleReponse, uneAutreReponse])
+        .avecLaReponseDonnee(nouvelleReponse, [
+          {
+            identifiant: "tiroir-1",
+            reponses: new Set(["choix-12"]),
+          },
+        ])
+        .construis();
+
+      const premierEtatReponse = reducteurReponse(
+        unEtatDeReponse(question).reponseChargee().construis(),
+        reponseTiroirUniqueDonnee(uneAutreReponse.identifiant, {
+          identifiantReponse: "tiroir-2",
+          reponse: "choix-23",
+        }),
+      );
+      const etatReponse = reducteurReponse(
+        premierEtatReponse,
+        reponseTiroirUniqueDonnee(uneAutreReponse.identifiant, {
+          identifiantReponse: "tiroir-3",
+          reponse: "choix-32",
+        }),
+      );
+
+      expect(etatReponse.reponseDonnee).toStrictEqual({
+        valeur: uneAutreReponse.identifiant,
+        reponses: [
+          {
+            identifiant: "tiroir-2",
+            reponses: new Set(["choix-23"]),
+          },
+          {
+            identifiant: "tiroir-3",
+            reponses: new Set(["choix-32"]),
+          },
+        ],
+      });
+      expect(etatReponse.reponse()).toStrictEqual({
+        identifiantQuestion: "une-question",
+        reponseDonnee: {
+          reponse: uneAutreReponse.identifiant,
+          questions: [
+            { identifiant: "tiroir-2", reponses: ["choix-23"] },
+            { identifiant: "tiroir-3", reponses: ["choix-32"] },
           ],
         },
       });


### PR DESCRIPTION
Pour une question à choix unique ayant des réponses avec question à tiroir, les réponses des questions à tiroir étaient conservées lorsque l'on change les réponses.
**Exemple:**
<img width="1338" alt="Capture d’écran 2023-09-18 à 15 56 50" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/8ea2804b-68a0-41aa-b957-bba674deacf4">
