### PR TITLE
[CORRECTION][AUTHENTIFICATION] permet le parsing du cookie de session dans le cas où il y a d'autres cookies présent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "typescript": "^5.1.3"
       },
       "devDependencies": {
-        "@faker-js/faker": "^8.0.2"
+        "@faker-js/faker": "^8.0.2",
+        "@types/cookies": "^0.7.10"
       }
     },
     "mon-aide-cyber-api": {
@@ -7987,6 +7988,18 @@
       "dependencies": {
         "@types/express": "*",
         "@types/keygrip": "*"
+      }
+    },
+    "node_modules/@types/cookies": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.10.tgz",
+      "integrity": "sha512-hmUCjAk2fwZVPPkkPBcI7jGLIR5mg4OVoNMBwU6aVsMm/iNPY7z9/R+x2fSwLt/ZXoGua6C5Zy2k5xOo9jUyhQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typescript": "^5.1.3"
   },
   "devDependencies": {
-    "@faker-js/faker": "^8.0.2"
+    "@faker-js/faker": "^8.0.2",
+    "@types/cookies": "^0.7.10"
   }
 }


### PR DESCRIPTION
Par exemple, le cas ci-dessous n'était pas pris en compte et renvoyait un 403 lorsqu'un aidant accédait à une ressource protégée. 

` session=ey...9; org.cups.sid=a...8; session.sig=i...M`

Plutôt que d'améliorer la regex, j'ai directement utilisé la bibliothèque 'Cookies' dont 'cookie-session' est déjà dépendante.