### PR TITLE
[CORRECTION][DIAGNOSTIC] Corrige la faute de grammaire sur les réponses à la question sur les accès distants aux systèmes industriels

### DIFF
--- a/mon-aide-cyber-api/src/diagnostic/referentiel/donneesSecuriteAcces.ts
+++ b/mon-aide-cyber-api/src/diagnostic/referentiel/donneesSecuriteAcces.ts
@@ -521,7 +521,7 @@ export const donneesSecuriteAcces: QuestionsThematique = {
           identifiant:
             'acces-si-industriel-teletravail-acces-distants-mesures-particulieres-mfa',
           libelle:
-            'Certaines connexions à distance sont protégés par une authentification multifacteur',
+            'Certaines connexions à distance sont protégées par une authentification multifacteur',
           resultat: {
             indice: { valeur: 1 },
             mesures: [
@@ -538,7 +538,7 @@ export const donneesSecuriteAcces: QuestionsThematique = {
           identifiant:
             'acces-si-industriel-teletravail-acces-distants-mesures-particulieres-vpn',
           libelle:
-            'Toutes les connexions à distance sont protégés par une authentification multifacteur',
+            'Toutes les connexions à distance sont protégées par une authentification multifacteur',
           resultat: { indice: { valeur: 3 } },
           ordre: 4,
         },


### PR DESCRIPTION
Accorder protégés en protégées