### PR TITLE
[CORRECTION] Corrige le nom des champs exposés sur l'API et prends en compte les retours post PR

### DIFF
--- a/mon-aide-cyber-api/src/api/routesAPIUtilisateur.ts
+++ b/mon-aide-cyber-api/src/api/routesAPIUtilisateur.ts
@@ -21,8 +21,8 @@ export const routesAPIUtilisateur = (configuration: ConfigurationServeur) => {
     ) => {
       try {
         const finalisationCompte: {
-          cguCochees: boolean;
-          charteCochee: boolean;
+          cguSignees: boolean;
+          charteSignee: boolean;
         } = requete.body;
         await new ServiceFinalisationCreationCompte(entrepots).finalise({
           ...finalisationCompte,

--- a/mon-aide-cyber-api/src/compte/ServiceFinalisationCompte.ts
+++ b/mon-aide-cyber-api/src/compte/ServiceFinalisationCompte.ts
@@ -5,8 +5,8 @@ import { Aidant, ErreurFinalisationCompte } from '../authentification/Aidant';
 import { FournisseurHorloge } from '../infrastructure/horloge/FournisseurHorloge';
 
 type FinalisationCompte = {
-  cguCochees: boolean;
-  charteCochee: boolean;
+  cguSignees: boolean;
+  charteSignee: boolean;
   identifiant: crypto.UUID;
 };
 
@@ -23,8 +23,8 @@ export class ServiceFinalisationCreationCompte {
     const verifieLesCGUEtLaCharte = (
       finalisationCompte: FinalisationCompte,
     ) => {
-      const cguNonValidees = !finalisationCompte.cguCochees;
-      const charteNonSignee = !finalisationCompte.charteCochee;
+      const cguNonValidees = !finalisationCompte.cguSignees;
+      const charteNonSignee = !finalisationCompte.charteSignee;
 
       if (cguNonValidees && charteNonSignee) {
         leveErreur(
@@ -38,16 +38,16 @@ export class ServiceFinalisationCreationCompte {
         leveErreur("Vous devez signer la charte de l'aidant.");
       }
     };
-    const verifieCGUEtCharteDejaSignee = (aidant: Aidant) => {
-      aidant.dateSignatureCGU &&
-        aidant.dateSignatureCharte &&
-        leveErreur('Vous avez déjà finaliser la création de votre compte.');
+    const cguEtCharteDejaSignees = (aidant: Aidant) => {
+      return aidant.dateSignatureCGU && aidant.dateSignatureCharte;
     };
 
     const aidant = await this.entrepots
       .aidants()
       .lis(finalisationCompte.identifiant);
-    verifieCGUEtCharteDejaSignee(aidant);
+    if (cguEtCharteDejaSignees(aidant)) {
+      return;
+    }
     verifieLesCGUEtLaCharte(finalisationCompte);
     aidant.dateSignatureCGU = FournisseurHorloge.maintenant();
     aidant.dateSignatureCharte = FournisseurHorloge.maintenant();

--- a/mon-aide-cyber-api/test/api/routesAPIUtilisateur.spec.ts
+++ b/mon-aide-cyber-api/test/api/routesAPIUtilisateur.spec.ts
@@ -36,7 +36,7 @@ describe('le serveur MAC sur les routes /api/utilisateur', () => {
         'POST',
         `/api/utilisateur/finalise`,
         donneesServeur.portEcoute,
-        { cguCochees: true, charteCochee: true },
+        { cguSignees: true, charteSignee: true },
       );
 
       expect(reponse.statusCode).toBe(204);
@@ -71,7 +71,7 @@ describe('le serveur MAC sur les routes /api/utilisateur', () => {
         'POST',
         `/api/utilisateur/finalise`,
         donneesServeur.portEcoute,
-        { cguCochees: false, charteCochee: true },
+        { cguSignees: false, charteSignee: true },
       );
 
       expect(reponse.statusCode).toBe(422);

--- a/mon-aide-cyber-api/test/compte/ServiceFinalisationCompte.spec.ts
+++ b/mon-aide-cyber-api/test/compte/ServiceFinalisationCompte.spec.ts
@@ -4,6 +4,7 @@ import { ErreurFinalisationCompte } from '../../src/authentification/Aidant';
 import { ServiceFinalisationCreationCompte } from '../../src/compte/ServiceFinalisationCompte';
 import { EntrepotsMemoire } from '../../src/infrastructure/entrepots/memoire/EntrepotsMemoire';
 import { unAidant } from '../authentification/constructeurs/constructeurAidant';
+import { FournisseurHorlogeDeTest } from '../infrastructure/horloge/FournisseurHorlogeDeTest';
 
 describe('Service de finalisation de création de compte', () => {
   it("renvoie une erreur si la charte de l'aidant n'est pas signée", async () => {
@@ -14,8 +15,8 @@ describe('Service de finalisation de création de compte', () => {
 
     await expect(() =>
       service.finalise({
-        cguCochees: true,
-        charteCochee: false,
+        cguSignees: true,
+        charteSignee: false,
         identifiant: aidant.identifiant,
       }),
     ).rejects.toThrowError(
@@ -36,8 +37,8 @@ describe('Service de finalisation de création de compte', () => {
 
     await expect(() =>
       service.finalise({
-        cguCochees: false,
-        charteCochee: false,
+        cguSignees: false,
+        charteSignee: false,
         identifiant: aidant.identifiant,
       }),
     ).rejects.toThrowError(
@@ -50,25 +51,25 @@ describe('Service de finalisation de création de compte', () => {
     );
   });
 
-  it('renvoie une erreur si le compte a déjà été finalisé', async () => {
+  it('ne modifie pas les dates de signature si le compte a déjà été finalisé', async () => {
+    const dateDeSignature = new Date(Date.parse('2024-01-12T12:34:26+01:00'));
+    FournisseurHorlogeDeTest.initialise(dateDeSignature);
     const entrepots = new EntrepotsMemoire();
     const aidant = unAidant().construis();
     entrepots.aidants().persiste(aidant);
     const service = new ServiceFinalisationCreationCompte(entrepots);
 
-    await expect(() =>
-      service.finalise({
-        cguCochees: false,
-        charteCochee: false,
-        identifiant: aidant.identifiant,
-      }),
-    ).rejects.toThrowError(
-      ErreurMAC.cree(
-        'Finalise la création du compte',
-        new ErreurFinalisationCompte(
-          'Vous avez déjà finaliser la création de votre compte.',
-        ),
-      ),
+    FournisseurHorlogeDeTest.initialise(
+      new Date(Date.parse('2024-01-15T10:14:37+01:00')),
     );
+    await service.finalise({
+      cguSignees: true,
+      charteSignee: true,
+      identifiant: aidant.identifiant,
+    });
+
+    const aidantRecupere = await entrepots.aidants().lis(aidant.identifiant);
+    expect(aidantRecupere.dateSignatureCharte).toStrictEqual(dateDeSignature);
+    expect(aidantRecupere.dateSignatureCGU).toStrictEqual(dateDeSignature);
   });
 });


### PR DESCRIPTION
- On ne renvoie pas d'erreur si on reçoit une demande de finalisation pour un aidant ayant déjà finalisé son compte
- On ne modifie pas les dates de signature dans le cas ci-dessus