### PR TITLE
[CORRECTION] Corrige le problème de traitement asynchrone lors de la consommation d’événements par le bus d’événements

### DIFF
--- a/mon-aide-cyber-api/src/infrastructure/bus/BusEvenementMAC.ts
+++ b/mon-aide-cyber-api/src/infrastructure/bus/BusEvenementMAC.ts
@@ -10,11 +10,12 @@ export class BusEvenementMAC implements BusEvenement {
     private readonly consomateurs: Map<TypeEvenement, ConsommateurEvenement[]>,
   ) {}
 
-  publie<E extends Evenement>(evenement: E): Promise<void> {
-    return (
-      this.consomateurs
-        .get(evenement.type)
-        ?.forEach((value) => value.consomme(evenement)) || Promise.resolve()
-    );
+  async publie<E extends Evenement>(evenement: E): Promise<void> {
+    const consommateurEvenements = this.consomateurs.get(evenement.type);
+    if (consommateurEvenements) {
+      for (const consommateurEvenement of consommateurEvenements) {
+        await consommateurEvenement.consomme(evenement);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Contexte
Import des Aidants

## Reproduction
- Prendre un fichier d’Aidants à importer
- Importer les Aidants
- Constater que les comptes utilisateurs ont bien été créés
- Vérifier le nombre d’événements `AIDANT_CREE` dans Metabase

## Résultat constaté
Le nombre d’événements `AIDANT_CREE` dans Metabase ne correspond pas au nombre de comptes Aidants réellement créés

**Exécution de l’import d’Aidants**
<img width="1143" alt="Capture d’écran 2024-06-07 à 10 15 23" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/da4a336b-e91f-4841-99d7-7441cdbc2147">

**Aidants créés dans MAC**
<img width="190" alt="Capture d’écran 2024-06-07 à 10 16 21" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/3dc7ad1b-f3fc-4e30-848c-4fe21812bc52">

**Nombre d’événements `AIDANT_CREE` dans Metabase**
<img width="237" alt="Capture d’écran 2024-06-07 à 10 16 03" src="https://github.com/betagouv/mon-aide-cyber/assets/5832143/f6499dba-63a9-49f5-99e5-f74e8b903a40">

## Résultat attendu
Le nombre d’événements `AIDANT_CREE` dans Metabase doit correspondre aux nombre de comptes effectivement créés.