### PR TITLE
[CORRECTION][TABLEAU DE BORD] Corrige la manière dont est récupéré le contexte des diagnostics

### DIFF
--- a/mon-aide-cyber-api/src/diagnostic/Diagnostic.ts
+++ b/mon-aide-cyber-api/src/diagnostic/Diagnostic.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto, { UUID } from 'crypto';
 import { Mesure, Question, Referentiel } from './Referentiel';
 import { Entrepot } from '../domaine/Entrepot';
 import { laValeurEstDefinie, Valeur } from './Indice';
@@ -69,7 +69,11 @@ type Diagnostic = Aggregat & {
   mesures: ReferentielDeMesures;
 };
 
-type EntrepotDiagnostic = Entrepot<Diagnostic>;
+interface EntrepotDiagnostic extends Entrepot<Diagnostic> {
+  tousLesDiagnosticsAyantPourIdentifiant(
+    identifiantDiagnosticsLie: UUID[]
+  ): Promise<Diagnostic[]>;
+}
 
 const initialiseDiagnostic = (
   r: Referentiel,

--- a/mon-aide-cyber-api/src/espace-aidant/tableau-de-bord/ServiceTableauDeBord.ts
+++ b/mon-aide-cyber-api/src/espace-aidant/tableau-de-bord/ServiceTableauDeBord.ts
@@ -1,5 +1,5 @@
 import { AdaptateurRelations } from '../../relation/AdaptateurRelations';
-import crypto from 'crypto';
+import crypto, { UUID } from 'crypto';
 import { ServiceDiagnostic } from '../../diagnostic/ServiceDiagnostic';
 import { FournisseurHorloge } from '../../infrastructure/horloge/FournisseurHorloge';
 
@@ -22,33 +22,23 @@ export class ServiceTableauDeBord {
     const identifiantDiagnosticsLie =
       await this.adaptateurRelation.diagnosticsInitiePar(identifiantAidant);
 
-    const contextes = identifiantDiagnosticsLie.map(
-      async (identifiantDiagnostic) => {
-        const contexte = await this.serviceDiagnostic.contexte(
-          identifiantDiagnostic as crypto.UUID
-        );
-        return { ...contexte, identifiantDiagnostic };
-      }
-    );
-
-    return Promise.all(contextes)
-      .then((contextes) =>
-        contextes.sort((contexte1, contexte2) =>
+    return this.serviceDiagnostic
+      .contextes(identifiantDiagnosticsLie as UUID[])
+      .then((diagnostics) => {
+        const resultat: Diagnostic[] = [];
+        for (const [id, contexte] of Object.entries(diagnostics)) {
+          resultat.push({
+            dateCreation: FournisseurHorloge.formateDate(contexte.dateCreation)
+              .date,
+            identifiant: id,
+            secteurActivite: contexte.secteurActivite || 'non renseigné',
+            secteurGeographique: contexte.departement || 'non renseigné',
+          } as Diagnostic);
+        }
+        resultat.sort((contexte1, contexte2) =>
           contexte1.dateCreation > contexte2.dateCreation ? -1 : 1
-        )
-      )
-      .then((contextes) =>
-        contextes.map(
-          (contexte) =>
-            ({
-              dateCreation: FournisseurHorloge.formateDate(
-                contexte.dateCreation
-              ).date,
-              identifiant: contexte.identifiantDiagnostic,
-              secteurActivite: contexte.secteurActivite || 'non renseigné',
-              secteurGeographique: contexte.departement || 'non renseigné',
-            }) as Diagnostic
-        )
-      );
+        );
+        return resultat;
+      });
   }
 }

--- a/mon-aide-cyber-api/src/infrastructure/entrepots/memoire/EntrepotMemoire.ts
+++ b/mon-aide-cyber-api/src/infrastructure/entrepots/memoire/EntrepotMemoire.ts
@@ -2,7 +2,7 @@ import { Aggregat, AggregatNonTrouve } from '../../../domaine/Aggregat';
 import { Entrepot } from '../../../domaine/Entrepot';
 import { Diagnostic, EntrepotDiagnostic } from '../../../diagnostic/Diagnostic';
 import { cloneDeep } from 'lodash';
-import crypto from 'crypto';
+import crypto, { UUID } from 'crypto';
 
 import {
   EntrepotEvenementJournal,
@@ -50,6 +50,16 @@ export class EntrepotDiagnosticMemoire
 {
   typeAggregat(): string {
     return 'diagnostic';
+  }
+
+  tousLesDiagnosticsAyantPourIdentifiant(
+    identifiantDiagnosticsLie: UUID[]
+  ): Promise<Diagnostic[]> {
+    return Promise.resolve(
+      identifiantDiagnosticsLie
+        .map((id) => this.entites.get(id))
+        .filter((d): d is Diagnostic => !!d)
+    );
   }
 }
 

--- a/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotDiagnosticPostgres.ts
+++ b/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotDiagnosticPostgres.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../diagnostic/Diagnostic';
 import { DTO, EntrepotPostgres } from './EntrepotPostgres';
 import { FournisseurHorloge } from '../../horloge/FournisseurHorloge';
+import { UUID } from 'crypto';
 
 export type DiagnosticDTO = DTO & {
   donnees: object;
@@ -88,6 +89,15 @@ export class EntrepotDiagnosticPostgres
       }),
       {}
     );
+  }
+
+  tousLesDiagnosticsAyantPourIdentifiant(
+    identifiantDiagnosticsLie: UUID[]
+  ): Promise<Diagnostic[]> {
+    return this.knex
+      .from(this.nomTable())
+      .whereIn('id', identifiantDiagnosticsLie)
+      .then((lignes) => lignes.map((ligne) => this.deDTOAEntite(ligne)));
   }
 }
 

--- a/mon-aide-cyber-api/test/diagnostic/ServiceDiagnostic.spec.ts
+++ b/mon-aide-cyber-api/test/diagnostic/ServiceDiagnostic.spec.ts
@@ -168,11 +168,11 @@ describe('Le service de diagnostic', () => {
       const diagnostic = unDiagnosticEnGironde().construis();
       await entrepots.diagnostic().persiste(diagnostic);
 
-      const contexte = await new ServiceDiagnostic(entrepots).contexte(
-        diagnostic.identifiant
-      );
+      const contexte = await new ServiceDiagnostic(entrepots).contextes([
+        diagnostic.identifiant,
+      ]);
 
-      expect(contexte).toStrictEqual<Contexte>({
+      expect(contexte[diagnostic.identifiant]).toStrictEqual<Contexte>({
         dateCreation,
         departement: 'Gironde',
       });
@@ -184,11 +184,14 @@ describe('Le service de diagnostic', () => {
         unDiagnosticAvecSecteurActivite(secteurActivite).construis();
       await entrepots.diagnostic().persiste(diagnostic);
 
-      const contexte = await new ServiceDiagnostic(entrepots).contexte(
-        diagnostic.identifiant
-      );
+      const contexte = await new ServiceDiagnostic(entrepots).contextes([
+        diagnostic.identifiant,
+      ]);
 
-      expect(contexte).toStrictEqual({ dateCreation, secteurActivite });
+      expect(contexte[diagnostic.identifiant]).toStrictEqual({
+        dateCreation,
+        secteurActivite,
+      });
     });
 
     it('retourne les informations de contexte lorsque renseignées', async () => {
@@ -202,11 +205,11 @@ describe('Le service de diagnostic', () => {
       ).construis();
       await entrepots.diagnostic().persiste(diagnostic);
 
-      const contexte = await new ServiceDiagnostic(entrepots).contexte(
-        diagnostic.identifiant
-      );
+      const contexte = await new ServiceDiagnostic(entrepots).contextes([
+        diagnostic.identifiant,
+      ]);
 
-      expect(contexte).toStrictEqual<Contexte>({
+      expect(contexte[diagnostic.identifiant]).toStrictEqual<Contexte>({
         departement,
         secteurActivite,
         dateCreation,
@@ -217,11 +220,46 @@ describe('Le service de diagnostic', () => {
       const diagnostic = unDiagnostic().construis();
       await entrepots.diagnostic().persiste(diagnostic);
 
-      const contexte = await new ServiceDiagnostic(entrepots).contexte(
-        diagnostic.identifiant
-      );
+      const contexte = await new ServiceDiagnostic(entrepots).contextes([
+        diagnostic.identifiant,
+      ]);
 
-      expect(contexte).toStrictEqual<Contexte>({ dateCreation });
+      expect(contexte[diagnostic.identifiant]).toStrictEqual<Contexte>({
+        dateCreation,
+      });
+    });
+  });
+
+  describe('Lorsque l’on veut récupérer les contextes de plusieurs diagnostics', () => {
+    it('retourne les informations du contexte pour chacun des diagnostics', async () => {
+      const dateCreation = new Date(Date.parse('2024-02-05T12:00:00+02:00'));
+      FournisseurHorlogeDeTest.initialise(dateCreation);
+      const diagnostic1 = unDiagnosticDansLeDepartementAvecSecteurActivite(
+        'Finistère',
+        'activité 1'
+      ).construis();
+      const diagnostic2 = unDiagnosticDansLeDepartementAvecSecteurActivite(
+        'Ile-et-vilaine',
+        'activité 2'
+      ).construis();
+      await entrepots.diagnostic().persiste(diagnostic1);
+      await entrepots.diagnostic().persiste(diagnostic2);
+
+      const contexte = await new ServiceDiagnostic(entrepots).contextes([
+        diagnostic1.identifiant,
+        diagnostic2.identifiant,
+      ]);
+
+      expect(contexte[diagnostic1.identifiant]).toStrictEqual<Contexte>({
+        departement: 'Finistère',
+        secteurActivite: 'activité 1',
+        dateCreation,
+      });
+      expect(contexte[diagnostic2.identifiant]).toStrictEqual<Contexte>({
+        departement: 'Ile-et-vilaine',
+        secteurActivite: 'activité 2',
+        dateCreation,
+      });
     });
   });
 });

--- a/mon-aide-cyber-api/test/diagnostic/ServiceDiagnosticTest.ts
+++ b/mon-aide-cyber-api/test/diagnostic/ServiceDiagnosticTest.ts
@@ -3,7 +3,7 @@ import {
   ServiceDiagnostic,
 } from '../../src/diagnostic/ServiceDiagnostic';
 import { EntrepotsMemoire } from '../../src/infrastructure/entrepots/memoire/EntrepotsMemoire';
-import crypto from 'crypto';
+import { UUID } from 'crypto';
 import { unContexteVide } from './ConstructeurContexte';
 
 export class ServiceDiagnosticTest extends ServiceDiagnostic {
@@ -11,10 +11,14 @@ export class ServiceDiagnosticTest extends ServiceDiagnostic {
     super(new EntrepotsMemoire());
   }
 
-  contexte = async (identifiantDiagnostic: crypto.UUID): Promise<Contexte> => {
-    return (
-      this.diagnostics.get(identifiantDiagnostic) ||
-      unContexteVide().construis()
-    );
+  contextes = async (
+    identifiantDiagnosticsLie: UUID[]
+  ): Promise<Record<UUID, Contexte>> => {
+    return identifiantDiagnosticsLie.reduce((prev, curr) => {
+      return {
+        ...prev,
+        [curr]: this.diagnostics.get(curr) || unContexteVide().construis(),
+      };
+    }, {});
   };
 }

--- a/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotDiagnosticPostgres.spec.ts
+++ b/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotDiagnosticPostgres.spec.ts
@@ -52,4 +52,20 @@ describe('Entrepot Diagnostic Postgres', () => {
       await entrepotDiagnosticPostgresLecture.lis(diagnostic.identifiant)
     ).toStrictEqual(diagnostic);
   });
+
+  it('Récupère les diagnostics pour les identifiants donnés', async () => {
+    const diagnostic1 = unDiagnostic().construis();
+    const diagnostic2 = unDiagnostic().construis();
+
+    await new EntrepotDiagnosticPostgres().persiste(diagnostic1);
+    await new EntrepotDiagnosticPostgres().persiste(diagnostic2);
+
+    const entrepotDiagnosticPostgresLecture =
+      await new EntrepotDiagnosticPostgres();
+    expect(
+      await entrepotDiagnosticPostgresLecture.tousLesDiagnosticsAyantPourIdentifiant(
+        [diagnostic1.identifiant, diagnostic2.identifiant]
+      )
+    ).toStrictEqual([diagnostic1, diagnostic2]);
+  });
 });


### PR DESCRIPTION
**Contexte**
Tableau de bord Aidant

**Description**
Une alerte [Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/108102/?project=125&referrer=webhooks_plugin) est remontée lorsque l’on charge le TDB. Il s’agit d’une erreur SELECT N+1.

**Reproduction**
- Configurer Sentry sur son environnement de développement || Faire le test en démo
- Se connecter à son espace Aidant

**Résultat constaté**
Une erreur Sentry est levée (Sur Mattermost et dans Sentry)
<img width="470" alt="Capture d’écran 2024-08-12 à 17 20 02" src="https://github.com/user-attachments/assets/173d3d20-1d9a-496f-a085-1039305436ab">
<img width="726" alt="Capture d’écran 2024-08-12 à 17 20 34" src="https://github.com/user-attachments/assets/5aea7f7d-10dc-49fc-9525-3c8d2b790635">

**Résultat attendu**
Plus aucune erreur du type `SELECT N+1` n’est remontée sur Sentry et dans Mattermost

**NB :**
Techniquement, nous récupérons la liste des identifiants des diagnostics de l’Aidant puis nous bouclons sur chacun d’entre eux afin de faire la requête vers le diagnostic correspondant.
Une requête du type `SELECT * FROM diagnostics WHERE id IN (LISTE_DIAGNOSTIC)` règlerait le problème