### PR TITLE
[CORRECTION][DIAGNOSTIC] Corrige le lancement du diagnostic qui ne s’affichait plus

### DIFF
--- a/mon-aide-cyber-ui/src/composants/diagnostic/ComposantLancerDiagnostic.tsx
+++ b/mon-aide-cyber-ui/src/composants/diagnostic/ComposantLancerDiagnostic.tsx
@@ -157,13 +157,13 @@ export const ComposantLancerDiagnostic = ({
         .then((lien) => {
           return navigationMAC.navigue(
             new MoteurDeLiens({
-              'afficher-diagnostic': {
-                url: '',
+              'modifier-diagnostic': {
+                url: lien.url(),
                 route: lien.route(),
                 methode: 'GET',
               },
             }),
-            'afficher-diagnostic'
+            'modifier-diagnostic'
           );
         })
         .catch((erreur) => showBoundary(erreur));

--- a/mon-aide-cyber-ui/src/composants/diagnostic/ComposantRestitution/useComposantRestitution.ts
+++ b/mon-aide-cyber-ui/src/composants/diagnostic/ComposantRestitution/useComposantRestitution.ts
@@ -102,7 +102,6 @@ export const useComposantRestitution = (idDiagnostic: UUID) => {
       'modifier-diagnostic',
       'restitution-pdf',
       'restitution-json',
-      'afficher-diagnostic',
     ]);
   }, [etatRestitution.restitution, navigationMAC]);
 

--- a/mon-aide-cyber-ui/src/domaine/Lien.ts
+++ b/mon-aide-cyber-ui/src/domaine/Lien.ts
@@ -11,7 +11,6 @@ export type ReponseHATEOAS = {
   liens: Liens;
 };
 export type Action =
-  | 'afficher-diagnostic'
   | `afficher-diagnostic-${UUID}`
   | 'afficher-profil'
   | 'afficher-tableau-de-bord'

--- a/mon-aide-cyber-ui/src/domaine/LienRoutage.ts
+++ b/mon-aide-cyber-ui/src/domaine/LienRoutage.ts
@@ -6,4 +6,8 @@ export class LienRoutage {
   route(): string {
     return this.lien.slice(this.lien.indexOf('/api') + 4);
   }
+
+  url(): string {
+    return this.lien;
+  }
 }


### PR DESCRIPTION
**Contexte**
Lancer un diagnostic

**Description**
Lorsque l’on veut commencer un diagnostic, une page blanche s’affiche en lieu et place du diagnostic

**Reproduction**
- Se connecter à son espace Aidant
- Cliquer sur le bouton `Créer un diagnostic`
- Valider la modale et cliquer sur `Commencer le diagnostic`

**Résultat constaté**
Le diagnostic est vide 
<img width="1946" alt="Capture d’écran 2024-09-10 à 11 42 06" src="https://github.com/user-attachments/assets/d019b5a3-8dd8-4092-b9f0-d708b7870caf">

**Résultat attendu**
Le diagnostic est affiché

**NB :**
Cette erreur est due à un remaniement que l’on a fait et qui a été mal testé. 
La correction apportée va empêcher le rafraîchissement de la page. Une correction sera apportée ultérieurement lorsque nous ferons évoluer le moteur HATEOAS
