### PR TITLE
[CORRECTION][DIAGNOSTIC] Corrige l'apparence de la barre de navigation dans le diagnostic

### DIFF
--- a/mon-aide-cyber-ui/src/assets/styles/_diagnostic.scss
+++ b/mon-aide-cyber-ui/src/assets/styles/_diagnostic.scss
@@ -42,9 +42,7 @@
 }
 
 .conteneur-thematique {
-  flex: 0 0 calc(calc(1200% / 12) - 64px);
-  width: calc(calc(1200% / 12) - 64px);
-  max-width: calc(calc(1200% / 12) - 64px);
+  flex: 0 0 100%;
 }
 
 .conteneur-navigation {
@@ -66,11 +64,12 @@
 }
 
 .navigation-thematiqes {
-  position: sticky;
-  top: 6.67rem;
-  left: 0;
-  height: 100%;
-  max-height: 100vh;
+  position: fixed;
+  //top: 6.67rem;
+  //left: 0;
+  height: 100vh;
+  background-color: var(--couleurs-mac-violet-fonce);
+  //max-height: 100vh;
 }
 
 .navigation-thematiqes ul {


### PR DESCRIPTION
**Contexte:**
Affichage du diagnostic

**Description:**
Lorsque l'on scroll vers le bas d'une thématique dans le diagnostic, la barre de navigation se cache derrière le header du diagnostic.

**Reproduction:**
1. Se rendre sur un diagnostic ou en lancer un nouveau
2. Descendre au bas d'une thématique

**Résultat constaté:**
Les premières thématiques sont masquées par le header du diagnostic (cf capture ci-dessous)

<img width="1516" alt="Capture d’écran 2024-01-04 à 17 26 36" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/a673d9e3-e8d1-414c-8cd8-94b7276a6249">

**Résultat attendu:**
La barre de navigation et l'intégralité des thématiques doit être accessible où que l'on soit dans la page.

<img width="1491" alt="Capture d’écran 2024-01-04 à 17 26 48" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/adf4320e-8323-445f-ac42-9e6ebf05376f">