### PR TITLE
 [DIAGNOSTIC][SECURITEACCES] modifie la question sur les différents sites géographiques

### DIFF
--- a/mon-aide-cyber-api/src/diagnostic/referentiel/donneesSecuriteAcces.ts
+++ b/mon-aide-cyber-api/src/diagnostic/referentiel/donneesSecuriteAcces.ts
@@ -566,7 +566,7 @@ export const donneesSecuriteAcces: QuestionsThematique = {
     {
       identifiant: "acces-entite-dispose-plusieurs-sites-geographiques",
       libelle:
-        "Si l'entité dispose de plusieurs sites géographiques interconnectés, et si à risque d'espionnage industriel : les interconnexions \"site à site\" font-elles l'objet de mesures de sécurité particulières ?",
+        "Si l'entité dispose de plusieurs sites géographiques interconnectés, et si à risque d'espionnage : les interconnexions \"site-à-site\" sont-elles chiffrées ?",
       reponsesPossibles: [
         {
           identifiant: "acces-entite-dispose-plusieurs-sites-geographiques-na",


### PR DESCRIPTION
[DIAGNOSTIC][QUESTIONS][SECURITEACCES] modifie la question acces-entite-dispose-plusieurs-sites-geographiques

- Pourquoi limiter à "l'espionnage industriel", "l'espionnage" est plus générique
- Quel autre "mesure de sécurité" que le chiffrement pourrait être mise en place sur les interconnexions pour limiter le risque d'espionnage ?

NB: ce changement est à mettre en perspective avec la [PR 168](https://github.com/betagouv/mon-aide-cyber/pull/168)