### PR TITLE
[REMANIEMENT] Supprime le champs reponses du modèle ReponseATranscrire

### DIFF
--- a/mon-aide-cyber-api/src/api/representateurs/types.ts
+++ b/mon-aide-cyber-api/src/api/representateurs/types.ts
@@ -72,7 +72,6 @@ export type Format = 'nombre' | 'texte';
 export type ReponseATranscrire = {
   identifiant: string;
   question?: QuestionATranscrire | undefined;
-  reponses?: ReponseATranscrire[];
   type?: { format: Format; type: TypeDeSaisie };
 };
 export type QuestionATranscrire = {


### PR DESCRIPTION
Ce champs est inutilisé et est incohérent avec le modèle