### PR TITLE
[CORRECTION][DEMANDE DEVENIR AIDANT] Corrige la saisie du mail de la demande en la mettant en minuscule

### DIFF
--- a/mon-aide-cyber-api/src/api/demandes/routeAPIDemandeDevenirAidant.ts
+++ b/mon-aide-cyber-api/src/api/demandes/routeAPIDemandeDevenirAidant.ts
@@ -98,7 +98,7 @@ export const routesAPIDemandesDevenirAidant = (
         const commande: CommandeDevenirAidant = {
           type: 'CommandeDevenirAidant',
           departement: rechercheParNomDepartement(requete.body.departement),
-          mail: requete.body.mail,
+          mail: requete.body.mail.toLowerCase(),
           nom: requete.body.nom,
           prenom: requete.body.prenom,
         };

--- a/mon-aide-cyber-api/test/api/demandes/routeAPIDemandeDevenirAidant.spec.ts
+++ b/mon-aide-cyber-api/test/api/demandes/routeAPIDemandeDevenirAidant.spec.ts
@@ -78,6 +78,28 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
       });
     });
 
+    it('Réponds OK à la requête lorsque le mail contient des majuscules', async () => {
+      const reponse = await executeRequete(
+        donneesServeur.app,
+        'POST',
+        '/api/demandes/devenir-aidant',
+        donneesServeur.portEcoute,
+        uneRequeteDemandeDevenirAidant()
+          .avecUnMail('JeaN.DupOnT@mail.com')
+          .dansLeDepartement('Hautes-Alpes')
+          .construis()
+      );
+
+      expect(reponse.statusCode).toStrictEqual(200);
+      expect(
+        (
+          await testeurMAC.entrepots
+            .demandesDevenirAidant()
+            .rechercheDemandeEnCoursParMail('jean.dupont@mail.com')
+        )?.mail
+      ).toStrictEqual('jean.dupont@mail.com');
+    });
+
     it("Renvoie une erreur 400 si l'utilisateur a déjà fait une demande préalable", async () => {
       await testeurMAC.entrepots
         .demandesDevenirAidant()


### PR DESCRIPTION
**Contexte**
Demande devenir Aidant

**Reproduction**
- Faire une demande devenir aidant en remplissant le champ mail avec des majuscules (e.g : `Jean.DupOnT@mail.com`)
- Finaliser la demande en envoyant le mail de création de l’espace Aidant (`npm run -w mon-aide-cyber-api administration:envoi-mail-creation-compte-aidant -- jean.dupont@mail.com` ),

**Résultat constaté**
Une erreur est remontée disant que la demande n’existe pas

**Comportement attendu**
S'assurer en base de données que dans demande Devenir Aidant, si l'email est saisi avec des majuscules, il sera stocké en minuscules dans tous les cas.

**Problème actuel**
Lorsque l'on fait une demande Devenir Aidant, si le mail comporte des majuscules, celles-ci ne sont pas transformées en minuscule. Cela a pour conséquence de ne pas envoyer de mail pour d'autres workflows (comme par exemple envoi-mail-creation-compte-aidant)

