### PR TITLE
[CORRECTION] Corrige l’affichage des erreurs qui en cas de navigation empêche l’affichage des pages publiques

### DIFF
--- a/mon-aide-cyber-ui/src/composants/intercepteurs/ComposantIntercepteur.tsx
+++ b/mon-aide-cyber-ui/src/composants/intercepteurs/ComposantIntercepteur.tsx
@@ -1,8 +1,6 @@
 import { useParams } from 'react-router-dom';
 import React from 'react';
 import { UUID } from '../../types/Types.ts';
-import { ErrorBoundary } from 'react-error-boundary';
-import { ComposantAffichageErreur } from '../alertes/ComposantAffichageErreur.tsx';
 
 ('use client');
 type CommePropriete<C extends React.ElementType> = {
@@ -30,9 +28,5 @@ export const ComposantIntercepteur = <C extends React.ElementType = 'div'>({
   const Composant = composant || 'div';
   const params = useParams();
 
-  return (
-    <ErrorBoundary FallbackComponent={ComposantAffichageErreur}>
-      <Composant {...params} />
-    </ErrorBoundary>
-  );
+  return <Composant {...params} />;
 };

--- a/mon-aide-cyber-ui/src/main.tsx
+++ b/mon-aide-cyber-ui/src/main.tsx
@@ -25,97 +25,83 @@ import { RequiertEspaceAidant } from './fournisseurs/RequiertEspaceAidant.tsx';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <FournisseurMacAPI>
-        <FournisseurNavigationMAC>
-          <FournisseurAuthentification>
-            <PortailModale>
-              <Routes>
-                <Route
-                  path="/"
-                  element={
-                    <ErrorBoundary FallbackComponent={ComposantAffichageErreur}>
-                      <Accueil />
-                    </ErrorBoundary>
-                  }
-                />
-                <Route path="/cgu" element={<CGU />} />
-                <Route path="/charte-aidant" element={<CharteAidant />} />
-                <Route path="/mentions-legales" element={<MentionsLegales />} />
-
-                <Route
-                  element={
-                    <Suspense>
-                      <RequiertAuthentification />
-                    </Suspense>
-                  }
-                >
+    <ErrorBoundary FallbackComponent={ComposantAffichageErreur}>
+      <BrowserRouter>
+        <FournisseurMacAPI>
+          <FournisseurNavigationMAC>
+            <FournisseurAuthentification>
+              <PortailModale>
+                <Routes>
+                  <Route path="/" element={<Accueil />} />
+                  <Route path="/cgu" element={<CGU />} />
+                  <Route path="/charte-aidant" element={<CharteAidant />} />
+                  <Route
+                    path="/mentions-legales"
+                    element={<MentionsLegales />}
+                  />
                   <Route
                     element={
                       <Suspense>
-                        <RequiertAidantSansEspace />
+                        <RequiertAuthentification />
                       </Suspense>
                     }
                   >
                     <Route
-                      path="/finalise-creation-espace-aidant"
                       element={
-                        <ComposantIntercepteur
-                          composant={ComposantCreationEspaceAidant}
-                        />
+                        <Suspense>
+                          <RequiertAidantSansEspace />
+                        </Suspense>
                       }
-                    ></Route>
+                    >
+                      <Route
+                        path="/finalise-creation-espace-aidant"
+                        element={<ComposantCreationEspaceAidant />}
+                      ></Route>
+                    </Route>
+                    <Route
+                      element={
+                        <Suspense>
+                          <RequiertEspaceAidant />
+                        </Suspense>
+                      }
+                    >
+                      <Route
+                        path="/tableau-de-bord"
+                        element={<TableauDeBord />}
+                      ></Route>
+                      /
+                      <Route
+                        path="/diagnostics"
+                        element={<ComposantDiagnostics />}
+                      ></Route>
+                      <Route
+                        path="/diagnostic/:idDiagnostic"
+                        element={
+                          <ComposantIntercepteur
+                            composant={ComposantDiagnostic}
+                          />
+                        }
+                      ></Route>
+                      <Route
+                        path="/diagnostic/:idDiagnostic/restitution"
+                        element={
+                          <ComposantIntercepteur
+                            composant={ComposantRestitution}
+                          />
+                        }
+                      ></Route>
+                      <Route
+                        path="/profil"
+                        element={<ComposantProfil />}
+                      ></Route>
+                    </Route>
                   </Route>
-                  <Route
-                    element={
-                      <Suspense>
-                        <RequiertEspaceAidant />
-                      </Suspense>
-                    }
-                  >
-                    <Route
-                      path="/tableau-de-bord"
-                      element={
-                        <ComposantIntercepteur composant={TableauDeBord} />
-                      }
-                    ></Route>
-                    <Route
-                      path="/diagnostics"
-                      element={
-                        <ComposantIntercepteur
-                          composant={ComposantDiagnostics}
-                        />
-                      }
-                    ></Route>
-                    <Route
-                      path="/diagnostic/:idDiagnostic"
-                      element={
-                        <ComposantIntercepteur
-                          composant={ComposantDiagnostic}
-                        />
-                      }
-                    ></Route>
-                    <Route
-                      path="/diagnostic/:idDiagnostic/restitution"
-                      element={
-                        <ComposantIntercepteur
-                          composant={ComposantRestitution}
-                        />
-                      }
-                    ></Route>
-                    <Route
-                      path="/profil"
-                      element={
-                        <ComposantIntercepteur composant={ComposantProfil} />
-                      }
-                    ></Route>
-                  </Route>
-                </Route>
-              </Routes>
-            </PortailModale>
-          </FournisseurAuthentification>
-        </FournisseurNavigationMAC>
-      </FournisseurMacAPI>
-    </BrowserRouter>
+                </Routes>
+              </PortailModale>
+            </FournisseurAuthentification>
+          </FournisseurNavigationMAC>
+        </FournisseurMacAPI>
+      </BrowserRouter>
+    </ErrorBoundary>
   </React.StrictMode>,
 );


### PR DESCRIPTION
**Contexte**

Gestion des erreurs React dans le front

**Reproduction**

- se connecter avec un compte (avec ou sans espace)
- une fois connecté, allé sur la page /cgu ou charte-aidant

**Résultat attendu**

la page s’affiche correctement

**Résultat constaté**

la page reste blanche, la console développeur affiche une erreur

![2024-03-25_18-09](https://github.com/betagouv/mon-aide-cyber/assets/5832143/dabe0117-a6af-49f7-b546-5a90f9bbad24)



PI : En positionnant le ErrorBoundary au plus haut dans l'arbre React (main.tsx) l’erreur disparaît