### PR TITLE
[CORRECTION] Corrige la génération des recommandations pour s'assurer qu'une seule recommandation par question est donnée

### DIFF
--- a/mon-aide-cyber-api/src/diagnostic/MoteurDeRecommandations.ts
+++ b/mon-aide-cyber-api/src/diagnostic/MoteurDeRecommandations.ts
@@ -96,8 +96,23 @@ class MoteurDeRecommandationReponsesMultiples extends MoteurDeRecommandation {
   enTantQue(note: RegleDeCalcul): RegleDeCalcul {
     return note;
   }
-  filtre(__: string, note: Note | RegleDeCalcul): boolean {
-    return estRegleDeCalcul(note);
+
+  filtre(identifiantReponse: string, note: Note | RegleDeCalcul): boolean {
+    const identifiantsReponsesTiroir = this.question.reponsesPossibles
+      .filter((reponse) => reponse.identifiant === identifiantReponse)
+      .map((reponse) => reponse.questions)
+      .flatMap(
+        (question) =>
+          question?.flatMap((question) =>
+            question.reponsesPossibles.map((reponse) => reponse.identifiant),
+          ),
+      );
+    return (
+      this.question.reponseDonnee.reponsesMultiples
+        .flatMap((reponses) => Array.from(reponses.reponses))
+        .some((reponse) => identifiantsReponsesTiroir.includes(reponse)) &&
+      estRegleDeCalcul(note)
+    );
   }
 
   calculeLaNote(regleDeCalcul: RegleDeCalcul): Note {
@@ -140,9 +155,9 @@ class CalculateurDeNote {
   }
 }
 
-function estUnNombre(note: Note): boolean {
+const estUnNombre = (note: Note): boolean => {
   return typeof note === "number";
-}
+};
 const estRegleDeCalcul = (
   note: Note | RegleDeCalcul,
 ): note is RegleDeCalcul => {

--- a/mon-aide-cyber-api/test/diagnostic/MoteurDeRecommandations.spec.ts
+++ b/mon-aide-cyber-api/test/diagnostic/MoteurDeRecommandations.spec.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { MoteurDeRecommandations } from "../../src/diagnostic/MoteurDeRecommandations";
+import {
+  unDiagnostic,
+  uneReponseDonnee,
+} from "../constructeurs/constructeurDiagnostic";
+import {
+  uneQuestion,
+  uneQuestionATiroir,
+  uneReponsePossible,
+  unReferentiel,
+} from "../constructeurs/constructeurReferentiel";
+import { unTableauDeNotes } from "../constructeurs/constructeurTableauDeNotes";
+import { unTableauDeRecommandations } from "../constructeurs/constructeurTableauDeRecommandations";
+
+describe("Moteur de recommandations", () => {
+  const tableauDeNotes = unTableauDeNotes()
+    .avecDesNotes([
+      {
+        "la-question": {
+          "rep-1": {
+            operation: "moyenne",
+            reponses: {
+              "rep-111": 1,
+              "rep-112": 1,
+              "rep-121": 1,
+              "rep-122": 1,
+            },
+          },
+          "rep-2": {
+            operation: "moyenne",
+            reponses: {
+              "rep-211": 0.5,
+              "rep-212": 1,
+              "rep-221": 0.5,
+            },
+          },
+        },
+      },
+    ])
+    .construis();
+
+  const tableauDeRecommandations = unTableauDeRecommandations()
+    .avecLesRecommandations([
+      {
+        "la-question": {
+          niveau1: "reco 1",
+          niveau2: "reco 2",
+          priorisation: 1,
+        },
+      },
+    ])
+    .construis();
+
+  const reponseATiroir = uneReponsePossible()
+    .avecLibelle("rep 1")
+    .ajouteUneQuestionATiroir(
+      uneQuestionATiroir()
+        .aChoixUnique("la sous question 1")
+        .avecReponsesPossibles([
+          uneReponsePossible().avecLibelle("rep 111").construis(),
+          uneReponsePossible().avecLibelle("rep 112").construis(),
+        ])
+        .construis(),
+    )
+    .ajouteUneQuestionATiroir(
+      uneQuestionATiroir()
+        .aChoixUnique("la sous question 2")
+        .avecReponsesPossibles([
+          uneReponsePossible().avecLibelle("rep 121").construis(),
+          uneReponsePossible().avecLibelle("rep 122").construis(),
+        ])
+        .construis(),
+    )
+    .construis();
+  const question = uneQuestion()
+    .aChoixUnique("La question")
+    .avecReponsesPossibles([
+      reponseATiroir,
+      uneReponsePossible()
+        .avecLibelle("rep 2")
+        .ajouteUneQuestionATiroir(
+          uneQuestionATiroir()
+            .avecReponsesPossibles([
+              uneReponsePossible().avecLibelle("rep-211").construis(),
+              uneReponsePossible().avecLibelle("rep-212").construis(),
+            ])
+            .construis(),
+        )
+        .ajouteUneQuestionATiroir(
+          uneQuestionATiroir()
+            .avecReponsesPossibles([
+              uneReponsePossible().avecLibelle("rep-221").construis(),
+            ])
+            .construis(),
+        )
+        .construis(),
+    ])
+    .construis();
+
+  it("recommande une seule fois pour une question avec plusieurs réponses à question à tiroir", () => {
+    const diagnostic = unDiagnostic()
+      .avecUnReferentiel(
+        unReferentiel()
+          .sansThematique()
+          .ajouteUneThematique("multi-tiroir", [question])
+          .construis(),
+      )
+      .avecUnTableauDeNotes(tableauDeNotes)
+      .avecUnTableauDeRecommandations(tableauDeRecommandations)
+      .ajouteUneReponseDonnee(
+        { thematique: "multi-tiroir", question: "la-question" },
+        uneReponseDonnee()
+          .ayantPourReponse("rep-1")
+          .avecDesReponsesMultilpes([
+            {
+              identifiant: "la-sous-question-1",
+              reponses: ["rep-111"],
+            },
+            {
+              identifiant: "la-sous-question-2",
+              reponses: ["rep-122"],
+            },
+          ])
+          .construis(),
+      )
+      .construis();
+
+    const recommandations = MoteurDeRecommandations.get(false)?.genere(
+      diagnostic,
+      diagnostic.referentiel["multi-tiroir"].questions[0],
+    );
+
+    expect(recommandations).toHaveLength(1);
+    expect(recommandations).toStrictEqual([
+      {
+        comment: "comme ça",
+        noteObtenue: 1,
+        pourquoi: "parce-que",
+        priorisation: 1,
+        titre: "reco 2",
+      },
+    ]);
+  });
+});

--- a/mon-aide-cyber-ui/test/constructeurs/constructeurQuestions.ts
+++ b/mon-aide-cyber-ui/test/constructeurs/constructeurQuestions.ts
@@ -51,14 +51,6 @@ class ConstructeurQuestion implements Constructeur<Question> {
     };
     return this;
   }
-
-  avecNReponses(nombreReponses: number): ConstructeurQuestion {
-    for (let i = 0; i < nombreReponses; i++) {
-      this.reponsesPossibles.push(uneReponsePossible().construis());
-    }
-    return this;
-  }
-
   avecLibelle(libelle: string): ConstructeurQuestion {
     this.identifiant = aseptise(libelle);
     this.libelle = libelle;


### PR DESCRIPTION
Des questions comportant plusieurs réponses contenant plusieurs questions à tiroir génère 2 même recommandations pour la question (cf captures ci-dessous)

**Exemple de question avec 2 réponses contenant des questions à tiroir:**
 
<img width="1167" alt="Capture d’écran 2023-10-02 à 09 04 51" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/bf490e5d-6ec7-43ba-98ef-83c0febc2047">


**Réponses données et résultat obtenu lorsque l'on génère le diagnostic:**

<img width="1056" alt="Capture d’écran 2023-10-02 à 09 09 25" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/66151a99-5bbf-45f6-9625-d41cc70a0dcf">

<img width="757" alt="Capture d’écran 2023-10-02 à 09 08 56" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/a262807b-f22c-41d7-a3fc-c018059701f8">
