### PR TITLE
 [DIAGNOSTIC][QUESTIONS] modifie la thématique SecuriteInfra : question sur les journaux des pare-feu

### DIFF
--- a/mon-aide-cyber-api/src/diagnostic/referentiel/donneesSecuriteInfrastructure.ts
+++ b/mon-aide-cyber-api/src/diagnostic/referentiel/donneesSecuriteInfrastructure.ts
@@ -71,7 +71,7 @@ export const donneesSecuriteInfrastructure: QuestionsThematique = {
               identifiant:
                 'securite-infrastructure-pare-feu-deploye-oui-tiroir-logs-stockes',
               libelle:
-                'Si "Oui" : stockez-vous les journaux des flux manipulés par votre pare-feu (entrants/sortants/bloqués) ? ',
+                'Si "Oui" : stockez-vous les journaux des flux (entrants/sortants/bloqués) générés par votre pare-feu ?',
               reponsesPossibles: [
                 {
                   identifiant:


### PR DESCRIPTION
[DIAGNOSTIC][QUESTIONS][SECURITEINFRA] modification de la question securite-infrastructure-pare-feu-deploye-oui-tiroir-logs-stockes

- "logs" est redondant avec "journaux"
- proposition de reformulation plus courte