### PR TITLE
[CORRECTION][ANNUAIRE AIDANTS] Corrige l'appel à l'annuaire lorsque l'on choisit la Collectivité de Wallis & Futuna

### DIFF
--- a/mon-aide-cyber-api/src/api/annuaire-aidants/routeAPIAnnuaireAidants.ts
+++ b/mon-aide-cyber-api/src/api/annuaire-aidants/routeAPIAnnuaireAidants.ts
@@ -99,7 +99,7 @@ export const routesAPIAnnuaireAidants = (
                 methode: 'GET',
               },
               'afficher-annuaire-aidants-parametre': {
-                url: `/api/annuaire-aidants${criteresDeRecherche ? `?departement=${criteresDeRecherche.departement}` : ''}`,
+                url: `/api/annuaire-aidants${criteresDeRecherche ? `?departement=${encodeURIComponent(criteresDeRecherche.departement)}` : ''}`,
                 methode: 'GET',
               },
               ...(annuaire && {

--- a/mon-aide-cyber-api/test/annuaire-aidants/constructeurAidant.ts
+++ b/mon-aide-cyber-api/test/annuaire-aidants/constructeurAidant.ts
@@ -27,6 +27,11 @@ class ConstructeurAidant implements Constructeur<Aidant> {
     return this;
   }
 
+  dansLeDepartement(departement: Departement): ConstructeurAidant {
+    this.departements.push(departement);
+    return this;
+  }
+
   construis(): Aidant {
     const departementsAidant =
       this.departements.length > 0

--- a/mon-aide-cyber-api/test/api/annuaire-aidants/routeAPIAnnuaireAidants.spec.ts
+++ b/mon-aide-cyber-api/test/api/annuaire-aidants/routeAPIAnnuaireAidants.spec.ts
@@ -143,6 +143,39 @@ describe('le serveur MAC sur les routes /api/annuaire-aidant', () => {
         });
       });
 
+      it('Encode le département dans les liens HATEOAS de la réponse', async () => {
+        const aidant = unAidant()
+          .dansLeDepartement(departements[102])
+          .construis();
+        const autreAidant = unAidant().enCorreze().construis();
+        await testeurMAC.entrepots.annuaireAidants().persiste(aidant);
+        await testeurMAC.entrepots.annuaireAidants().persiste(autreAidant);
+
+        const reponse = await executeRequete(
+          donneesServeur.app,
+          'GET',
+          '/api/annuaire-aidants?departement=Collectivit%C3%A9%20de%20Wallis%20%26%20Futuna',
+          donneesServeur.portEcoute
+        );
+
+        expect(reponse.statusCode).toBe(200);
+        const reponseJson: ReponseAPIAnnuaireAidants = await reponse.json();
+        expect(reponseJson.liens).toStrictEqual({
+          'afficher-annuaire-aidants': {
+            url: '/api/annuaire-aidants',
+            methode: 'GET',
+          },
+          'afficher-annuaire-aidants-parametre': {
+            url: '/api/annuaire-aidants?departement=Collectivit%C3%A9%20de%20Wallis%20%26%20Futuna',
+            methode: 'GET',
+          },
+          'solliciter-aide': {
+            methode: 'POST',
+            url: '/api/demandes/solliciter-aide',
+          },
+        });
+      });
+
       it('Valide le département passé en paramètre', async () => {
         const reponse = await executeRequete(
           donneesServeur.app,

--- a/mon-aide-cyber-ui/src/domaine/vitrine/ecran-annuaire/composants/liste-aidants/useListeAidants.ts
+++ b/mon-aide-cyber-ui/src/domaine/vitrine/ecran-annuaire/composants/liste-aidants/useListeAidants.ts
@@ -24,7 +24,7 @@ const recupereAnnuaireAidants = (
 
   let urlComplete = lien.url;
   if (departementARechercher && departementARechercher !== '') {
-    urlComplete = `${lien.url}?departement=${departementARechercher}`;
+    urlComplete = `${lien.url}?departement=${encodeURIComponent(departementARechercher)}`;
   }
 
   return macAPI.execute<ReponseAidantAnnuaire, ReponseAidantAnnuaire>(


### PR DESCRIPTION
**Contexte**
Annuaire des Aidants

**Reproduction**
- Se rendre sur l'annuaire des Aidants
- Ouvrir la console développeur, onglet réseau
- Sélectionner la collectivité Wallis & Futuna

**Résultat constaté**
‌- Il n'y a pas d'Aidants remontés 
- L'appel réseau remonte en erreur

<img width="1007" alt="Capture d’écran 2024-10-31 à 11 52 16" src="https://github.com/user-attachments/assets/f1efd92d-3eda-48ea-a60d-62f01c0888c5">


**Résultat attendu**
- L'appel réseau ne remonte pas en erreur
- Les Aidants et Wallis & Futuna sont retournés

**NB**
- Il faut faire de l'URL encode codé front mais aussi côté back dans la réponse hateoas