### PR TITLE
[CORRECTION] Corrige la recommandation sur les mises à jour de sécurité des équipements

### DIFF
--- a/mon-aide-cyber-api/src/diagnostic/recommandations/recommandationsSecuriteInfrastructure.ts
+++ b/mon-aide-cyber-api/src/diagnostic/recommandations/recommandationsSecuriteInfrastructure.ts
@@ -1,147 +1,147 @@
 export const recommandationsSecuriteInfrastructure = {
-  'securite-infrastructure-pare-feu-deploye': {
+  "securite-infrastructure-pare-feu-deploye": {
     niveau1: {
       titre:
-        'Déployer un pare-feu physique pour protéger l’interconnexion du SI à Internet.',
+        "Déployer un pare-feu physique pour protéger l’interconnexion du SI à Internet.",
       pourquoi:
-        'recommandations/infras/securite-infrastructure-pare-feu-deploye-niveau1-pourquoi.pug',
+        "recommandations/infras/securite-infrastructure-pare-feu-deploye-niveau1-pourquoi.pug",
       comment:
-        'recommandations/infras/securite-infrastructure-pare-feu-deploye-niveau1-comment.pug',
+        "recommandations/infras/securite-infrastructure-pare-feu-deploye-niveau1-comment.pug",
     },
     priorisation: 20,
   },
-  'securite-infrastructure-pare-feu-deploye-interconnexions-protegees': {
+  "securite-infrastructure-pare-feu-deploye-interconnexions-protegees": {
     niveau1: {
       titre:
-        'Déployer un pare-feu physique pour protéger l’interconnexion du SI à Internet.',
+        "Déployer un pare-feu physique pour protéger l’interconnexion du SI à Internet.",
       pourquoi:
-        'recommandations/infras/securite-infrastructure-pare-feu-deploye-interconnexions-protegees-niveau1-pourquoi.pug',
+        "recommandations/infras/securite-infrastructure-pare-feu-deploye-interconnexions-protegees-niveau1-pourquoi.pug",
       comment:
-        'recommandations/infras/securite-infrastructure-pare-feu-deploye-interconnexions-protegees-niveau1-comment.pug',
+        "recommandations/infras/securite-infrastructure-pare-feu-deploye-interconnexions-protegees-niveau1-comment.pug",
     },
     priorisation: 20,
   },
-  'securite-infrastructure-pare-feu-deploye-logs-stockes': {
+  "securite-infrastructure-pare-feu-deploye-logs-stockes": {
     niveau1: {
       titre:
         "Activer et conserver l'historique de l’ensemble des flux bloqués et des flux entrants et sortants identifiés par le pare-feu.",
       pourquoi:
-        'recommandations/infras/securite-infrastructure-pare-feu-deploye-logs-stockes-niveau1-pourquoi.pug',
+        "recommandations/infras/securite-infrastructure-pare-feu-deploye-logs-stockes-niveau1-pourquoi.pug",
       comment:
-        'recommandations/infras/securite-infrastructure-pare-feu-deploye-logs-stockes-niveau1-comment.pug',
+        "recommandations/infras/securite-infrastructure-pare-feu-deploye-logs-stockes-niveau1-comment.pug",
     },
     priorisation: 20,
   },
-  'securite-infrastructure-si-industriel-pare-feu-deploye': {
+  "securite-infrastructure-si-industriel-pare-feu-deploye": {
     niveau1: {
       titre:
-        'Fermer tous les flux et les ports non strictement nécessaires au SI industriel.',
+        "Fermer tous les flux et les ports non strictement nécessaires au SI industriel.",
       pourquoi:
-        'recommandations/infras/securite-infrastructure-si-industriel-pare-feu-deploye-niveau1-pourquoi.pug',
+        "recommandations/infras/securite-infrastructure-si-industriel-pare-feu-deploye-niveau1-pourquoi.pug",
       comment:
-        'recommandations/infras/securite-infrastructure-si-industriel-pare-feu-deploye-niveau1-comment.pug',
+        "recommandations/infras/securite-infrastructure-si-industriel-pare-feu-deploye-niveau1-comment.pug",
     },
     niveau2: {
       titre:
-        'Dans la mesure du possible et si non nécessaire, séparer le réseau industriel du réseau bureautique interne.',
+        "Dans la mesure du possible et si non nécessaire, séparer le réseau industriel du réseau bureautique interne.",
       pourquoi:
-        'recommandations/infras/securite-infrastructure-si-industriel-pare-feu-deploye-niveau2-pourquoi.pug',
+        "recommandations/infras/securite-infrastructure-si-industriel-pare-feu-deploye-niveau2-pourquoi.pug",
       comment:
-        'recommandations/infras/securite-infrastructure-si-industriel-pare-feu-deploye-niveau2-comment.pug',
+        "recommandations/infras/securite-infrastructure-si-industriel-pare-feu-deploye-niveau2-comment.pug",
     },
     priorisation: 20,
   },
-  'securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees':
+  "securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees":
     {
       niveau1: {
         titre:
-          'Déployer systématiquement toutes les mises à jour dès que celles-ci sont disponibles  (ou après qualification interne) et hors exceptions spécifiquement identifiées.',
+          "Déployer systématiquement toutes les mises à jour dès que celles-ci sont disponibles  (ou après qualification interne) et hors exceptions spécifiquement identifiées.",
         pourquoi:
-          'recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees-niveau1-pourquoi.pug',
+          "recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees-niveau1-pourquoi.pug",
         comment:
-          'recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees-niveau1-comment.pug',
+          "recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees-niveau1-comment.pug",
       },
       niveau2: {
         titre:
-          'Mettre en œuvre des mesures de sécurité supplémentaires (cloisonnement, règles EDR durcies, déconnexion AD) sur les systèmes ne pouvant pas bénéficier des mises à jour (ex : systèmes industriels, applications particulières).',
+          "Déployer systématiquement toutes les mises à jour dès que celles-ci sont disponibles  (ou après qualification interne) et hors exceptions spécifiquement identifiées.",
         pourquoi:
-          'recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees-niveau2-pourquoi.pug',
+          "recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees-niveau2-pourquoi.pug",
         comment:
-          'recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees-niveau2-comment.pug',
+          "recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees-niveau2-comment.pug",
       },
       priorisation: 2,
     },
-  'securite-infrastructure-mises-a-jour-fonctionnelles-securite-systemes-exploitation-securite-deployees':
+  "securite-infrastructure-mises-a-jour-fonctionnelles-securite-systemes-exploitation-securite-deployees":
     {
       niveau1: {
         titre:
-          'Déployer systématiquement toutes les mises à jour dès que celles-ci sont disponibles  (ou après qualification interne) et hors exceptions spécifiquement identifiées.',
+          "Déployer systématiquement toutes les mises à jour dès que celles-ci sont disponibles  (ou après qualification interne) et hors exceptions spécifiquement identifiées.",
         pourquoi:
-          'recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-systemes-exploitation-securite-deployees-niveau1-pourquoi.pug',
+          "recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-systemes-exploitation-securite-deployees-niveau1-pourquoi.pug",
         comment:
-          'recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-systemes-exploitation-securite-deployees-niveau1-comment.pug',
+          "recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-systemes-exploitation-securite-deployees-niveau1-comment.pug",
       },
       niveau2: {
         titre:
-          'Mettre en œuvre des mesures de sécurité supplémentaires (cloisonnement, règles EDR durcies, déconnexion AD) sur les systèmes ne pouvant pas bénéficier des mises à jour (ex : systèmes industriels, applications particulières).',
+          "Mettre en œuvre des mesures de sécurité supplémentaires (cloisonnement, règles EDR durcies, déconnexion AD) sur les systèmes ne pouvant pas bénéficier des mises à jour (ex : systèmes industriels, applications particulières).",
         pourquoi:
-          'recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-systemes-exploitation-securite-deployees-niveau2-pourquoi.pug',
+          "recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-systemes-exploitation-securite-deployees-niveau2-pourquoi.pug",
         comment:
-          'recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-systemes-exploitation-securite-deployees-niveau2-comment.pug',
+          "recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-systemes-exploitation-securite-deployees-niveau2-comment.pug",
       },
       priorisation: 2,
     },
-  'securite-infrastructure-outils-securisation-systeme-messagerie': {
+  "securite-infrastructure-outils-securisation-systeme-messagerie": {
     niveau1: {
       titre: "Mettre en oeuvre une solution d'anti-spam et d'anti-hameçonnage.",
       pourquoi:
-        'recommandations/infras/securite-infrastructure-outils-securisation-systeme-messagerie-niveau1-pourquoi.pug',
+        "recommandations/infras/securite-infrastructure-outils-securisation-systeme-messagerie-niveau1-pourquoi.pug",
       comment:
-        'recommandations/infras/securite-infrastructure-outils-securisation-systeme-messagerie-niveau1-comment.pug',
+        "recommandations/infras/securite-infrastructure-outils-securisation-systeme-messagerie-niveau1-comment.pug",
     },
     niveau2: {
       titre: 'Désactiver le portail de type "webmail"',
       pourquoi:
-        'recommandations/infras/securite-infrastructure-outils-securisation-systeme-messagerie-niveau2-pourquoi.pug',
+        "recommandations/infras/securite-infrastructure-outils-securisation-systeme-messagerie-niveau2-pourquoi.pug",
       comment:
-        'recommandations/infras/securite-infrastructure-outils-securisation-systeme-messagerie-niveau2-comment.pug',
+        "recommandations/infras/securite-infrastructure-outils-securisation-systeme-messagerie-niveau2-comment.pug",
     },
     priorisation: 22,
   },
-  'securite-infrastructure-acces-wifi-securises': {
+  "securite-infrastructure-acces-wifi-securises": {
     niveau1: {
-      titre: 'Mettre en place des mesures de sécurisation wifi.',
+      titre: "Mettre en place des mesures de sécurisation wifi.",
       pourquoi:
-        'recommandations/infras/securite-infrastructure-acces-wifi-securises-niveau1-pourquoi.pug',
+        "recommandations/infras/securite-infrastructure-acces-wifi-securises-niveau1-pourquoi.pug",
       comment:
-        'recommandations/infras/securite-infrastructure-acces-wifi-securises-niveau1-comment.pug',
+        "recommandations/infras/securite-infrastructure-acces-wifi-securises-niveau1-comment.pug",
     },
     niveau2: {
       titre:
         "Restreindre l'accès à l'interface d’administration dédiée seulement via le réseau cablé (et non en Wifi).",
       pourquoi:
-        'recommandations/infras/securite-infrastructure-acces-wifi-securises-niveau2-pourquoi.pug',
+        "recommandations/infras/securite-infrastructure-acces-wifi-securises-niveau2-pourquoi.pug",
       comment:
-        'recommandations/infras/securite-infrastructure-acces-wifi-securises-niveau2-comment.pug',
+        "recommandations/infras/securite-infrastructure-acces-wifi-securises-niveau2-comment.pug",
     },
     priorisation: 29,
   },
-  'securite-infrastructure-espace-stockage-serveurs': {
+  "securite-infrastructure-espace-stockage-serveurs": {
     niveau1: {
       titre:
         "Mettre en place des mesures de sécurisation de l'espace dédié au stockage des serveurs d'administration et des équipements réseau.",
       pourquoi:
-        'recommandations/infras/securite-infrastructure-espace-stockage-serveurs-niveau1-pourquoi.pug',
+        "recommandations/infras/securite-infrastructure-espace-stockage-serveurs-niveau1-pourquoi.pug",
       comment:
-        'recommandations/infras/securite-infrastructure-espace-stockage-serveurs-niveau1-comment.pug',
+        "recommandations/infras/securite-infrastructure-espace-stockage-serveurs-niveau1-comment.pug",
     },
     niveau2: {
       titre:
         "En complément des pratiques déjà en œuvre, mettre en place des mesures complémentaires de sécurisation de l'espace dédié au stockage des serveurs d'administration et des équipements réseau.",
       pourquoi:
-        'recommandations/infras/securite-infrastructure-espace-stockage-serveurs-niveau2-pourquoi.pug',
+        "recommandations/infras/securite-infrastructure-espace-stockage-serveurs-niveau2-pourquoi.pug",
       comment:
-        'recommandations/infras/securite-infrastructure-espace-stockage-serveurs-niveau2-comment.pug',
+        "recommandations/infras/securite-infrastructure-espace-stockage-serveurs-niveau2-comment.pug",
     },
     priorisation: 30,
   },

--- a/mon-aide-cyber-api/src/infrastructure/pdf/modeles/recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees-niveau2-comment.pug
+++ b/mon-aide-cyber-api/src/infrastructure/pdf/modeles/recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees-niveau2-comment.pug
@@ -1,12 +1,1 @@
-div
-    | Plusieurs mesures pour sécuriser son système d’information envers les postes obsolètes sont possibles :
-    ul
-        li
-            | Isolement et cloisonnement des postes obsolètes au reste du système d’information (exemple : non inclus dans
-            | l’annuaire centralisée, réseau à part du réseau bureautique commun, non accessible via internet, restriction
-            | et filtrage web par liste blanche selon les nécessites métiers),
-        li
-            | Mise en place d’un EDR avec des règles de sécurité durcies.
-    p
-        | Il est préconisé de s’appuyer sur les compétences d’un prestataire externe, idéalement labellisé Expert Cyber,
-        | pour la mise en œuvre de cette recommandation.
+include securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees-niveau1-comment

--- a/mon-aide-cyber-api/src/infrastructure/pdf/modeles/recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees-niveau2-pourquoi.pug
+++ b/mon-aide-cyber-api/src/infrastructure/pdf/modeles/recommandations/infras/securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees-niveau2-pourquoi.pug
@@ -1,4 +1,1 @@
-div
-    | Bien que la grande majorité des systèmes soit à jour, il suffit parfois d’un seul système obsolète pour compromettre
-    | le système d’information. S’il réside donc des systèmes obsolètes, ne pouvant être mis à jour, il convient ainsi de
-    | mettre en œuvre des mesures de sécurité spécifiques.
+include securite-infrastructure-mises-a-jour-fonctionnelles-securite-equipements-securite-deployees-niveau1-pourquoi


### PR DESCRIPTION
Dans la thématique **Sécurité des infrastructures**, la question `Les mises à jour fonctionnelles et de sécurité des équipements de sécurité sont-elles déployées ?` n’a pas de **niveau 2**. 
Elle prenait jusqu’alors la recommandation de **niveau 2** de la question `Les mises à jour fonctionnelles et de sécurité des systèmes d'exploitation des serveurs, services et logiciels d'admnistration sont-elles déployées ?`.

**La recommandation a été remplacée par celle de niveau 1 pour la question correspondante.**