### PR TITLE
[MODE MAINTENANCE] Affiche un bandeau de maintenance si nécessaire

### DIFF
--- a/mon-aide-cyber-ui/.env-template
+++ b/mon-aide-cyber-ui/.env-template
@@ -1,0 +1,5 @@
+# Commande l'affichage du bandeau de maintenance.
+# Si valorisée, la valeur sera utilisée telle quelle dans le bandeau de maintenance après "sera en maintenance"
+# Pas besoin de point final.
+# Exemple : si valorisée à "lundi 12 janvier" alors "sera en maintenance lundi 12 janvier." sera affiché.
+VITE_MAINTENANCE_CRENEAU_PREVU=

--- a/mon-aide-cyber-ui/src/assets/styles/_maintenance.scss
+++ b/mon-aide-cyber-ui/src/assets/styles/_maintenance.scss
@@ -1,0 +1,4 @@
+.bandeau-maintenance {
+  background: #FECA51;
+  padding: 10px 0;
+}

--- a/mon-aide-cyber-ui/src/assets/styles/index.scss
+++ b/mon-aide-cyber-ui/src/assets/styles/index.scss
@@ -27,6 +27,7 @@
 @import 'menu-utilisateur';
 @import 'profil';
 @import 'mot-de-passe';
+@import 'maintenance';
 @import 'commun';
 
 .devise {

--- a/mon-aide-cyber-ui/src/composants/alertes/BandeauMaintenance.tsx
+++ b/mon-aide-cyber-ui/src/composants/alertes/BandeauMaintenance.tsx
@@ -1,0 +1,8 @@
+export const BandeauMaintenance = (props: { creneauDeMaintenance: string }) => (
+  <div className="bandeau-maintenance">
+    <div className="fr-container">
+      MonAideCyber sera en maintenance <b>{props.creneauDeMaintenance}</b>. La
+      plate-forme sera indisponible durant ce créneau.
+    </div>
+  </div>
+);

--- a/mon-aide-cyber-ui/src/composants/layout/Header.tsx
+++ b/mon-aide-cyber-ui/src/composants/layout/Header.tsx
@@ -4,6 +4,7 @@ import { liensNavigation } from './LayoutPublic.tsx';
 import { ComposantMenuUtilisateur } from '../utilisateur/ComposantMenuUtilisateur.tsx';
 import { useUtilisateur } from '../../fournisseurs/hooks.ts';
 import { NavigationPublique } from './header/NavigationPublique.tsx';
+import { BandeauMaintenance } from '../alertes/BandeauMaintenance.tsx';
 
 export type HeaderProprietes = PropsWithChildren<{
   lienMAC: ReactElement;
@@ -17,6 +18,10 @@ export const Header = ({
   enteteSimple,
 }: HeaderProprietes) => {
   const { utilisateur } = useUtilisateur();
+
+  const maintenanceEstPrevue: string = import.meta.env[
+    'VITE_MAINTENANCE_CRENEAU_PREVU'
+  ];
 
   return (
     <header role="banner" className="fr-header public mac-sticky">
@@ -70,6 +75,11 @@ export const Header = ({
           </div>
         </div>
       </div>
+
+      {maintenanceEstPrevue && (
+        <BandeauMaintenance creneauDeMaintenance={maintenanceEstPrevue} />
+      )}
+
       {!enteteSimple && afficheNavigation ? (
         <div
           className="fr-header__menu fr-modal"

--- a/mon-aide-cyber-ui/src/composants/layout/HeaderAidant.tsx
+++ b/mon-aide-cyber-ui/src/composants/layout/HeaderAidant.tsx
@@ -2,9 +2,14 @@ import { HeaderProprietes } from './Header';
 import { useUtilisateur } from '../../fournisseurs/hooks';
 import { SeConnecter } from '../../domaine/authentification/SeConnecter.tsx';
 import { ComposantMenuUtilisateur } from '../utilisateur/ComposantMenuUtilisateur';
+import { BandeauMaintenance } from '../alertes/BandeauMaintenance.tsx';
 
 export const HeaderAidant = ({ lienMAC }: HeaderProprietes) => {
   const { utilisateur } = useUtilisateur();
+
+  const maintenanceEstPrevue: string = import.meta.env[
+    'VITE_MAINTENANCE_CRENEAU_PREVU'
+  ];
 
   return (
     <header role="banner" className="fr-header public mac-sticky">
@@ -52,6 +57,9 @@ export const HeaderAidant = ({ lienMAC }: HeaderProprietes) => {
           </div>
         </div>
       </div>
+      {maintenanceEstPrevue && (
+        <BandeauMaintenance creneauDeMaintenance={maintenanceEstPrevue} />
+      )}
     </header>
   );
 };


### PR DESCRIPTION
Cette PR permet de prévenir d'une maintenance à venir via un bandeau 👇 

![image](https://github.com/user-attachments/assets/1c9a0a66-4c5a-45ce-82eb-30e63ec69f1b)


⚠️  Le bandeau est commandé par une variable `VITE_` qui est donc une variable « build time ».
Afficher ou supprimer le bandeau nécessite donc un re-build du front.
Ce n'est pas idéal, mais c'est suffisant pour le peu de fois où ce sera utilisé.


⚠️ Je n'ai pas testé l'affichage dans l'espace aidant. Si vous pouvez tester de votre côté ça serait top.

📋 La suite sera de faire une PR qui sert une page complète de maintenance lorsque la maintenance est indiquée comme « ACTIVE » par une variable d'env.