### PR TITLE
[CORRECTION] Corrige le bouton et le lien pour lancer un diagnostic

### DIFF
--- a/mon-aide-cyber-ui/src/composants/diagnostic/ComposantLancerDiagnostic.tsx
+++ b/mon-aide-cyber-ui/src/composants/diagnostic/ComposantLancerDiagnostic.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useCallback } from 'react';
+import { ReactElement, useCallback } from 'react';
 import { useErrorBoundary } from 'react-error-boundary';
 import { useNavigationMAC, useMACAPI } from '../../fournisseurs/hooks.ts';
 import { FormatLien, LienRoutage } from '../../domaine/LienRoutage.ts';
@@ -7,7 +7,44 @@ import { constructeurParametresAPI } from '../../fournisseurs/api/ConstructeurPa
 import { MoteurDeLiens } from '../../domaine/MoteurDeLiens.ts';
 import { Lien } from '../../domaine/Lien.ts';
 
-export const ComposantLancerDiagnostic = ({ children }: PropsWithChildren) => {
+type ProprietesComposant = {
+  surClick: () => void;
+};
+type ProprietesComposantLancerDiagnostic = {
+  composant: ({
+    surClick,
+  }: ProprietesComposant) => ReactElement<
+    HTMLButtonElement | HTMLAnchorElement
+  >;
+};
+
+export const ComposantBoutonLancerDiagnostic = ({
+  surClick,
+}: ProprietesComposant): ReactElement<HTMLButtonElement> => {
+  return (
+    <button className="bouton-mac bouton-mac-primaire" onClick={surClick}>
+      Lancer un diagnostic
+    </button>
+  );
+};
+
+export const ComposantLienLancerDiagnostic = ({
+  surClick,
+}: ProprietesComposant): ReactElement<HTMLAnchorElement> => {
+  return (
+    <a
+      href="#"
+      className="fr-icon-arrow-go-forward-line fr-link--icon-right"
+      onClick={surClick}
+    >
+      Lancer un diagnostic
+    </a>
+  );
+};
+
+export const ComposantLancerDiagnostic = ({
+  composant,
+}: ProprietesComposantLancerDiagnostic) => {
   const { showBoundary } = useErrorBoundary();
   const navigationMAC = useNavigationMAC();
   const macapi = useMACAPI();
@@ -46,5 +83,5 @@ export const ComposantLancerDiagnostic = ({ children }: PropsWithChildren) => {
     );
   }, [navigationMAC.etat, lanceDiagnostic]);
 
-  return <div onClick={lancerDiagnostic}>{children}</div>;
+  return composant({ surClick: lancerDiagnostic });
 };

--- a/mon-aide-cyber-ui/src/composants/espace-aidant/tableau-de-bord/ComposantDiagnostics.tsx
+++ b/mon-aide-cyber-ui/src/composants/espace-aidant/tableau-de-bord/ComposantDiagnostics.tsx
@@ -1,4 +1,8 @@
-import { ComposantLancerDiagnostic } from '../../diagnostic/ComposantLancerDiagnostic.tsx';
+import {
+  ComposantBoutonLancerDiagnostic,
+  ComposantLancerDiagnostic,
+  ComposantLienLancerDiagnostic,
+} from '../../diagnostic/ComposantLancerDiagnostic.tsx';
 import { ComposantIdentifiantDiagnostic } from '../../ComposantIdentifiantDiagnostic.tsx';
 import { Diagnostic } from './TableauDeBord.tsx';
 import { useCallback } from 'react';
@@ -48,11 +52,9 @@ export const ComposantDiagnostics = ({
     ) : (
       <div className="fr-col-10 fr-col-offset-2">
         <h4>Vous n’avez pas encore effectué de diagnostic. </h4>
-        <ComposantLancerDiagnostic>
-          <button className="bouton-mac bouton-mac-primaire">
-            Lancer un diagnostic
-          </button>
-        </ComposantLancerDiagnostic>
+        <ComposantLancerDiagnostic
+          composant={ComposantBoutonLancerDiagnostic}
+        />
       </div>
     );
 
@@ -77,14 +79,9 @@ export const ComposantDiagnostics = ({
                     diagnostic et de validation des CGU :
                   </div>
                   <br />
-                  <ComposantLancerDiagnostic>
-                    <a
-                      href="#"
-                      className="fr-icon-arrow-go-forward-line fr-link--icon-right"
-                    >
-                      Lancer un diagnostic
-                    </a>
-                  </ComposantLancerDiagnostic>
+                  <ComposantLancerDiagnostic
+                    composant={ComposantLienLancerDiagnostic}
+                  />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Contexte

Lorsque l’on est sur la page **Mes diagnostics** , on peut lancer un diagnostic en cliquant à côté du bouton `Lancer un diagnostic`.

## Reproduction

- Se connecter à son espace Aidant
- Cliquer sur la ligne à côté du bouton Lancer un diagnostic (cf capture ci-dessous)

<img width="1337" alt="Capture d’écran 2024-05-06 à 12 16 27" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/128caff1-4f75-466b-8401-9eb2734247c0">


## Résultat constaté

Un diagnostic est lancé, on se retrouve sur la page d’un nouveau diagnostic

## Résultat attendu

Cliquer en dehors du bouton ne doit pas lancer un nouveau diagnostic