### PR TITLE
[REMANIEMENT] Introduis un bus d'événement

### DIFF
--- a/mon-aide-cyber-api/src/domaine/BusEvenement.ts
+++ b/mon-aide-cyber-api/src/domaine/BusEvenement.ts
@@ -1,0 +1,12 @@
+import crypto from 'crypto';
+
+export type Evenement = {
+  identifiant: crypto.UUID;
+  type: 'DIAGNOSTIC_LANCE' | 'REPONSE_AJOUTEE' | 'DIAGNOSTIC_TERMINE';
+  date: Date;
+  corps: object;
+};
+
+export interface BusEvenement {
+  publie<E extends Evenement>(evenement: E): Promise<void>;
+}

--- a/mon-aide-cyber-api/src/infrastructure/horloge/FournisseurHorloge.ts
+++ b/mon-aide-cyber-api/src/infrastructure/horloge/FournisseurHorloge.ts
@@ -1,0 +1,3 @@
+export class FournisseurHorloge {
+  static maintenant = (): Date => new Date();
+}

--- a/mon-aide-cyber-api/test/infrastructure/bus/BusEvenementDeTest.ts
+++ b/mon-aide-cyber-api/test/infrastructure/bus/BusEvenementDeTest.ts
@@ -1,0 +1,10 @@
+import { BusEvenement, Evenement } from '../../../src/domaine/BusEvenement';
+
+export class BusEvenementDeTest implements BusEvenement {
+  public evenementRecu: Evenement | undefined;
+
+  publie(evenement: Evenement): Promise<void> {
+    this.evenementRecu = evenement;
+    return Promise.resolve(undefined);
+  }
+}

--- a/mon-aide-cyber-api/test/infrastructure/horloge/FournisseurHorlogeDeTest.ts
+++ b/mon-aide-cyber-api/test/infrastructure/horloge/FournisseurHorlogeDeTest.ts
@@ -1,0 +1,7 @@
+import { FournisseurHorloge } from '../../../src/infrastructure/horloge/FournisseurHorloge';
+
+export class FournisseurHorlogeDeTest {
+  static initialise(maintenant: Date) {
+    FournisseurHorloge.maintenant = () => maintenant;
+  }
+}


### PR DESCRIPTION
- afin de mettre à disposition une file pour contacter des services tiers pour un événement donné