### PR TITLE
[CORRECTION][ANNUAIRE AIDANTS][MISE EN RELATION] Applique les retours sur le corps du mail à l'Aidant

### DIFF
--- a/mon-aide-cyber-api/src/aide/CapteurCommandeCreerAide.ts
+++ b/mon-aide-cyber-api/src/aide/CapteurCommandeCreerAide.ts
@@ -2,7 +2,7 @@ import { CapteurCommande, Commande } from '../domaine/commande';
 import { Entrepots } from '../domaine/Entrepots';
 import { FournisseurHorloge } from '../infrastructure/horloge/FournisseurHorloge';
 import { Aide } from './Aide';
-import crypto from 'crypto';
+import { adaptateurUUID } from '../infrastructure/adaptateurs/adaptateurUUID';
 
 export type CommandeCreerAide = Omit<Commande, 'type'> & {
   type: 'CommandeCreerAide';
@@ -21,7 +21,7 @@ export class CapteurCommandeCreerAide
       dateSignatureCGU: FournisseurHorloge.maintenant(),
       departement: commande.departement,
       email: commande.email,
-      identifiant: crypto.randomUUID(),
+      identifiant: adaptateurUUID.genereUUID(),
       ...(commande.raisonSociale && { raisonSociale: commande.raisonSociale }),
     };
 

--- a/mon-aide-cyber-api/src/api/demandes/routesAPIDemandeSolliciterAide.ts
+++ b/mon-aide-cyber-api/src/api/demandes/routesAPIDemandeSolliciterAide.ts
@@ -17,7 +17,7 @@ type CorpsRequeteDemandeSolliciterAide = {
   cguValidees: boolean;
   email: string;
   departement: string;
-  raisonSociale: string;
+  raisonSociale?: string;
   aidantSollicite: crypto.UUID;
 };
 
@@ -77,6 +77,7 @@ export const routesAPIDemandeSolliciterAide = (
         email: corps.email,
         departement: corps.departement,
         identifiantAidant: corps.aidantSollicite,
+        ...(corps.raisonSociale && { raisonSociale: corps.raisonSociale }),
         type: 'SagaDemandeSolliciterAide',
       };
       return busCommande

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurSagaDemandeSolliciterAide.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurSagaDemandeSolliciterAide.ts
@@ -9,6 +9,7 @@ export type SagaDemandeSolliciterAide = Omit<Saga, 'type'> & {
   email: string;
   departement: string;
   identifiantAidant: crypto.UUID;
+  raisonSociale?: string;
   type: 'SagaDemandeSolliciterAide';
 };
 
@@ -26,6 +27,7 @@ export class CapteurSagaDemandeSolliciterAide
       type: 'CommandeCreerAide',
       departement: saga.departement,
       email: saga.email,
+      ...(saga.raisonSociale && { raisonSociale: saga.raisonSociale }),
     };
     return this.busCommande.publie<CommandeCreerAide, void>(commande).then(() =>
       this.entrepots
@@ -36,10 +38,17 @@ export class CapteurSagaDemandeSolliciterAide
             {
               corps: adaptateurCorpsMessage
                 .notificationAidantSollicitation()
-                .genereCorpsMessage(aidant.nomPrenom, saga.departement),
+                .genereCorpsMessage({
+                  departement: saga.departement,
+                  mailEntite: saga.email,
+                  nomPrenom: aidant.nomPrenom,
+                  ...(saga.raisonSociale && {
+                    raisonSocialeEntite: saga.raisonSociale,
+                  }),
+                }),
               destinataire: { email: aidant.identifiantConnexion },
               objet:
-                'MonAideCyber - Une entité a fait appel à vous depuis l’annuaire des Aidants cyber.',
+                'MonAideCyber - Une entité vous sollicite depuis l’annuaire des Aidants cyber.',
             },
             'INFO'
           )

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/adaptateurCorpsMessage.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/adaptateurCorpsMessage.ts
@@ -1,26 +1,34 @@
+export type ProprietesMessageAidant = {
+  nomPrenom: string;
+  departement: string;
+  mailEntite: string;
+  raisonSocialeEntite?: string;
+};
+
 const genereCorpsNotificationAidantSollicitation = (
-  nomPrenom: string,
-  departement: string
+  proprietesMessage: ProprietesMessageAidant
 ): string => {
   return (
     '<html lang="fr">' +
     '<body>' +
-    `Bonjour ${nomPrenom},\n` +
+    `Bonjour ${proprietesMessage.nomPrenom},\n` +
     '\n' +
-    `Une entité vous a sélectionné sur l’annuaire des Aidants cyber car elle souhaite bénéficier avec vous d’un diagnostic MonAideCyber dans le département <b>${departement}</b>.\n` +
+    `Une entité ${proprietesMessage.raisonSocialeEntite ? `(${proprietesMessage.raisonSocialeEntite})` : ''} vous a sollicité sur l’annuaire des Aidants cyber car elle souhaite bénéficier avec vous d’un diagnostic MonAideCyber dans le département <b>${proprietesMessage.departement}</b>.\n` +
+    '\n' +
+    'Voici ses coordonnées afin de programmer ensemble la réalisation du prochain diagnostic :' +
+    '\n' +
+    `${proprietesMessage.mailEntite}` +
     '\n' +
     'Au cours de sa demande, l’entité a accepté les CGU.\n' +
     '\n' +
-    'Vous avez reçu un email avec les coordonnées de cette entité afin de programmer ensemble la réalisation du prochain diagnostic.\n' +
-    'Lors du rdv, vous pourrez créer le diagnostic sur votre espace aidant comme vous le faites actuellement.\n' +
+    'Lors du rendez-vous, vous pourrez créer le diagnostic sur votre espace aidant comme vous le faites actuellement.\n' +
     'Il est conseillé de réaliser le diagnostic en présentiel, la visioconférence est cependant tolérée.\n' +
     '\n' +
-    'En cas d’empêchement de votre part, nous vous remercions d’envoyer un mail à l’adresse monaidecyber@ssi.gouv.fr afin que la demande soit attribuée à un autre Aidant cyber.\n' +
+    `En cas d’empêchement de votre part, nous vous remercions d’envoyer un mail à l’adresse <a href="mailto:monaidecyber@ssi.gouv.fr?subject=[MonAideCyber] Indisponibilité réalisation diagnostic dans le département ${proprietesMessage.departement}">monaidecyber@ssi.gouv.fr</a> afin que la demande soit attribuée à un autre Aidant cyber.\n` +
     '\n' +
     'Toute l’équipe reste à votre disposition,\n' +
     '\n' +
-    '<b>L’équipe MonAideCyber</b>\n' +
-    'monaidecyber@ssi.gouv.fr' +
+    '<b>L’équipe MonAideCyber</b>' +
     '</body>' +
     '</html>'
   );
@@ -28,8 +36,8 @@ const genereCorpsNotificationAidantSollicitation = (
 
 const adaptateurCorpsMessage = {
   notificationAidantSollicitation: () => ({
-    genereCorpsMessage: (nomPrenom: string, departement: string): string =>
-      genereCorpsNotificationAidantSollicitation(nomPrenom, departement),
+    genereCorpsMessage: (proprietesMessage: ProprietesMessageAidant): string =>
+      genereCorpsNotificationAidantSollicitation(proprietesMessage),
   }),
 };
 

--- a/mon-aide-cyber-api/test/gestion-demandes/aide/CapteurSagaDemandeSolliciterAide.spec.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/aide/CapteurSagaDemandeSolliciterAide.spec.ts
@@ -6,7 +6,10 @@ import { BusCommandeMAC } from '../../../src/infrastructure/bus/BusCommandeMAC';
 import { BusEvenementDeTest } from '../../infrastructure/bus/BusEvenementDeTest';
 import { unServiceAidant } from '../../../src/authentification/ServiceAidantMAC';
 import { unAidant } from '../../authentification/constructeurs/constructeurAidant';
-import { adaptateurCorpsMessage } from '../../../src/gestion-demandes/aide/adaptateurCorpsMessage';
+import {
+  adaptateurCorpsMessage,
+  ProprietesMessageAidant,
+} from '../../../src/gestion-demandes/aide/adaptateurCorpsMessage';
 
 describe('Capteur saga demande solliciter Aide', () => {
   describe("En ce qui concerne l'Aidant", () => {
@@ -44,6 +47,43 @@ describe('Capteur saga demande solliciter Aide', () => {
         adaptateurEnvoiMail.aEteEnvoyeA(
           aidant.identifiantConnexion,
           'Bonjour Aidant!'
+        )
+      ).toBe(true);
+      expect(adaptateurEnvoiMail.aEteEnvoyePar('INFO')).toBe(true);
+    });
+
+    it("Envoie le mail sollicitant l'aide à l'Aidant indiqué avec la raison sociale", async () => {
+      adaptateurCorpsMessage.notificationAidantSollicitation = () => ({
+        genereCorpsMessage: (proprietes: ProprietesMessageAidant) =>
+          `Bonjour Aidant! ${proprietes.raisonSocialeEntite}`,
+      });
+      const adaptateurEnvoiMail = new AdaptateurEnvoiMailMemoire();
+      const entrepots = new EntrepotsMemoire();
+      const busCommande = new BusCommandeMAC(
+        entrepots,
+        new BusEvenementDeTest(),
+        adaptateurEnvoiMail,
+        { aidant: unServiceAidant(entrepots.aidants()) }
+      );
+      const aidant = unAidant().construis();
+      await entrepots.aidants().persiste(aidant);
+
+      await new CapteurSagaDemandeSolliciterAide(
+        entrepots,
+        busCommande,
+        adaptateurEnvoiMail
+      ).execute({
+        type: 'SagaDemandeSolliciterAide',
+        email: 'entite@mail.com',
+        departement: 'Finistère',
+        identifiantAidant: aidant.identifiant,
+        raisonSociale: 'BetaGouv',
+      });
+
+      expect(
+        adaptateurEnvoiMail.aEteEnvoyeA(
+          aidant.identifiantConnexion,
+          'Bonjour Aidant! BetaGouv'
         )
       ).toBe(true);
       expect(adaptateurEnvoiMail.aEteEnvoyePar('INFO')).toBe(true);


### PR DESCRIPTION
- Rendre le lien vers le mail cliquable en ajoutant l'objet du mail `[MonAideCyber] Indisponibilité réalisation diagnostic dans le département DEPARTEMENT`
- Suppression du mail `monaidecyber@ssi.gouv.fr` dans la signature