### PR TITLE
[CORRECTION][INDICATEURS] Ajoute un traite entre chaque indicateur du graphe polaire

### DIFF
--- a/mon-aide-cyber-api/src/infrastructure/restitution/html/modeles/graphe-polaire.pug
+++ b/mon-aide-cyber-api/src/infrastructure/restitution/html/modeles/graphe-polaire.pug
@@ -11,7 +11,7 @@ svg(viewbox=`0 -5 ${size} ${height}` class="indicateur-polaire")
   each v, i in values
     - const startAngle = angleStep * i - Math.PI / 2;
     - const r = v !== 0 ? (v  / valueMax) * radius : 2
-    path(d=pathForSlice(r, startAngle, startAngle + angleStep) fill=colors[i])
+    path(d=pathForSlice(r, startAngle, startAngle + angleStep) fill=colors[i] stroke='#ffffff' stroke-width=1)
   each i in new Array(5).fill(0).map((_, i) => i + 1)
     - const r = i / 5 * radius;
     - const ordinateCoordinate = (-(i-5) / 5 * radius) - 1.5


### PR DESCRIPTION
**Contexte**
Affichage des indicateurs lors de la restitution.

**Reproduction**
- Initier un diagnostic
- Répondre aux questions de toutes les thématiques
- Cliquer sur `Accéder à la restitution`

**Résultat constaté**
Les éléments de chaque indicateurs sont trop rapprochés les uns des autres ce qui pose des problèmes d’accessibilité

<img width="869" alt="Capture d’écran 2024-09-23 à 15 48 50" src="https://github.com/user-attachments/assets/d8acebfb-46d0-43d1-a657-3f0e8121e6f6">


**Résultat attendu**
Les éléments de chaque indicateurs doivent être séparés par une bordure pour facilité l’accessibilité 