### PR TITLE
[CORRECTION] Modifie l’identifiant de la réponse à la question sur les EDR

### DIFF
--- a/mon-aide-cyber-api/src/diagnostic/referentiel/donneesSecuritePoste.ts
+++ b/mon-aide-cyber-api/src/diagnostic/referentiel/donneesSecuritePoste.ts
@@ -305,7 +305,7 @@ export const donneesSecuritePoste: QuestionsThematique = {
         },
         {
           identifiant:
-            'securite-poste-outils-complementaires-securisation-oui-outil-complementaire-type-edr',
+            'securite-poste-outils-complementaires-securisation-oui-systematique-outil-complementaire-type-edr',
           libelle:
             'Oui, un outil de type EDR a été mis en place et ses alertes sont systématiquement traitées',
           resultat: { indice: { valeur: 3 } },
@@ -317,7 +317,7 @@ export const donneesSecuritePoste: QuestionsThematique = {
     {
       identifiant: 'securite-poste-r-et-d-disques-chiffres',
       libelle:
-        "Si entité avec risque d’espionnage ciblé, les disques durs des matériels nomades sont-ils chiffrés ?",
+        'Si entité avec risque d’espionnage ciblé, les disques durs des matériels nomades sont-ils chiffrés ?',
       poids: 2,
       reponsesPossibles: [
         {

--- a/mon-aide-cyber-api/test/diagnostic/coherenceDiagnostic.spec.ts
+++ b/mon-aide-cyber-api/test/diagnostic/coherenceDiagnostic.spec.ts
@@ -81,4 +81,35 @@ describe('Cohérence du référentiel et des mesures', () => {
       });
     },
   );
+
+  it('Les réponses sont uniques', () => {
+    const toutesLesReponses = Object.entries(referentiel)
+      .filter(([thematique]) => thematique !== 'contexte')
+      .flatMap(([_, questions]) => {
+        return {
+          reponses: questions.questions.flatMap((q) => {
+            const identifiants: string[] = [];
+            return q.reponsesPossibles.reduce((prev, cur) => {
+              prev.push(cur.identifiant);
+              if (cur.questions) {
+                const strings = cur.questions
+                  ?.flatMap((q) =>
+                    q.reponsesPossibles.flatMap((r) => r.identifiant),
+                  )
+                  .filter((r) => !!r);
+                prev.push(...strings);
+              }
+              return prev;
+            }, identifiants);
+          }),
+        };
+      })
+      .flatMap((r) => r.reponses);
+
+    const set = toutesLesReponses.reduce((prev, curr) => {
+      return new Set([...prev, curr]);
+    }, new Set());
+
+    expect(toutesLesReponses.length).toStrictEqual(set.size);
+  });
 });


### PR DESCRIPTION
# Bug
## Contexte
Lors d'un diagnostic et de l'accès à la restitution.

## Reproduction
À la question "25. En complément de l'antivirus, un outil de type EDR a-t-il été mis en place ?"
Répondre 'Oui, un outil de type EDR a été mis en place et ses alertes sont systématiquement traitées'

## Résultat constaté
La restitution est faussé puisque la mesure "Traiter systématiquement les alertes générées par l'EDR" est proposé.

## Comportement attendu
La mesure  "Traiter systématiquement les alertes générées par l'EDR" ne doit pas s'afficher lorsque la réponse 'Oui, un outil de type EDR a été mis en place et ses alertes sont systématiquement traitées' est cochée.