### PR TITLE
[ACCUEIL][MOBILE] adapte l'affichage quand le mobile est en mode paysage

### DIFF
--- a/mon-aide-cyber-ui/src/Accueil.tsx
+++ b/mon-aide-cyber-ui/src/Accueil.tsx
@@ -180,7 +180,7 @@ export const Accueil = () => {
           </div>
           <div className="fr-container">
             <div id="ce-que-cest" className="fr-grid-row fr-grid-row--gutters">
-              <div className="fr-col-8">
+              <div className="fr-col-8 fr-col-sm-12">
                 <h2>Qu&apos;est-ce que MonAideCyber?</h2>
               </div>
               <div className="fr-col-md-6 fr-col-sm-12">

--- a/mon-aide-cyber-ui/src/assets/styles/_footer.scss
+++ b/mon-aide-cyber-ui/src/assets/styles/_footer.scss
@@ -22,7 +22,7 @@
     justify-content: center;
 
     img {
-      width: 182px;
+      width: 100px;
       height: auto;
     }
   }

--- a/mon-aide-cyber-ui/src/assets/styles/index.mobile-paysage.scss
+++ b/mon-aide-cyber-ui/src/assets/styles/index.mobile-paysage.scss
@@ -1,0 +1,82 @@
+@import 'etapes.mobile';
+
+@media screen and (min-width: 769px) and (max-width: 991px) {
+  .tuile-petite h4 {
+    font-size: 1.4rem;
+  }
+
+  .accueil {
+    height: 52rem;
+  }
+
+  .les-mots-de .titre {
+    margin-top: 56px;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+    line-height: 4.125rem;
+  }
+
+  h2 {
+    line-height: 3rem !important;
+    font-size: 2.6rem;
+  }
+
+  .tuile-grande {
+    @include tuile(31.4rem);
+    padding: 2.5rem 3.5rem;
+    gap: 1.5rem;
+
+    .illustration {
+      justify-content: flex-start;
+    }
+
+    img {
+      width: 100%;
+    }
+  }
+
+  .icone-se-connecter-mobile {
+    align-self: center;
+
+    button {
+      color: var(--couleurs-mac-violet-fonce) !important;
+    }
+  }
+
+  .taille-reduite-en-mobile {
+    display: block;
+    width: 80%;
+    margin: auto;
+  }
+
+  #guillemets {
+    width: 20%;
+  }
+
+  .les-mots-de {
+    display: flex;
+    padding: 8.5rem 0 5rem 0;
+    flex-direction: column;
+    align-items: center;
+    gap: 3rem;
+
+    .titre {
+      font-size: 1rem;
+      font-style: normal;
+      font-weight: 300;
+      line-height: 2.25rem;
+      color: var(--couleurs-mac-violet-tres-clair);
+    }
+
+    .contenu {
+      font-family: Spectral;
+      font-size: 1.5rem;
+      font-style: italic;
+      font-weight: 500;
+      line-height: 1.5rem;
+      text-align: center;
+    }
+  }
+}

--- a/mon-aide-cyber-ui/src/assets/styles/index.scss
+++ b/mon-aide-cyber-ui/src/assets/styles/index.scss
@@ -12,6 +12,7 @@
 @import 'accueil';
 @import 'index.desktop';
 @import 'index.mobile';
+@import 'index.mobile-paysage';
 @import 'modale';
 @import 'input';
 @import 'tableau-de-bord';


### PR DESCRIPTION
Corrige l'affichage des éléments :

- tuiles du hero
- mots du directeur
  - taille texte
  - taille guillemets
- padding des tuiles "participer"
- softwrap du titre "qu'est-ce que MAC"