### PR TITLE
[DIAGNOSTIC][QUESTIONS] modifie la thématique SecuriteInfra

### DIFF
--- a/mon-aide-cyber-api/src/diagnostic/referentiel/donneesSecuriteInfrastructure.ts
+++ b/mon-aide-cyber-api/src/diagnostic/referentiel/donneesSecuriteInfrastructure.ts
@@ -72,6 +72,7 @@ export const donneesSecuriteInfrastructure: QuestionsThematique = {
                 'securite-infrastructure-pare-feu-deploye-oui-tiroir-logs-stockes',
               libelle:
                 'Si "Oui" : stockez-vous les journaux des flux entrants, sortants et bloqués générés par votre pare-feu ?',
+              reponsesPossibles: [
                 {
                   identifiant:
                     'securite-infrastructure-pare-feu-deploye-oui-tiroir-logs-stockes-nsp',


### PR DESCRIPTION
[DIAGNOSTIC][QUESTIONS][SECURITEINFRA] modification des réponse à la question securite-infrastructure-pare-feu-deploye-oui-tiroir-logs-stockes

« logs » est redondant avec « journaux »