### PR TITLE
[DIAGNOSTIC][QUESTIONS] modifie la thématique SecuriteInfra

### DIFF
--- a/mon-aide-cyber-api/src/diagnostic/referentiel/donneesSecuriteInfrastructure.ts
+++ b/mon-aide-cyber-api/src/diagnostic/referentiel/donneesSecuriteInfrastructure.ts
@@ -4,7 +4,7 @@ export const donneesSecuriteInfrastructure: QuestionsThematique = {
   questions: [
     {
       identifiant: 'securite-infrastructure-pare-feu-deploye',
-      libelle: 'Votre interconnexion à l\'Internet est-elle protégée par un pare-feu physique ?',
+      libelle: 'Votre connexion à Internet est-elle protégée par un pare-feu physique ?',
       reponsesPossibles: [
         {
           identifiant: 'securite-infrastructure-pare-feu-deploye-nsp',


### PR DESCRIPTION
[DIAGNOSTIC][QUESTIONS][SECURITEINFRA] modification de la question securite-infrastructure-pare-feu-deploye

Un pare-feu est forcément déployé "au niveau du réseau" (puisque c'est lui-même un équipement réseau) => proposition d'une nouvelle formulation moins ambigüe