### PR TITLE
[CORRECTION] Corrige le focus sur Me Déconnecter dans le menu utilisateur

### DIFF
--- a/mon-aide-cyber-ui/src/assets/styles/_menu-utilisateur.scss
+++ b/mon-aide-cyber-ui/src/assets/styles/_menu-utilisateur.scss
@@ -18,6 +18,7 @@
     position: absolute;
     right: 0;
     min-width: 18rem;
+    z-index: 10;
   }
 
   input {


### PR DESCRIPTION
**Menu utilisateur**

**Reproduction**
- Se connecter à MAC
- Cliquer sur le menu utilisateur
- Cliquer sur la partie gauche du bouton déconnecter (le bandeau devrait se mettre en sur-brillance, cf capture)
<img width="1143" alt="Capture d’écran 2024-03-05 à 09 38 34" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/8550e1a7-e5b6-4835-95c5-62e73244aa26">


**Résultat constaté**
L'utilisateur n'est pas déconnecté, il est redirigé vers la page d'accueil.

**Résultat attendu**
L'utilisateur est déconnecté