### PR TITLE
[RESTITUTION] Ajoute la nouvelle règle de génération des mesures

### DIFF
--- a/mon-aide-cyber-api/src/diagnostic/Diagnostic.ts
+++ b/mon-aide-cyber-api/src/diagnostic/Diagnostic.ts
@@ -129,7 +129,7 @@ const genereLaRestitution = (diagnostic: Diagnostic) => {
     mesures: MesureDiagnostic[],
     valeursDesIndices: ValeursDesIndicesAuDiagnostic,
   ): MesurePriorisee[] => {
-    return mesures
+    const mesurePriorisees = mesures
       .map((mesure) => {
         const valeurObtenue = Object.values(valeursDesIndices)
           .flatMap((valeurReponse) => valeurReponse)
@@ -147,7 +147,9 @@ const genereLaRestitution = (diagnostic: Diagnostic) => {
         (mesure) =>
           mesure.valeurObtenue !== undefined && mesure.valeurObtenue !== null,
       )
-      .sort((a, b) => (a.priorisation < b.priorisation ? -1 : 1) || 0)
+      .sort((a, b) => (a.priorisation < b.priorisation ? -1 : 1) || 0);
+    const les8MesuresLesPlusPrioritaires = mesurePriorisees
+      .filter((mesure) => mesure.priorisation < 9)
       .sort(
         (a, b) =>
           (laValeurEstDefinie(a.valeurObtenue) &&
@@ -156,6 +158,18 @@ const genereLaRestitution = (diagnostic: Diagnostic) => {
             ? -1
             : 1) || 0,
       );
+    const lesAutresMesures = mesurePriorisees
+      .filter((mesure) => mesure.priorisation > 8)
+      .sort(
+        (a, b) =>
+          (laValeurEstDefinie(a.valeurObtenue) &&
+          laValeurEstDefinie(b.valeurObtenue) &&
+          a.valeurObtenue < b.valeurObtenue
+            ? -1
+            : 1) || 0,
+      );
+
+    return [...les8MesuresLesPlusPrioritaires, ...lesAutresMesures];
   };
   const mesuresPriorisees = prioriseLesMesures(mesures, valeursDesIndices);
 

--- a/mon-aide-cyber-api/test/diagnostic/Diagnostic.spec.ts
+++ b/mon-aide-cyber-api/test/diagnostic/Diagnostic.spec.ts
@@ -405,6 +405,126 @@ describe('Diagnostic', () => {
             },
           ]);
         });
+
+        it('en priorisant les 8 mesures les plus prioritaires quelque soit le niveau des autres', () => {
+          const mesures = desMesures()
+            .avecLesMesures([
+              {
+                q1: {
+                  niveau1: 'mesure 1',
+                  niveau2: 'mesure 12',
+                  priorisation: 3,
+                },
+              },
+              {
+                q2: {
+                  niveau1: 'mesure 2',
+                  niveau2: 'mesure 22',
+                  priorisation: 8,
+                },
+              },
+              {
+                q3: {
+                  niveau1: 'mesure 3',
+                  niveau2: 'mesure 32',
+                  priorisation: 9,
+                },
+              },
+            ])
+            .construis();
+          const questions = uneListeDeQuestions()
+            .dontLesLabelsSont(['q1', 'q2', 'q3'])
+            .avecLesReponsesPossiblesSuivantesAssociees([
+              {
+                libelle: 'reponse 1',
+                association: uneAssociation()
+                  .avecIdentifiant('q1')
+                  .deNiveau1()
+                  .ayantPourValeurDIndice(0)
+                  .construis(),
+              },
+              {
+                libelle: 'reponse 21',
+                association: uneAssociation()
+                  .avecIdentifiant('q1')
+                  .deNiveau2()
+                  .ayantPourValeurDIndice(1)
+                  .construis(),
+              },
+              {
+                libelle: 'reponse 2',
+                association: uneAssociation()
+                  .avecIdentifiant('q2')
+                  .deNiveau1()
+                  .ayantPourValeurDIndice(0)
+                  .construis(),
+              },
+              {
+                libelle: 'reponse 22',
+                association: uneAssociation()
+                  .avecIdentifiant('q2')
+                  .deNiveau2()
+                  .ayantPourValeurDIndice(1)
+                  .construis(),
+              },
+              {
+                libelle: 'reponse 3',
+                association: uneAssociation()
+                  .avecIdentifiant('q3')
+                  .deNiveau1()
+                  .ayantPourValeurDIndice(0)
+                  .construis(),
+              },
+              {
+                libelle: 'reponse 32',
+                association: uneAssociation()
+                  .avecIdentifiant('q3')
+                  .deNiveau2()
+                  .ayantPourValeurDIndice(1)
+                  .construis(),
+              },
+            ])
+            .construis();
+          const diagnostic = unDiagnostic()
+            .avecUnReferentiel(
+              unReferentiel()
+                .ajouteUneThematique('thematique', [...questions])
+                .construis(),
+            )
+            .avecLesReponsesDonnees('thematique', [
+              { q2: 'reponse-22' },
+              { q1: 'reponse-1' },
+              { q3: 'reponse-3' },
+            ])
+            .avecDesMesures(mesures)
+            .construis();
+
+          genereLaRestitution(diagnostic);
+
+          expect(
+            diagnostic.restitution?.mesures?.mesuresPrioritaires,
+          ).toStrictEqual<MesurePriorisee[]>([
+            {
+              priorisation: 3,
+              titre: 'mesure 1',
+              ...PARTIE_COMMUNE_ATTENDUE,
+            },
+            {
+              priorisation: 8,
+              titre: 'mesure 22',
+              ...PARTIE_COMMUNE_ATTENDUE,
+              valeurObtenue: 1,
+            },
+            {
+              priorisation: 9,
+              titre: 'mesure 3',
+              ...PARTIE_COMMUNE_ATTENDUE,
+            },
+          ]);
+          expect(diagnostic.restitution?.mesures?.autresMesures).toStrictEqual<
+            MesurePriorisee[]
+          >([]);
+        });
       });
 
       describe("pour des questions dont le résultat dépend d'une règle de calcul", () => {


### PR DESCRIPTION
Les 8 mesures les plus prioritaires (dont la priorisation est maximum 8) sont prises en compte dans la génération des mesures quelque soit leur niveau comparé aux mesures moins prioritaires.

Si un Aidé a répondu à une question, ayant une priorité entre 1 et 8, donnant lieu à une mesure de niveau 2, la mesure de niveau 2 est remontée dans les mesures priorisées (prioritaires ou autres mesures) avant toutes les mesures des questions ayant une priorité entre 9 et 34 (quelque soit le niveau de la mesure).

## Exemple

**Question A :**
- priorité 1
- réponses :
   - Oui
   - Non (niveau 1)
   - En cours (niveau 2)

**Question B :**
- priorité 2
- réponses :
   - Oui
   - Non (niveau 1)
   - En cours (niveau 2)

**Question C :**
- priorité 11
- réponses :
   - Oui (niveau 2)
   - Non (niveau 1)
‌

**Les réponses fournies par l’Aidé sont :**

1. Question A : En cours
2. Question B : Oui
3. Question C : Non

**Aujourd’hui le résultat des mesures priorisées donne :**
`[Question C - niveau 1, Question A - niveau 2]`

**Le résultat attendu, avec cette nouvelle règle, est :**
`[Question A - niveau 2, Question C - niveau 1]`