### PR TITLE
[CORRECTION] Corrige l'erreur 500 remontée par MAC lors de la vérification des cookies

### DIFF
--- a/mon-aide-cyber-api/src/adaptateurs/AdaptateurDeVerificationDeSessionHttp.ts
+++ b/mon-aide-cyber-api/src/adaptateurs/AdaptateurDeVerificationDeSessionHttp.ts
@@ -45,7 +45,7 @@ export class AdaptateurDeVerificationDeSessionHttp
         throw ErreurMAC.cree(
           contexte,
           e instanceof ErreurMAC
-            ? e
+            ? e.erreurOriginelle
             : new ErreurAccesRefuse('Session invalide.'),
         );
       }

--- a/mon-aide-cyber-api/test/adaptateurs/AdaptateurDeVerificationDeSessionHttp.spec.ts
+++ b/mon-aide-cyber-api/test/adaptateurs/AdaptateurDeVerificationDeSessionHttp.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it, assert } from 'vitest';
 import { AdaptateurDeVerificationDeSessionHttp } from '../../src/adaptateurs/AdaptateurDeVerificationDeSessionHttp';
 import { FauxGestionnaireDeJeton } from '../infrastructure/authentification/FauxGestionnaireDeJeton';
 import { NextFunction } from 'express-serve-static-core';
@@ -36,12 +36,25 @@ describe('Adaptateur de vérification de session', () => {
       new AdaptateurDeVerificationDeSessionHttp(
         new FauxGestionnaireDeJeton(),
       ).verifie('Accès diagnostic')(requete, reponse, fausseSuite);
-    }).toThrow(
+    }).toThrowError(
       ErreurMAC.cree(
         'Accès diagnostic',
         new ErreurAccesRefuse('Cookie invalide.'),
       ),
     );
+  });
+
+  it("vérifie que l'erreur levée est de type Accès Refusé", () => {
+    try {
+      new AdaptateurDeVerificationDeSessionHttp(
+        new FauxGestionnaireDeJeton(),
+      ).verifie('Accès diagnostic')(requete, reponse, fausseSuite);
+      assert.fail('Ce test est sensé échouer');
+    } catch (e) {
+      expect((e as ErreurMAC).erreurOriginelle).toBeInstanceOf(
+        ErreurAccesRefuse,
+      );
+    }
   });
 
   it("lève une erreur quand le cookie de session envoyé n'est pas un cookie", () => {


### PR DESCRIPTION
**Contexte**
La vérification des cookies au niveau de MAC produit des erreurs.

**Reproduction**
- Se connecter à MAC
- Vider ses cookies dans la console de développement du navigateur
- Rafraîchir la page

**Résultat constaté**
- Le message suivant s'affiche
   <img width="1292" alt="Capture d’écran 2024-02-26 à 10 09 49" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/1587dfc9-ae56-4b7d-8f4c-3eee139d4758">

- Nous recevons une alerte sur Sentry
   <img width="317" alt="Capture d’écran 2024-02-26 à 10 03 38" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/e0410c6c-47e2-4730-ba9a-6e17cda29a2e">

- Une trace apparaît dans les logs de MAC
   <img width="1109" alt="Capture d’écran 2024-02-26 à 10 04 09" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/4b2708d8-dc8e-42cf-bc4b-0c5c002e60cc">

- Une erreur 500 est renvoyée par le serveur
   <img width="463" alt="Capture d’écran 2024-02-26 à 10 05 29" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/5fe2f77f-251e-411a-b13a-895b25aeb034">

**Résultat attendu**
- Devrait afficher un message à l'utilisateur disant que l'accès à la page demandée est interdit
- L'erreur remontée au niveau de Sentry doit être gérée
- MAC doit retourner une erreur HTTP 403 

