### PR TITLE
[CORRECTION][RESTITUTION] Corrige le calcul des indicateurs lorsqu'une question tiroir n'a pas de résultat

### DIFF
--- a/mon-aide-cyber-api/src/diagnostic/MoteurIndice.ts
+++ b/mon-aide-cyber-api/src/diagnostic/MoteurIndice.ts
@@ -93,12 +93,13 @@ export class MoteurIndice {
               .filter((reponsePossible) =>
                 reponsesMultiples.reponses.has(reponsePossible.identifiant),
               )
+              .filter((reponsePossible) => !!reponsePossible.resultat)
               .map(
                 (reponsePossible) =>
                   ({
                     resultat: reponsePossible.resultat,
                     poids: questionATiroir.poids,
-                  } as IndiceIntermediaire),
+                  }) as IndiceIntermediaire,
               )
               .filter(
                 (indice: IndiceIntermediaire): indice is IndiceIntermediaire =>

--- a/mon-aide-cyber-api/test/diagnostic/MoteurIndice.spec.ts
+++ b/mon-aide-cyber-api/test/diagnostic/MoteurIndice.spec.ts
@@ -341,5 +341,69 @@ describe('Moteur Indice', () => {
         ],
       });
     });
+
+    it("génère l'indice pour une question tiroir quand la réponse n'a pas de valeur", () => {
+      const question1 = uneQuestion()
+        .aChoixUnique('Quelle est la réponse?')
+        .avecPoids(1)
+        .avecReponsesPossibles([
+          uneReponsePossible().avecLibelle('42').construis(),
+          uneReponsePossible()
+            .avecLibelle('24')
+            .ayantPourValeurDIndice(2)
+            .ajouteUneQuestionATiroir(
+              uneQuestionATiroir()
+                .avecPoids(2)
+                .aChoixUnique('Voulez-vous inverser les chiffres?')
+                .avecReponsesPossibles([
+                  uneReponsePossible().avecLibelle('Ne sais pas').construis(),
+                  uneReponsePossible()
+                    .avecLibelle('Non')
+                    .ayantPourValeurDIndice(0)
+                    .construis(),
+                ])
+                .construis(),
+            )
+            .construis(),
+        ])
+        .construis();
+
+      const diagnostic = constructeurDiagnostic
+        .avecUnReferentiel(
+          unReferentiel()
+            .sansThematique()
+            .ajouteUneThematique('thematique', [question1])
+            .construis(),
+        )
+        .ajouteUneReponseDonnee(
+          {
+            thematique: 'thematique',
+            question: 'quelle-est-la-reponse',
+          },
+          uneReponseDonnee()
+            .ayantPourReponse('24')
+            .avecDesReponsesMultiples([
+              {
+                identifiant: 'voulezvous-inverser-les-chiffres',
+                reponses: ['ne-sais-pas'],
+              },
+            ])
+            .construis(),
+        )
+        .construis();
+
+      const valeursDesIndices =
+        MoteurIndice.genereLesIndicesDesReponses(diagnostic);
+
+      expect(valeursDesIndices).toStrictEqual<ValeursDesIndicesAuDiagnostic>({
+        thematique: [
+          {
+            identifiant: 'quelle-est-la-reponse',
+            indice: 2,
+            poids: 1,
+          },
+        ],
+      });
+    });
   });
 });


### PR DESCRIPTION
**Contexte**
La génération de la restitution ne fonctionne pas.

**Reproduction**
- Lancer un diagnostic
- Se rendre sur la thématique `Réaction`
- Répondre à la question `Des sauvegardes régulières des données et des systèmes d'information sont-elles réalisées ?` par `Des sauvegardes des données et des systèmes d'information sont réalisées ponctuellement.` ou `Des sauvegardes des données et des systèmes sont réalisées de manière automatique et régulière`
- Répondre par `Je ne sais pas` ou `Non applicable` indifféremment (voir capture d'écran)
   <img width="841" alt="Capture d’écran 2023-12-22 à 10 05 30" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/60b44058-fce6-4035-af14-3c0c1e766f51">

- Cliquer sur `Terminer Diagnostic`

**Résultat constaté**
La génération de la restitution ne fonctionne pas.
Le message suivant apparaît: `{"message":"MonAideCyber n'est pas en mesure de traiter votre demande."}`

**Résultat attendu**
La restitution est générée, j'ai accès aux mesures et aux indicateurs