### PR TITLE
[CORRECTION] Corrige les tests d'intégration pour les appels d'API

### DIFF
--- a/mon-aide-cyber-api/package.json
+++ b/mon-aide-cyber-api/package.json
@@ -6,7 +6,7 @@
     "build": "",
     "start": "ts-node --transpile-only --require dotenv/config index.ts",
     "dev": "nodemon --require dotenv/config index.ts",
-    "test": "tsc && vitest run --config vitest.config.ts --reporter verbose",
+    "test": "tsc --noEmit && vitest run --config vitest.config.ts --reporter verbose",
     "test:coverage": "vitest --config vitest.config.ts run --coverage",
     "test:watch": "vitest --config vitest.config.ts --ui --reporter verbose"
   },
@@ -27,6 +27,7 @@
     "@typescript-eslint/parser": "^5.60.1",
     "@vitest/coverage-v8": "^0.32.2",
     "eslint": "^8.43.0",
+    "light-my-request": "^5.11.0",
     "nodemon": "^2.0.22",
     "vitest": "^0.32.2"
   }

--- a/mon-aide-cyber-api/src/serveur.ts
+++ b/mon-aide-cyber-api/src/serveur.ts
@@ -21,9 +21,7 @@ export type ConfigurationServeur = {
   entrepots: Entrepots;
 };
 
-const creeServeur = (config: ConfigurationServeur) => {
-  let serveur: http.Server;
-
+const creeApp = (config: ConfigurationServeur) => {
   const app = express();
 
   const limiteurTrafficUI = rateLimit({
@@ -41,13 +39,6 @@ const creeServeur = (config: ConfigurationServeur) => {
   app.use(
     express.static(path.join(__dirname, "./../../mon-aide-cyber-ui/dist")),
   );
-  const ecoute = (port: number, succes: () => void) => {
-    serveur = app.listen(port, succes);
-  };
-  const arreteEcoute = () => {
-    serveur.close();
-  };
-
   app.use("/api", routesAPI(config));
 
   app.get("*", (_: Request, reponse: Response) =>
@@ -57,8 +48,22 @@ const creeServeur = (config: ConfigurationServeur) => {
   );
 
   app.use(gestionnaireErreurAggregatNonTrouve);
+  return app;
+};
 
-  return { ecoute, arreteEcoute };
+const creeServeur = (config: ConfigurationServeur) => {
+  let serveur: http.Server;
+
+  const app = creeApp(config);
+
+  const ecoute = (port: number, succes: () => void) => {
+    serveur = app.listen(port, succes);
+  };
+  const arreteEcoute = () => {
+    serveur.close();
+  };
+
+  return { app, ecoute, arreteEcoute };
 };
 
 export default { creeServeur };

--- a/mon-aide-cyber-api/test/api/executeurRequete.ts
+++ b/mon-aide-cyber-api/test/api/executeurRequete.ts
@@ -1,8 +1,12 @@
+import { Express } from "express";
+import { inject, Response } from "light-my-request";
+
 export const executeRequete = (
+  app: Express,
   verbe: "GET" | "POST" | "PATCH",
   chemin: string,
   port: number,
-  corps: object | null = null,
+  corps: object | undefined = undefined,
 ): Promise<Response> => {
   const requeteInit: RequestInit = {
     method: verbe,
@@ -11,5 +15,9 @@ export const executeRequete = (
   if (corps !== null) {
     requeteInit["body"] = JSON.stringify(corps);
   }
-  return fetch(`http://localhost:${port}${chemin}`, requeteInit);
+  return inject(app, {
+    method: verbe,
+    url: { pathname: chemin, port },
+    ...(corps && { body: corps }),
+  }).then((rep) => rep);
 };

--- a/mon-aide-cyber-api/test/api/routeAPIDiagnostics.spec.ts
+++ b/mon-aide-cyber-api/test/api/routeAPIDiagnostics.spec.ts
@@ -2,13 +2,14 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import testeurIntegration from "./testeurIntegration";
 import { executeRequete } from "./executeurRequete";
 import { unDiagnostic } from "../constructeurs/constructeurDiagnostic";
+import { Express } from "express";
 
 describe("le serveur MAC sur les routes /api/diagnostics/", () => {
   const testeurMAC = testeurIntegration();
-  let numeroPort: number;
+  let donneesServeur: { portAleatoire: number; app: Express };
 
   beforeEach(() => {
-    numeroPort = testeurMAC.initialise();
+    donneesServeur = testeurMAC.initialise();
   });
 
   afterEach(() => testeurMAC.arrete());
@@ -23,12 +24,13 @@ describe("le serveur MAC sur les routes /api/diagnostics/", () => {
       testeurMAC.entrepots.diagnostic().persiste(troisiemeDiagnostic);
 
       const reponse = await executeRequete(
+        donneesServeur.app,
         "GET",
         "/api/diagnostics",
-        numeroPort,
+        donneesServeur.portAleatoire,
       );
 
-      expect(reponse.status).toBe(200);
+      expect(reponse.statusCode).toBe(200);
       expect(await reponse.json()).toStrictEqual([
         {
           identifiant: premierDiagnostic.identifiant,

--- a/mon-aide-cyber-api/test/api/testeurIntegration.ts
+++ b/mon-aide-cyber-api/test/api/testeurIntegration.ts
@@ -7,9 +7,11 @@ import { AdaptateurTableauDeNotesDeTest } from "../adaptateurs/AdaptateurTableau
 import { AdaptateurTableauDeRecommandationsDeTest } from "../adaptateurs/AdaptateurTableauDeRecommandationsDeTest";
 import { AdaptateurPDF } from "../../src/adaptateurs/AdaptateurPDF";
 import { Diagnostic } from "../../src/diagnostic/Diagnostic";
+import { Express } from "express";
 
 const testeurIntegration = () => {
   let serveurDeTest: {
+    app: Express;
     arreteEcoute: () => void;
     ecoute: (port: number, succes: () => void) => void;
   };
@@ -35,7 +37,7 @@ const testeurIntegration = () => {
     const portAleatoire = faker.number.int({ min: 1000, max: 3000 });
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     serveurDeTest.ecoute(portAleatoire, () => {});
-    return portAleatoire;
+    return { portAleatoire, app: serveurDeTest.app };
   };
 
   const arrete = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@typescript-eslint/parser": "^5.60.1",
         "@vitest/coverage-v8": "^0.32.2",
         "eslint": "^8.43.0",
+        "light-my-request": "^5.11.0",
         "nodemon": "^2.0.22",
         "vitest": "^0.32.2"
       }
@@ -16721,6 +16722,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/light-my-request": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.11.0.tgz",
+      "integrity": "sha512-qkFCeloXCOMpmEdZ/MV91P8AT4fjwFXWaAFz3lUeStM8RcoM1ks4J/F8r1b3r6y/H4u3ACEJ1T+Gv5bopj7oDA==",
+      "dev": true,
+      "dependencies": {
+        "cookie": "^0.5.0",
+        "process-warning": "^2.0.0",
+        "set-cookie-parser": "^2.4.1"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -18445,6 +18457,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/process-warning": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+      "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==",
+      "dev": true
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -19847,6 +19865,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
       "dev": true
     },
     "node_modules/setprototypeof": {


### PR DESCRIPTION
- Sur la CI, les tests sur le réseau (en HTTP) cassent aléatoirement (address already in use)
- On utilise une librairie d'injection pour éviter des appels sur la couche HTTP