### PR TITLE
[DIAGNOSTIC] Corrige la manière dont est présentée la question sur les disques durs des matériels nomades

### DIFF
--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/transcripteur/transcripteurSecuritePoste.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/transcripteur/transcripteurSecuritePoste.ts
@@ -37,8 +37,10 @@ export const transcripteurSecuritePoste: Thematique = {
         {
           identifiant: 'securite-poste-outils-complementaires-securisation',
         },
-        { identifiant: 'securite-poste-r-et-d-disques-chiffres' },
       ],
+    },
+    {
+      questions: [{ identifiant: 'securite-poste-r-et-d-disques-chiffres' }],
     },
   ],
 };


### PR DESCRIPTION
**Contexte**
Présentation de la question `Si entité à risque d'espionnage, les disques durs des matériels nomades sont-ils chiffrés ?` dans la thématique sur la sécurité des postes.

**Reproduction**
- Lancer un diagnostic
- Se rendre sur la thématique `Sécurité des postes`
- Descendre jusqu'à la question 24

**Résultat constaté**
Les questions `Un outil complémentaire à un antivirus de type EDR a-t-il été mis en place ?` et `Si entité à risque d'espionnage, les disques durs des matériels nomades sont-ils chiffrés ?` sont regroupées (voir capture).

<img width="864" alt="Capture d’écran 2024-03-01 à 09 57 05" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/9db11469-9e00-4d52-afb4-e6fae63d103a">

**Résultat attendu**
Les 2 questions ne font pas partie du même groupe, la question `Si entité à risque d'espionnage, les disques durs des matériels nomades sont-ils chiffrés ?` est une question à part entière