### PR TITLE
[CORRECTION] Corrige la gestion des réponses sous forme de liste

### DIFF
--- a/mon-aide-cyber-ui/src/composants/diagnostic/ComposantDiagnostic.tsx
+++ b/mon-aide-cyber-ui/src/composants/diagnostic/ComposantDiagnostic.tsx
@@ -148,8 +148,8 @@ const ComposantQuestionListe = ({
         value: etatReponse.valeur(),
       }}
     >
-      <option value="" disabled hidden>
-        Selectionnez une option
+      <option value="" disabled hidden selected>
+        Sélectionnez une option
       </option>
       {question.reponsesPossibles.map((reponse) => {
         return (


### PR DESCRIPTION
- les réponses sous forme de liste prennent le premier élément comme sélectionné et il n'est pas possible de le sélectionné par la suite
- ajoute un libellé 'Sélectionnez une option'