### PR TITLE
[CORRECTION][ANNUAIRE AIDANTS] Corrige le formatage du nom de l’Aidant

### DIFF
--- a/mon-aide-cyber-api/src/annuaire-aidants/ServiceAnnuaireAidants.ts
+++ b/mon-aide-cyber-api/src/annuaire-aidants/ServiceAnnuaireAidants.ts
@@ -7,9 +7,9 @@ export type CriteresDeRecherche = {
 export class ServiceAnnuaireAidants {
   constructor(private readonly entrepotAidant: EntrepotAnnuaireAidants) {}
 
-  formateLeNom(nomPrenom: string): string {
+  private formateLeNom(nomPrenom: string): string {
     const [prenom, nom] = nomPrenom.split(' ');
-    return `${prenom} ${nom[0]}.`;
+    return `${prenom} ${nom ? `${nom[0]}.` : ''}`.trim();
   }
 
   recherche(

--- a/mon-aide-cyber-api/test/annuaire-aidants/ServiceAnnuaireAidants.spec.ts
+++ b/mon-aide-cyber-api/test/annuaire-aidants/ServiceAnnuaireAidants.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it } from 'vitest';
+import { Aidant } from '../../src/annuaire-aidants/annuaireAidants';
+import { unAidant } from './constructeurAidant';
+import { EntrepotAnnuaireAidantsMemoire } from '../../src/infrastructure/entrepots/memoire/EntrepotMemoire';
+import { ServiceAnnuaireAidants } from '../../src/annuaire-aidants/ServiceAnnuaireAidants';
+
+describe('Service d’annuaire des Aidants', () => {
+  it('Formate le nom des Aidants', async () => {
+    const jean = unAidant().avecNomPrenom('Jean').construis();
+    const martin = unAidant().avecNomPrenom('Martin N').construis();
+    const entrepot = new EntrepotAnnuaireAidantsMemoire();
+    await entrepot.persiste(jean);
+    await entrepot.persiste(martin);
+
+    const aidants = await new ServiceAnnuaireAidants(entrepot).recherche(
+      undefined
+    );
+
+    expect(aidants).toStrictEqual<Aidant[]>([
+      { identifiant: expect.any(String), nomPrenom: 'Jean', departements: [] },
+      {
+        identifiant: expect.any(String),
+        nomPrenom: 'Martin N.',
+        departements: [],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
**Contexte**
Annuaire des Aidants.

Lorsque l’on se rend sur l’annuaire des Aidants, l’annuaire ne se charge pas.

**Reproduction**
- Créer un Aidant avec juste un prénom
- Se rendre sur l’annuaire

**Résultat constaté**
La page affiche chargement des Aidants
<img width="1112" alt="Capture d’écran 2024-10-18 à 16 50 00" src="https://github.com/user-attachments/assets/59e68a89-2eca-416c-a12c-5c6e4cad1375">

Les logs applicatifs affichent 

```
2024-10-18 16:24:12.876126472 +0200 CEST[web-1] TypeError: Cannot read properties of undefined (reading '0')
2024-10-18 16:24:12.876127270 +0200 CEST[web-1] at ServiceAnnuaireAidants.formateLeNom (/app/mon-aide-cyber-api/src/annuaire-aidants/ServiceAnnuaireAidants.ts:12:28)
2024-10-18 16:24:12.876127730 +0200 CEST[web-1] at /app/mon-aide-cyber-api/src/annuaire-aidants/ServiceAnnuaireAidants.ts:23:27
2024-10-18 16:24:12.876128627 +0200 CEST[web-1] at /app/mon-aide-cyber-api/src/annuaire-aidants/ServiceAnnuaireAidants.ts:21:24
2024-10-18 16:24:12.876128127 +0200 CEST[web-1] at Array.map (<anonymous>)
2024-10-18 16:24:12.876129025 +0200 CEST[web-1] at processTicksAndRejections (node:internal/process/task_queues:95:5)
2024-10-18 16:24:34.504249933 +0200 CEST[web-1] This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise
```

**Résultat attendu**
La liste des Aidants s’affiche correctement

