### PR TITLE
[CORRECTION] Corrige l'envoi des réponses déjà données lorsque l'on change de thématique

### DIFF
--- a/mon-aide-cyber-ui/package.json
+++ b/mon-aide-cyber-ui/package.json
@@ -14,7 +14,7 @@
     "prebuild": "only-include-used-icons",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
-    "test": "tsc && vitest run --config vitest.config.ts --reporter verbose",
+    "test": "tsc -p test/tsconfig.test.json && vitest run --config vitest.config.ts --reporter verbose",
     "test:coverage": "vitest --config vitest.config.ts run --coverage",
     "test:watch": "vitest --config vitest.config.ts --ui --reporter verbose",
     "test:storybook": "test-storybook"

--- a/mon-aide-cyber-ui/src/domaine/diagnostic/reducteurReponse.ts
+++ b/mon-aide-cyber-ui/src/domaine/diagnostic/reducteurReponse.ts
@@ -1,16 +1,18 @@
-import { Question, ReponseDonnee, ReponseMultiple } from "./Referentiel.ts";
-import { ActionReponseDiagnostic, Reponse } from "./Diagnostic.ts";
+import { Question, ReponseDonnee, ReponseMultiple } from './Referentiel.ts';
+import { ActionReponseDiagnostic, Reponse } from './Diagnostic.ts';
 
 enum TypeActionReponse {
-  REPONSE_UNIQUE_DONNEE = "REPONSE_UNIQUE_DONNEE",
-  REPONSE_MULTIPLE_DONNEE = "REPONSE_MULTIPLE_DONNEE",
-  REPONSE_TIROIR_UNIQUE_DONNEE = "REPONSE_TIROIR_UNIQUE_DONNEE",
-  REPONSE_TIROIR_MULTIPLE_DONNEE = "REPONSE_TIROIR_MULTIPLE_DONNEE",
+  REPONSE_UNIQUE_DONNEE = 'REPONSE_UNIQUE_DONNEE',
+  REPONSE_MULTIPLE_DONNEE = 'REPONSE_MULTIPLE_DONNEE',
+  REPONSE_TIROIR_UNIQUE_DONNEE = 'REPONSE_TIROIR_UNIQUE_DONNEE',
+  REPONSE_TIROIR_MULTIPLE_DONNEE = 'REPONSE_TIROIR_MULTIPLE_DONNEE',
+  REPONSE_ENVOYEE = 'REPONSE_ENVOYEE',
 }
 
 export enum EtatReponseStatut {
-  CHARGEE = "CHARGEE",
-  MODIFIE = "MODIFIE",
+  CHARGEE = 'CHARGEE',
+  MODIFIEE = 'MODIFIEE',
+  ENVOYEE = 'ENVOYEE',
 }
 
 export type EtatReponse = {
@@ -62,6 +64,9 @@ type ActionReponse =
   | {
       reponse: ElementReponseTiroirMultiple;
       type: TypeActionReponse.REPONSE_TIROIR_MULTIPLE_DONNEE;
+    }
+  | {
+      type: TypeActionReponse.REPONSE_ENVOYEE;
     };
 export const reducteurReponse = (
   etat: EtatReponse,
@@ -151,12 +156,17 @@ export const reducteurReponse = (
         reponses,
       },
       reponse: genereLaReponsePourUneQuestionTiroir(reponses, valeur),
-      statut: EtatReponseStatut.MODIFIE,
+      statut: EtatReponseStatut.MODIFIEE,
       valeur: () => valeur,
     };
   };
 
   switch (action.type) {
+    case TypeActionReponse.REPONSE_ENVOYEE:
+      return {
+        ...etat,
+        statut: EtatReponseStatut.ENVOYEE,
+      };
     case TypeActionReponse.REPONSE_UNIQUE_DONNEE: {
       return {
         ...etat,
@@ -169,7 +179,7 @@ export const reducteurReponse = (
           identifiantQuestion: etat.question.identifiant,
           reponseDonnee: action.reponse.valeur,
         }),
-        statut: EtatReponseStatut.MODIFIE,
+        statut: EtatReponseStatut.MODIFIEE,
         valeur: () => action.reponse.valeur,
       };
     }
@@ -187,7 +197,7 @@ export const reducteurReponse = (
           identifiantQuestion: etat.question.identifiant,
           reponseDonnee: reponses.flatMap((rep) => Array.from(rep.reponses)),
         }),
-        statut: EtatReponseStatut.MODIFIE,
+        statut: EtatReponseStatut.MODIFIEE,
         valeur: () => undefined,
       };
     }
@@ -270,6 +280,12 @@ export const reponseTiroirMultipleDonnee = (
       elementReponse,
     },
     type: TypeActionReponse.REPONSE_TIROIR_MULTIPLE_DONNEE,
+  };
+};
+
+export const reponseEnvoyee = (): ActionReponse => {
+  return {
+    type: TypeActionReponse.REPONSE_ENVOYEE,
   };
 };
 

--- a/mon-aide-cyber-ui/test/domaine/diagnostic/constructeurEtaReponse.ts
+++ b/mon-aide-cyber-ui/test/domaine/diagnostic/constructeurEtaReponse.ts
@@ -1,12 +1,15 @@
-import { Reponse } from "../../../src/domaine/diagnostic/Diagnostic";
+import {
+  ActionReponseDiagnostic,
+  Reponse,
+} from '../../../src/domaine/diagnostic/Diagnostic';
 import {
   EtatReponse,
   EtatReponseStatut,
-} from "../../../src/domaine/diagnostic/reducteurReponse";
+} from '../../../src/domaine/diagnostic/reducteurReponse';
 import {
   Question,
   ReponseDonnee,
-} from "../../../src/domaine/diagnostic/Referentiel";
+} from '../../../src/domaine/diagnostic/Referentiel';
 
 class ConstructeurEtaReponse {
   private reponse: () => Reponse | null = () => null;
@@ -25,6 +28,10 @@ class ConstructeurEtaReponse {
       reponses: this.question.reponseDonnee.reponses,
     };
     return {
+      action(_: string): ActionReponseDiagnostic | undefined {
+        return undefined;
+      },
+      actions: [],
       question: this.question,
       reponse: this.reponse,
       reponseDonnee,

--- a/mon-aide-cyber-ui/test/domaine/diagnostic/reducteurDiagnostic.spec.ts
+++ b/mon-aide-cyber-ui/test/domaine/diagnostic/reducteurDiagnostic.spec.ts
@@ -1,58 +1,58 @@
-import { describe, expect, it } from "vitest";
-import { unReferentiel } from "../../constructeurs/constructeurReferentiel";
-import { unDiagnostic } from "../../constructeurs/constructeurDiagnostic";
+import { describe, expect, it } from 'vitest';
+import { unReferentiel } from '../../constructeurs/constructeurReferentiel';
+import { unDiagnostic } from '../../constructeurs/constructeurDiagnostic';
 import {
   diagnosticCharge,
   reducteurDiagnostic,
   thematiqueAffichee,
-} from "../../../src/domaine/diagnostic/reducteurDiagnostic";
-import { uneReponsePossible } from "../../constructeurs/constructeurReponsePossible";
+} from '../../../src/domaine/diagnostic/reducteurDiagnostic';
+import { uneReponsePossible } from '../../constructeurs/constructeurReponsePossible';
 import {
   uneQuestionAChoixMultiple,
   uneQuestionAChoixUnique,
   uneQuestionTiroirAChoixUnique,
-} from "../../constructeurs/constructeurQuestions";
+} from '../../constructeurs/constructeurQuestions';
 
-describe("Les réducteurs de diagnostic", () => {
-  describe("Lorsque le diagnostic est chargé", () => {
+describe('Les réducteurs de diagnostic', () => {
+  describe('Lorsque le diagnostic est chargé', () => {
     it("trie les réponses aux questions par l'ordre définit pour la thématique 'Contexte'", () => {
       const diagnostic = unDiagnostic()
         .avecUnReferentiel(
           unReferentiel()
             .avecUneQuestionEtDesReponses(
-              { libelle: "Première question ?", type: "choixUnique" },
+              { libelle: 'Première question ?', type: 'choixUnique' },
               [
                 uneReponsePossible()
-                  .avecLibelle("Réponse D")
+                  .avecLibelle('Réponse D')
                   .enPosition(3)
                   .construis(),
                 uneReponsePossible()
-                  .avecLibelle("Réponse B")
+                  .avecLibelle('Réponse B')
                   .enPosition(1)
                   .construis(),
                 uneReponsePossible()
-                  .avecLibelle("Réponse A")
+                  .avecLibelle('Réponse A')
                   .enPosition(0)
                   .construis(),
                 uneReponsePossible()
-                  .avecLibelle("Réponse C")
+                  .avecLibelle('Réponse C')
                   .enPosition(2)
                   .construis(),
               ],
             )
             .avecUneQuestionEtDesReponses(
-              { libelle: "Deuxième question ?", type: "choixUnique" },
+              { libelle: 'Deuxième question ?', type: 'choixUnique' },
               [
                 uneReponsePossible()
-                  .avecLibelle("Réponse B")
+                  .avecLibelle('Réponse B')
                   .enPosition(1)
                   .construis(),
                 uneReponsePossible()
-                  .avecLibelle("Réponse C")
+                  .avecLibelle('Réponse C')
                   .enPosition(2)
                   .construis(),
                 uneReponsePossible()
-                  .avecLibelle("Réponse A")
+                  .avecLibelle('Réponse A')
                   .enPosition(0)
                   .construis(),
               ],
@@ -67,7 +67,7 @@ describe("Les réducteurs de diagnostic", () => {
       );
 
       const questions =
-        etatDiagnostic.diagnostic.referentiel["contexte"].questions;
+        etatDiagnostic.diagnostic?.referentiel['contexte'].questions || [];
       expect(
         questions[0].reponsesPossibles.map((reponse) => reponse.ordre),
       ).toStrictEqual([0, 1, 2, 3]);
@@ -76,7 +76,7 @@ describe("Les réducteurs de diagnostic", () => {
       ).toStrictEqual([0, 1, 2]);
     });
 
-    it("trie les réponses aux questions pour toutes les thématiques", () => {
+    it('trie les réponses aux questions pour toutes les thématiques', () => {
       const diagnostic = unDiagnostic()
         .avecUnReferentiel(
           unReferentiel()
@@ -84,25 +84,25 @@ describe("Les réducteurs de diagnostic", () => {
               uneQuestionAChoixUnique()
                 .avecDesReponses([
                   uneReponsePossible()
-                    .avecLibelle("Réponse B")
+                    .avecLibelle('Réponse B')
                     .enPosition(1)
                     .construis(),
                   uneReponsePossible()
-                    .avecLibelle("Réponse A")
+                    .avecLibelle('Réponse A')
                     .enPosition(0)
                     .construis(),
                 ])
                 .construis(),
             )
-            .ajouteUneThematique("Autre thématique", [
+            .ajouteUneThematique('Autre thématique', [
               uneQuestionAChoixUnique()
                 .avecDesReponses([
                   uneReponsePossible()
-                    .avecLibelle("Réponse B")
+                    .avecLibelle('Réponse B')
                     .enPosition(1)
                     .construis(),
                   uneReponsePossible()
-                    .avecLibelle("Réponse A")
+                    .avecLibelle('Réponse A')
                     .enPosition(0)
                     .construis(),
                 ])
@@ -118,22 +118,22 @@ describe("Les réducteurs de diagnostic", () => {
       );
 
       const thematiqueContexte =
-        etatDiagnostic.diagnostic.referentiel["contexte"];
+        etatDiagnostic.diagnostic?.referentiel['contexte'];
       const thematiqueAutreThematique =
-        etatDiagnostic.diagnostic.referentiel["Autre thématique"];
+        etatDiagnostic.diagnostic?.referentiel['Autre thématique'];
       expect(
-        thematiqueContexte.questions[0].reponsesPossibles.map(
+        thematiqueContexte?.questions[0].reponsesPossibles.map(
           (reponse) => reponse.ordre,
         ),
       ).toStrictEqual([0, 1]);
       expect(
-        thematiqueAutreThematique.questions[0].reponsesPossibles.map(
+        thematiqueAutreThematique?.questions[0].reponsesPossibles.map(
           (reponse) => reponse.ordre,
         ),
       ).toStrictEqual([0, 1]);
     });
 
-    it("trie les réponses des questions à tiroir", () => {
+    it('trie les réponses des questions à tiroir', () => {
       const diagnostic = unDiagnostic()
         .avecUnReferentiel(
           unReferentiel()
@@ -145,11 +145,11 @@ describe("Les réducteurs de diagnostic", () => {
                       uneQuestionTiroirAChoixUnique()
                         .avecDesReponses([
                           uneReponsePossible()
-                            .avecLibelle("Réponse B")
+                            .avecLibelle('Réponse B')
                             .enPosition(1)
                             .construis(),
                           uneReponsePossible()
-                            .avecLibelle("Réponse A")
+                            .avecLibelle('Réponse A')
                             .enPosition(0)
                             .construis(),
                         ])
@@ -159,11 +159,11 @@ describe("Les réducteurs de diagnostic", () => {
                       uneQuestionTiroirAChoixUnique()
                         .avecDesReponses([
                           uneReponsePossible()
-                            .avecLibelle("Réponse Z")
+                            .avecLibelle('Réponse Z')
                             .enPosition(1)
                             .construis(),
                           uneReponsePossible()
-                            .avecLibelle("Réponse Y")
+                            .avecLibelle('Réponse Y')
                             .enPosition(0)
                             .construis(),
                         ])
@@ -183,14 +183,16 @@ describe("Les réducteurs de diagnostic", () => {
       );
 
       const thematiqueContexte =
-        etatDiagnostic.diagnostic.referentiel["contexte"];
+        etatDiagnostic.diagnostic?.referentiel['contexte'];
+      const reponsesPossible =
+        thematiqueContexte?.questions[0]?.reponsesPossibles[0];
       expect(
-        thematiqueContexte.questions[0].reponsesPossibles[0].questions[0].reponsesPossibles.map(
+        reponsesPossible?.questions?.[0]?.reponsesPossibles.map(
           (reponse) => reponse.ordre,
         ),
       ).toStrictEqual([0, 1]);
       expect(
-        thematiqueContexte.questions[0].reponsesPossibles[0].questions[1].reponsesPossibles.map(
+        reponsesPossible?.questions?.[1]?.reponsesPossibles.map(
           (reponse) => reponse.ordre,
         ),
       ).toStrictEqual([0, 1]);
@@ -198,15 +200,15 @@ describe("Les réducteurs de diagnostic", () => {
   });
 
   describe("Lorsque l'on veut changer la thématique affichée", () => {
-    it("change la thématique affichée", () => {
+    it('change la thématique affichée', () => {
       const etatDiagnostic = reducteurDiagnostic(
         {
           diagnostic: undefined,
           thematiqueAffichee: undefined,
         },
-        thematiqueAffichee("nouvelle-thematique"),
+        thematiqueAffichee('nouvelle-thematique'),
       );
-      expect(etatDiagnostic.thematiqueAffichee).toBe("nouvelle-thematique");
+      expect(etatDiagnostic.thematiqueAffichee).toBe('nouvelle-thematique');
     });
   });
 });

--- a/mon-aide-cyber-ui/test/domaine/diagnostic/reducteurReponse.spec.ts
+++ b/mon-aide-cyber-ui/test/domaine/diagnostic/reducteurReponse.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest';
 import {
   EtatReponseStatut,
   initialiseReducteur,
@@ -7,26 +7,28 @@ import {
   reponseTiroirMultipleDonnee,
   reponseTiroirUniqueDonnee,
   reponseUniqueDonnee,
-} from "../../../src/domaine/diagnostic/reducteurReponse";
-import { uneReponsePossible } from "../../constructeurs/constructeurReponsePossible";
+} from '../../../src/domaine/diagnostic/reducteurReponse';
+import { uneReponsePossible } from '../../constructeurs/constructeurReponsePossible';
 import {
   uneQuestionAChoixMultiple,
   uneQuestionAChoixUnique,
   uneQuestionTiroirAChoixMultiple,
   uneQuestionTiroirAChoixUnique,
-} from "../../constructeurs/constructeurQuestions";
-import { unEtatDeReponse } from "./constructeurEtaReponse";
-import { actions } from "../../../src/domaine/Actions";
+} from '../../constructeurs/constructeurQuestions';
+import { unEtatDeReponse } from './constructeurEtaReponse';
+import { uneAction } from '../../constructeurs/constructeurActionDiagnostic';
 
-describe("Le réducteur de réponse", () => {
-  describe("dans le cas de question simple", () => {
-    it("initialise le réducteur", () => {
+describe('Le réducteur de réponse', () => {
+  describe('dans le cas de question simple', () => {
+    it('initialise le réducteur', () => {
       const reponse = uneReponsePossible().construis();
       const question = uneQuestionAChoixUnique()
         .avecDesReponses([reponse])
         .construis();
 
-      const etatReponse = initialiseReducteur(question, actions);
+      const etatReponse = initialiseReducteur(question, [
+        uneAction().construis(),
+      ]);
 
       expect(etatReponse.reponseDonnee).toStrictEqual({
         reponses: [],
@@ -35,14 +37,16 @@ describe("Le réducteur de réponse", () => {
       expect(etatReponse.statut).toStrictEqual(EtatReponseStatut.CHARGEE);
     });
 
-    it("initialise le réducteur avec une réponse donnée", () => {
+    it('initialise le réducteur avec une réponse donnée', () => {
       const reponse = uneReponsePossible().construis();
       const question = uneQuestionAChoixUnique()
         .avecDesReponses([reponse])
         .avecLaReponseDonnee(reponse)
         .construis();
 
-      const etatReponse = initialiseReducteur(question, actions);
+      const etatReponse = initialiseReducteur(question, [
+        uneAction().construis(),
+      ]);
 
       expect(etatReponse.reponseDonnee).toStrictEqual({
         reponses: [],
@@ -51,10 +55,10 @@ describe("Le réducteur de réponse", () => {
       expect(etatReponse.statut).toStrictEqual(EtatReponseStatut.CHARGEE);
     });
 
-    it("change la réponse donnée et modifie le statut", () => {
+    it('change la réponse donnée et modifie le statut', () => {
       const nouvelleReponse = uneReponsePossible().construis();
       const question = uneQuestionAChoixUnique()
-        .avecLibelle("Une question?")
+        .avecLibelle('Une question?')
         .avecDesReponses([nouvelleReponse])
         .construis();
 
@@ -66,11 +70,12 @@ describe("Le réducteur de réponse", () => {
       expect(etatReponse.reponseDonnee.valeur).toBe(
         nouvelleReponse.identifiant,
       );
-      expect(etatReponse.statut).toBe(EtatReponseStatut.MODIFIE);
+      expect(etatReponse.statut).toBe(EtatReponseStatut.MODIFIEE);
+      // expect(etatReponse.entrepot.)
     });
   });
 
-  describe("dans le cas de question à choix multiples", () => {
+  describe('dans le cas de question à choix multiples', () => {
     it("prend en compte l'ajout d'une réponse", () => {
       const premiereReponse = uneReponsePossible().construis();
       const deuxiemeReponse = uneReponsePossible().construis();
@@ -107,7 +112,7 @@ describe("Le réducteur de réponse", () => {
           premiereReponse.identifiant,
         ],
       });
-      expect(etatReponse.statut).toStrictEqual(EtatReponseStatut.MODIFIE);
+      expect(etatReponse.statut).toStrictEqual(EtatReponseStatut.MODIFIEE);
     });
 
     it("retire un élément de la réponse lorsqu'il est déja présent (l'utilisateur désélectionne cet élément)", () => {
@@ -140,80 +145,80 @@ describe("Le réducteur de réponse", () => {
         identifiantQuestion: question.identifiant,
         reponseDonnee: [troisiemeReponse.identifiant],
       });
-      expect(etatReponse.statut).toStrictEqual(EtatReponseStatut.MODIFIE);
+      expect(etatReponse.statut).toStrictEqual(EtatReponseStatut.MODIFIEE);
     });
   });
 
-  describe("dans le cas de question à tiroir", () => {
-    it("prend en compte les réponses à choix multiple", () => {
+  describe('dans le cas de question à tiroir', () => {
+    it('prend en compte les réponses à choix multiple', () => {
       const nouvelleReponse = uneReponsePossible()
         .avecUneQuestion(
           uneQuestionTiroirAChoixMultiple()
-            .avecLibelle("QCM")
+            .avecLibelle('QCM')
             .avecDesReponses([
-              uneReponsePossible().avecLibelle("choix 2").construis(),
-              uneReponsePossible().avecLibelle("choix 3").construis(),
+              uneReponsePossible().avecLibelle('choix 2').construis(),
+              uneReponsePossible().avecLibelle('choix 3').construis(),
             ])
             .construis(),
         )
         .construis();
       const question = uneQuestionAChoixUnique()
-        .avecLibelle("Une question?")
+        .avecLibelle('Une question?')
         .avecDesReponses([nouvelleReponse])
         .avecLaReponseDonnee(nouvelleReponse, [
-          { identifiant: "qcm", reponses: new Set(["choix-2"]) },
+          { identifiant: 'qcm', reponses: new Set(['choix-2']) },
         ])
         .construis();
 
       const etatReponse = reducteurReponse(
         unEtatDeReponse(question).reponseChargee().construis(),
         reponseTiroirMultipleDonnee(nouvelleReponse.identifiant, {
-          identifiantReponse: "qcm",
-          reponse: "choix-3",
+          identifiantReponse: 'qcm',
+          reponse: 'choix-3',
         }),
       );
 
       expect(etatReponse.reponseDonnee).toStrictEqual({
         valeur: nouvelleReponse.identifiant,
         reponses: [
-          { identifiant: "qcm", reponses: new Set(["choix-2", "choix-3"]) },
+          { identifiant: 'qcm', reponses: new Set(['choix-2', 'choix-3']) },
         ],
       });
       expect(etatReponse.reponse()).toStrictEqual({
-        identifiantQuestion: "une-question",
+        identifiantQuestion: 'une-question',
         reponseDonnee: {
           reponse: nouvelleReponse.identifiant,
           questions: [
             {
-              identifiant: "qcm",
-              reponses: ["choix-2", "choix-3"],
+              identifiant: 'qcm',
+              reponses: ['choix-2', 'choix-3'],
             },
           ],
         },
       });
-      expect(etatReponse.statut).toBe(EtatReponseStatut.MODIFIE);
+      expect(etatReponse.statut).toBe(EtatReponseStatut.MODIFIEE);
     });
 
     it("retire un élément de la réponse lorsqu'il est déja présent (l'utilisateur désélectionne cet élément)", () => {
       const nouvelleReponse = uneReponsePossible()
         .avecUneQuestion(
           uneQuestionTiroirAChoixMultiple()
-            .avecLibelle("QCM")
+            .avecLibelle('QCM')
             .avecDesReponses([
-              uneReponsePossible().avecLibelle("choix 2").construis(),
-              uneReponsePossible().avecLibelle("choix 3").construis(),
-              uneReponsePossible().avecLibelle("choix 4").construis(),
+              uneReponsePossible().avecLibelle('choix 2').construis(),
+              uneReponsePossible().avecLibelle('choix 3').construis(),
+              uneReponsePossible().avecLibelle('choix 4').construis(),
             ])
             .construis(),
         )
         .construis();
       const question = uneQuestionAChoixUnique()
-        .avecLibelle("Une question?")
+        .avecLibelle('Une question?')
         .avecDesReponses([nouvelleReponse])
         .avecLaReponseDonnee(nouvelleReponse, [
           {
-            identifiant: "qcm",
-            reponses: new Set(["choix-2", "choix-3", "choix-4"]),
+            identifiant: 'qcm',
+            reponses: new Set(['choix-2', 'choix-3', 'choix-4']),
           },
         ])
         .construis();
@@ -221,64 +226,64 @@ describe("Le réducteur de réponse", () => {
       const etatReponse = reducteurReponse(
         unEtatDeReponse(question).reponseChargee().construis(),
         reponseTiroirMultipleDonnee(nouvelleReponse.identifiant, {
-          identifiantReponse: "qcm",
-          reponse: "choix-4",
+          identifiantReponse: 'qcm',
+          reponse: 'choix-4',
         }),
       );
 
       expect(etatReponse.reponseDonnee).toStrictEqual({
         valeur: nouvelleReponse.identifiant,
         reponses: [
-          { identifiant: "qcm", reponses: new Set(["choix-2", "choix-3"]) },
+          { identifiant: 'qcm', reponses: new Set(['choix-2', 'choix-3']) },
         ],
       });
       expect(etatReponse.reponse()).toStrictEqual({
-        identifiantQuestion: "une-question",
+        identifiantQuestion: 'une-question',
         reponseDonnee: {
           reponse: nouvelleReponse.identifiant,
           questions: [
             {
-              identifiant: "qcm",
-              reponses: ["choix-2", "choix-3"],
+              identifiant: 'qcm',
+              reponses: ['choix-2', 'choix-3'],
             },
           ],
         },
       });
-      expect(etatReponse.statut).toBe(EtatReponseStatut.MODIFIE);
+      expect(etatReponse.statut).toBe(EtatReponseStatut.MODIFIEE);
     });
 
-    it("prend en compte les réponses à plusieurs questions à tiroir", () => {
+    it('prend en compte les réponses à plusieurs questions à tiroir', () => {
       const nouvelleReponse = uneReponsePossible()
         .avecUneQuestion(
           uneQuestionTiroirAChoixMultiple()
-            .avecLibelle("tiroir 1")
+            .avecLibelle('tiroir 1')
             .avecDesReponses([
-              uneReponsePossible().avecLibelle("choix 12").construis(),
-              uneReponsePossible().avecLibelle("choix 13").construis(),
+              uneReponsePossible().avecLibelle('choix 12').construis(),
+              uneReponsePossible().avecLibelle('choix 13').construis(),
             ])
             .construis(),
         )
         .avecUneQuestion(
           uneQuestionTiroirAChoixMultiple()
-            .avecLibelle("tiroir 2")
+            .avecLibelle('tiroir 2')
             .avecDesReponses([
-              uneReponsePossible().avecLibelle("choix 21").construis(),
-              uneReponsePossible().avecLibelle("choix 23").construis(),
+              uneReponsePossible().avecLibelle('choix 21').construis(),
+              uneReponsePossible().avecLibelle('choix 23').construis(),
             ])
             .construis(),
         )
         .construis();
       const question = uneQuestionAChoixUnique()
-        .avecLibelle("Une Question")
+        .avecLibelle('Une Question')
         .avecDesReponses([nouvelleReponse])
         .avecLaReponseDonnee(nouvelleReponse, [
           {
-            identifiant: "tiroir-1",
-            reponses: new Set(["choix-12", "choix-13"]),
+            identifiant: 'tiroir-1',
+            reponses: new Set(['choix-12', 'choix-13']),
           },
           {
-            identifiant: "tiroir-2",
-            reponses: new Set(["choix-21"]),
+            identifiant: 'tiroir-2',
+            reponses: new Set(['choix-21']),
           },
         ])
         .construis();
@@ -286,8 +291,8 @@ describe("Le réducteur de réponse", () => {
       const etatReponse = reducteurReponse(
         unEtatDeReponse(question).reponseChargee().construis(),
         reponseTiroirMultipleDonnee(nouvelleReponse.identifiant, {
-          identifiantReponse: "tiroir-2",
-          reponse: "choix-23",
+          identifiantReponse: 'tiroir-2',
+          reponse: 'choix-23',
         }),
       );
 
@@ -295,36 +300,36 @@ describe("Le réducteur de réponse", () => {
         valeur: nouvelleReponse.identifiant,
         reponses: [
           {
-            identifiant: "tiroir-1",
-            reponses: new Set(["choix-12", "choix-13"]),
+            identifiant: 'tiroir-1',
+            reponses: new Set(['choix-12', 'choix-13']),
           },
           {
-            identifiant: "tiroir-2",
-            reponses: new Set(["choix-21", "choix-23"]),
+            identifiant: 'tiroir-2',
+            reponses: new Set(['choix-21', 'choix-23']),
           },
         ],
       });
       expect(etatReponse.reponse()).toStrictEqual({
-        identifiantQuestion: "une-question",
+        identifiantQuestion: 'une-question',
         reponseDonnee: {
           reponse: nouvelleReponse.identifiant,
           questions: [
-            { identifiant: "tiroir-1", reponses: ["choix-12", "choix-13"] },
-            { identifiant: "tiroir-2", reponses: ["choix-21", "choix-23"] },
+            { identifiant: 'tiroir-1', reponses: ['choix-12', 'choix-13'] },
+            { identifiant: 'tiroir-2', reponses: ['choix-21', 'choix-23'] },
           ],
         },
       });
-      expect(etatReponse.statut).toBe(EtatReponseStatut.MODIFIE);
+      expect(etatReponse.statut).toBe(EtatReponseStatut.MODIFIEE);
     });
 
-    it("prend en compte les réponses à choix unique avec plusieurs questions à tiroir", () => {
+    it('prend en compte les réponses à choix unique avec plusieurs questions à tiroir', () => {
       const nouvelleReponse = uneReponsePossible()
         .avecUneQuestion(
           uneQuestionTiroirAChoixUnique()
-            .avecLibelle("tiroir 1")
+            .avecLibelle('tiroir 1')
             .avecDesReponses([
-              uneReponsePossible().avecLibelle("choix 12").construis(),
-              uneReponsePossible().avecLibelle("choix 13").construis(),
+              uneReponsePossible().avecLibelle('choix 12').construis(),
+              uneReponsePossible().avecLibelle('choix 13').construis(),
             ])
             .construis(),
         )
@@ -332,30 +337,30 @@ describe("Le réducteur de réponse", () => {
       const uneAutreReponse = uneReponsePossible()
         .avecUneQuestion(
           uneQuestionTiroirAChoixUnique()
-            .avecLibelle("tiroir 2")
+            .avecLibelle('tiroir 2')
             .avecDesReponses([
-              uneReponsePossible().avecLibelle("choix 22").construis(),
-              uneReponsePossible().avecLibelle("choix 23").construis(),
+              uneReponsePossible().avecLibelle('choix 22').construis(),
+              uneReponsePossible().avecLibelle('choix 23').construis(),
             ])
             .construis(),
         )
         .avecUneQuestion(
           uneQuestionTiroirAChoixUnique()
-            .avecLibelle("tiroir 3")
+            .avecLibelle('tiroir 3')
             .avecDesReponses([
-              uneReponsePossible().avecLibelle("choix 32").construis(),
-              uneReponsePossible().avecLibelle("choix 33").construis(),
+              uneReponsePossible().avecLibelle('choix 32').construis(),
+              uneReponsePossible().avecLibelle('choix 33').construis(),
             ])
             .construis(),
         )
         .construis();
       const question = uneQuestionAChoixUnique()
-        .avecLibelle("Une Question")
+        .avecLibelle('Une Question')
         .avecDesReponses([nouvelleReponse, uneAutreReponse])
         .avecLaReponseDonnee(nouvelleReponse, [
           {
-            identifiant: "tiroir-1",
-            reponses: new Set(["choix-12"]),
+            identifiant: 'tiroir-1',
+            reponses: new Set(['choix-12']),
           },
         ])
         .construis();
@@ -363,15 +368,15 @@ describe("Le réducteur de réponse", () => {
       const premierEtatReponse = reducteurReponse(
         unEtatDeReponse(question).reponseChargee().construis(),
         reponseTiroirUniqueDonnee(uneAutreReponse.identifiant, {
-          identifiantReponse: "tiroir-2",
-          reponse: "choix-23",
+          identifiantReponse: 'tiroir-2',
+          reponse: 'choix-23',
         }),
       );
       const etatReponse = reducteurReponse(
         premierEtatReponse,
         reponseTiroirUniqueDonnee(uneAutreReponse.identifiant, {
-          identifiantReponse: "tiroir-3",
-          reponse: "choix-32",
+          identifiantReponse: 'tiroir-3',
+          reponse: 'choix-32',
         }),
       );
 
@@ -379,54 +384,54 @@ describe("Le réducteur de réponse", () => {
         valeur: uneAutreReponse.identifiant,
         reponses: [
           {
-            identifiant: "tiroir-2",
-            reponses: new Set(["choix-23"]),
+            identifiant: 'tiroir-2',
+            reponses: new Set(['choix-23']),
           },
           {
-            identifiant: "tiroir-3",
-            reponses: new Set(["choix-32"]),
+            identifiant: 'tiroir-3',
+            reponses: new Set(['choix-32']),
           },
         ],
       });
       expect(etatReponse.reponse()).toStrictEqual({
-        identifiantQuestion: "une-question",
+        identifiantQuestion: 'une-question',
         reponseDonnee: {
           reponse: uneAutreReponse.identifiant,
           questions: [
-            { identifiant: "tiroir-2", reponses: ["choix-23"] },
-            { identifiant: "tiroir-3", reponses: ["choix-32"] },
+            { identifiant: 'tiroir-2', reponses: ['choix-23'] },
+            { identifiant: 'tiroir-3', reponses: ['choix-32'] },
           ],
         },
       });
-      expect(etatReponse.statut).toBe(EtatReponseStatut.MODIFIE);
+      expect(etatReponse.statut).toBe(EtatReponseStatut.MODIFIEE);
     });
 
-    it("prend en compte les réponses à choix unique", () => {
+    it('prend en compte les réponses à choix unique', () => {
       const nouvelleReponse = uneReponsePossible()
         .avecUneQuestion(
           uneQuestionAChoixUnique()
-            .avecLibelle("choix unique")
+            .avecLibelle('choix unique')
             .avecDesReponses([
-              uneReponsePossible().avecLibelle("1").construis(),
-              uneReponsePossible().avecLibelle("2").construis(),
-              uneReponsePossible().avecLibelle("3").construis(),
+              uneReponsePossible().avecLibelle('1').construis(),
+              uneReponsePossible().avecLibelle('2').construis(),
+              uneReponsePossible().avecLibelle('3').construis(),
             ])
             .construis(),
         )
         .construis();
       const question = uneQuestionAChoixUnique()
-        .avecLibelle("une question?")
+        .avecLibelle('une question?')
         .avecDesReponses([nouvelleReponse])
         .avecLaReponseDonnee(nouvelleReponse, [
-          { identifiant: "choix-unique", reponses: new Set(["2"]) },
+          { identifiant: 'choix-unique', reponses: new Set(['2']) },
         ])
         .construis();
 
       const etatReponse = reducteurReponse(
         unEtatDeReponse(question).reponseChargee().construis(),
         reponseTiroirUniqueDonnee(nouvelleReponse.identifiant, {
-          identifiantReponse: "choix-unique",
-          reponse: "1",
+          identifiantReponse: 'choix-unique',
+          reponse: '1',
         }),
       );
 
@@ -434,16 +439,16 @@ describe("Le réducteur de réponse", () => {
         valeur: nouvelleReponse.identifiant,
         reponses: [
           {
-            identifiant: "choix-unique",
-            reponses: new Set(["1"]),
+            identifiant: 'choix-unique',
+            reponses: new Set(['1']),
           },
         ],
       });
       expect(etatReponse.reponse()).toStrictEqual({
-        identifiantQuestion: "une-question",
+        identifiantQuestion: 'une-question',
         reponseDonnee: {
           reponse: nouvelleReponse.identifiant,
-          questions: [{ identifiant: "choix-unique", reponses: ["1"] }],
+          questions: [{ identifiant: 'choix-unique', reponses: ['1'] }],
         },
       });
     });

--- a/mon-aide-cyber-ui/test/tsconfig.test.json
+++ b/mon-aide-cyber-ui/test/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig",
+  "include": ["../src", "../test"]
+}


### PR DESCRIPTION
**Contexte**
Les réponses données lors d'un diagnostic sont dupliquées dans Metabase.

**Description**
Lorsque l'on change de thématique dans un diagnostic ou que l'on clique sur `Terminer Diagnostic`, les résultats des réponses envoyés sur Metabase sont dupliquées (voir la capture ci-dessous).
 
![bug_duplication](https://github.com/betagouv/mon-aide-cyber/assets/5832143/468b1ebf-a35e-4921-8a52-29012cae6413)

**Comment reproduire**
- Vider la table `diagnostics` dans MAC
- Vider la table `evenements` dans MAC journal
- Ouvrir les outils développeurs du navigateur dans l'onglet réseau
- Ouvrir une page de Metabase en allant dans la vue des événements (constater qu'il n'y en a aucun)
- Lancer un diagnostic
- Répondre à différentes questions et constater que les appels pour chaque réponse sont faits dans la console développeur
- Ouvrir la page Metabase et constater que les événements sont présents
- Vider la console développeur
- Cliquer sur une autre thématique
- Constater qu'un nouvel appel réseau a été fait avec les réponses aux précédentes questions
- Rafraichir la page Metabase et constater que les événements sont dupliqués

**Résultat constaté**
Les événements sont dupliqués autant de fois que l'on change de thématique

**Résultat attendu**
Les événements sont sauvegardés une seule et unique fois