### PR TITLE
💡 [REMANIEMENT] Propose une vérification de session par `middleware`

### DIFF
--- a/mon-aide-cyber-api/src/adaptateurs/AdaptateurDeVerificationDeSession.ts
+++ b/mon-aide-cyber-api/src/adaptateurs/AdaptateurDeVerificationDeSession.ts
@@ -1,14 +1,8 @@
-import { Request, Response } from 'express';
-import { NextFunction } from 'express-serve-static-core';
+import { RequestHandler } from 'express';
 import { Contexte } from '../domaine/erreurMAC';
 
 export interface AdaptateurDeVerificationDeSession {
-  verifie(
-    contexte: Contexte,
-    requete: Request,
-    _reponse: Response,
-    suite: NextFunction,
-  ): void;
+  verifie(contexte: Contexte): RequestHandler;
 }
 
 export class ErreurAccesRefuse extends Error {

--- a/mon-aide-cyber-api/src/api/routesAPIDiagnostic.ts
+++ b/mon-aide-cyber-api/src/api/routesAPIDiagnostic.ts
@@ -9,15 +9,11 @@ import bodyParser from 'body-parser';
 export const routesAPIDiagnostic = (configuration: ConfigurationServeur) => {
   const routes = express.Router();
 
+  const { adaptateurDeVerificationDeSession: session } = configuration;
+
   routes.post(
     '/',
-    (requete, reponse, suite) =>
-      configuration.adaptateurDeVerificationDeSession.verifie(
-        'Lance le diagnostic',
-        requete,
-        reponse,
-        suite,
-      ),
+    session.verifie('Lance le diagnostic'),
     (_requete: Request, reponse: Response, suite: NextFunction) => {
       new ServiceDiagnostic(
         configuration.adaptateurReferentiel,
@@ -40,13 +36,7 @@ export const routesAPIDiagnostic = (configuration: ConfigurationServeur) => {
 
   routes.get(
     '/:id/termine',
-    (requete, reponse, suite) =>
-      configuration.adaptateurDeVerificationDeSession.verifie(
-        'Termine le diagnostic',
-        requete,
-        reponse,
-        suite,
-      ),
+    session.verifie('Termine le diagnostic'),
     (requete: Request, reponse: Response, suite: NextFunction) => {
       const { id } = requete.params;
       const serviceDiagnostic = new ServiceDiagnostic(
@@ -70,13 +60,7 @@ export const routesAPIDiagnostic = (configuration: ConfigurationServeur) => {
 
   routes.get(
     '/:id',
-    (requete, reponse, suite) =>
-      configuration.adaptateurDeVerificationDeSession.verifie(
-        'Accès diagnostic',
-        requete,
-        reponse,
-        suite,
-      ),
+    session.verifie('Accès diagnostic'),
     (requete: Request, reponse: Response, suite: NextFunction) => {
       const { id } = requete.params;
       new ServiceDiagnostic(
@@ -99,13 +83,7 @@ export const routesAPIDiagnostic = (configuration: ConfigurationServeur) => {
 
   routes.patch(
     '/:id',
-    (requete, reponse, suite) =>
-      configuration.adaptateurDeVerificationDeSession.verifie(
-        'Ajout réponse au diagnostic',
-        requete,
-        reponse,
-        suite,
-      ),
+    session.verifie('Ajout réponse au diagnostic'),
     bodyParser.json(),
     (requete: Request, reponse: Response, suite: NextFunction) => {
       const { id } = requete.params;
@@ -127,13 +105,7 @@ export const routesAPIDiagnostic = (configuration: ConfigurationServeur) => {
 
   routes.get(
     '/:id/restitution',
-    (requete, reponse, suite) =>
-      configuration.adaptateurDeVerificationDeSession.verifie(
-        'Ajout réponse au diagnostic',
-        requete,
-        reponse,
-        suite,
-      ),
+    session.verifie('Ajout réponse au diagnostic'),
     (requete: Request, reponse: Response, suite: NextFunction) => {
       const { id } = requete.params;
       const serviceDiagnostic = new ServiceDiagnostic(

--- a/mon-aide-cyber-api/src/api/routesAPIDiagnostics.ts
+++ b/mon-aide-cyber-api/src/api/routesAPIDiagnostics.ts
@@ -27,13 +27,9 @@ export const routesAPIDiagnostics = (configuration: ConfigurationServeur) => {
 
   routes.get(
     '/',
-    (requete, reponse, suite) =>
-      configuration.adaptateurDeVerificationDeSession.verifie(
-        'Accède aux diagnostics',
-        requete,
-        reponse,
-        suite,
-      ),
+    configuration.adaptateurDeVerificationDeSession.verifie(
+      'Accède aux diagnostics',
+    ),
     (_requete: Request, reponse: Response, suite: NextFunction) => {
       configuration.entrepots
         .diagnostic()

--- a/mon-aide-cyber-api/test/adaptateurs/AdaptateurDeVerificationDeSessionDeTest.ts
+++ b/mon-aide-cyber-api/test/adaptateurs/AdaptateurDeVerificationDeSessionDeTest.ts
@@ -1,6 +1,6 @@
 import { AdaptateurDeVerificationDeSession } from '../../src/adaptateurs/AdaptateurDeVerificationDeSession';
 import { NextFunction } from 'express-serve-static-core';
-import { Request, Response } from 'express';
+import { Request, RequestHandler, Response } from 'express';
 import { Contexte } from '../../src/domaine/erreurMAC';
 
 export class AdaptateurDeVerificationDeSessionDeTest
@@ -8,14 +8,11 @@ export class AdaptateurDeVerificationDeSessionDeTest
 {
   constructor(private estPassee = false) {}
 
-  verifie(
-    _contexte: Contexte,
-    _requete: Request,
-    _reponse: Response,
-    suite: NextFunction,
-  ): void {
-    this.estPassee = true;
-    suite();
+  verifie(__contexte: Contexte): RequestHandler {
+    return (_requete: Request, _reponse: Response, suite: NextFunction) => {
+      this.estPassee = true;
+      suite();
+    };
   }
 
   verifiePassage(): boolean {

--- a/mon-aide-cyber-api/test/adaptateurs/AdaptateurDeVerificationDeSessionHttp.spec.ts
+++ b/mon-aide-cyber-api/test/adaptateurs/AdaptateurDeVerificationDeSessionHttp.spec.ts
@@ -5,6 +5,7 @@ import { NextFunction } from 'express-serve-static-core';
 import { Request, Response } from 'express';
 import { ErreurMAC } from '../../src/domaine/erreurMAC';
 import { ErreurAccesRefuse } from '../../src/adaptateurs/AdaptateurDeVerificationDeSession';
+import { MACCookies } from '../../src/adaptateurs/fabriqueDeCookies';
 
 describe('Adaptateur de vérification de session', () => {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -22,10 +23,7 @@ describe('Adaptateur de vérification de session', () => {
 
     new AdaptateurDeVerificationDeSessionHttp(fauxGestionnaireDeJeton).verifie(
       'Accède aux diagnostics',
-      requete,
-      reponse,
-      fausseSuite,
-    );
+    )(requete, reponse, fausseSuite);
 
     fauxGestionnaireDeJeton.verifieToken(
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudGlmaWFudCI6ImNiYTMzYTRmLTAyMjQtNGQ4MS1iODk5LTE1MjEwNWM2YjhhZiIsImlhdCI6MTcwMDkwMjY1MTk2MH0.WxgG3fHtTPyzGwyOdjpQGq9klq4yBo6UF9nwkYmKsho',
@@ -36,7 +34,7 @@ describe('Adaptateur de vérification de session', () => {
     expect(() => {
       new AdaptateurDeVerificationDeSessionHttp(
         new FauxGestionnaireDeJeton(),
-      ).verifie('Accès diagnostic', requete, reponse, fausseSuite);
+      ).verifie('Accès diagnostic')(requete, reponse, fausseSuite);
     }).toThrow(
       ErreurMAC.cree(
         'Accès diagnostic',
@@ -54,7 +52,7 @@ describe('Adaptateur de vérification de session', () => {
     expect(() => {
       new AdaptateurDeVerificationDeSessionHttp(
         new FauxGestionnaireDeJeton(),
-      ).verifie('Accès diagnostic', requete, reponse, fausseSuite);
+      ).verifie('Accès diagnostic')(requete, reponse, fausseSuite);
     }).toThrow(`Cookie invalide.`);
   });
 
@@ -65,9 +63,13 @@ describe('Adaptateur de vérification de session', () => {
     expect(() => {
       new AdaptateurDeVerificationDeSessionHttp(
         new FauxGestionnaireDeJeton(),
-      ).verifie('Accès diagnostic', requete, reponse, fausseSuite, {
-        session: cookieDeSession,
-      });
+      ).verifie(
+        'Accès diagnostic',
+        () =>
+          ({
+            session: cookieDeSession,
+          }) as MACCookies,
+      )(requete, reponse, fausseSuite);
     }).toThrow(`Session invalide.`);
   });
 
@@ -79,9 +81,13 @@ describe('Adaptateur de vérification de session', () => {
     expect(() => {
       new AdaptateurDeVerificationDeSessionHttp(
         fauxGestionnaireDeJeton,
-      ).verifie('Accès diagnostic', requete, reponse, fausseSuite, {
-        session: cookieDeSession,
-      });
+      ).verifie(
+        'Accès diagnostic',
+        () =>
+          ({
+            session: cookieDeSession,
+          }) as MACCookies,
+      )(requete, reponse, fausseSuite);
     }).toThrow(`Session invalide.`);
   });
 });


### PR DESCRIPTION
Cette PR propose de remplacer `AdaptateurDeVerificationDeSession.verifie` par une approche plus orientée middleware express.

Exemple sur une route :

#### ⬅️  AVANT 
```js
  routes.post(
    '/',
    (requete, reponse, suite) =>
      configuration.adaptateurDeVerificationDeSession.verifie(
        'Lance le diagnostic',
        requete,
        reponse,
        suite,
      ),
    (_requete: Request, reponse: Response, suite: NextFunction) => {
         …
    }
}
```

#### ➡️ APRÈS 
```js
  routes.post(
    '/',
    session.verifie('Lance le diagnostic'),
    (_requete: Request, reponse: Response, suite: NextFunction) => {
         …
    }
}
```

### 🗒️ Éléments clés 
 -  `verifieParMiddleware` typé comme un `RequestHandler` : ça veut dire qu'il est un middleware qui renvoie la fonction « suivante »
 - `verifieParMiddleware` appelé sans passer `requete, reponse, suite` grâce au design expliqué ci-dessus


⚠️ Prettier a modifié des guillemets et virgules. Désolé pour le bruit dans la PR.