### PR TITLE
[MAINTENANCE] Activation d'une page de maintenance côté serveur

### DIFF
--- a/mon-aide-cyber-api/.env.template
+++ b/mon-aide-cyber-api/.env.template
@@ -14,6 +14,7 @@
 
 #SENTRY_DSN= # le DSN Sentry
 #SENTRY_ENVIRONNEMENT= # L'environnement pour distinguer sur Sentry
+#MAINTENANCE_EST_ACTIVE= # 'true' pour afficher systématiquement une page de maintenance sur toutes les routes. Toute autre valeur désactive la maintenance.
 
 #########################################################
 #                                                       #

--- a/mon-aide-cyber-api/index.ts
+++ b/mon-aide-cyber-api/index.ts
@@ -21,6 +21,7 @@ import { recuperateurDeCookies } from './src/adaptateurs/fabriqueDeCookies';
 import { adaptateurMetabase } from './src/infrastructure/adaptateurs/adaptateurMetabase';
 import { unServiceAidant } from './src/espace-aidant/ServiceAidantMAC';
 import { AdaptateurDeVerificationDeTypeDeRelationMAC } from './src/adaptateurs/AdaptateurDeVerificationDeTypeDeRelationMAC';
+import { adaptateurEnvironnement } from './src/adaptateurs/adaptateurEnvironnement';
 
 const gestionnaireDeJeton = new GestionnaireDeJetonJWT(
   process.env.CLEF_SECRETE_SIGNATURE_JETONS_SESSIONS || 'clef-par-defaut'
@@ -83,7 +84,7 @@ const serveurMAC = serveur.creeServeur({
   serviceDeChiffrement: adaptateurServiceChiffrement(),
   recuperateurDeCookies: recuperateurDeCookies,
   adaptateurMetabase: adaptateurMetabase(),
-  estEnMaintenance: false,
+  estEnMaintenance: adaptateurEnvironnement.modeMaintenance().estActif(),
 });
 
 const port = process.env.PORT || 8081;

--- a/mon-aide-cyber-api/index.ts
+++ b/mon-aide-cyber-api/index.ts
@@ -83,6 +83,7 @@ const serveurMAC = serveur.creeServeur({
   serviceDeChiffrement: adaptateurServiceChiffrement(),
   recuperateurDeCookies: recuperateurDeCookies,
   adaptateurMetabase: adaptateurMetabase(),
+  estEnMaintenance: false,
 });
 
 const port = process.env.PORT || 8081;

--- a/mon-aide-cyber-api/src/adaptateurs/adaptateurEnvironnement.ts
+++ b/mon-aide-cyber-api/src/adaptateurs/adaptateurEnvironnement.ts
@@ -14,9 +14,14 @@ const mac = () => ({
   urlMAC: () => process.env.URL_MAC || '',
 });
 
+const modeMaintenance = () => ({
+  estActif: () => process.env.MAINTENANCE_EST_ACTIVE === 'true',
+});
+
 const adaptateurEnvironnement = {
   messagerie,
   mac,
+  modeMaintenance,
 };
 
 export { sentry, adaptateurEnvironnement };

--- a/mon-aide-cyber-api/src/maintenance/maintenance.html
+++ b/mon-aide-cyber-api/src/maintenance/maintenance.html
@@ -1,0 +1,38 @@
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicons/favicon.ico" />
+    <link
+      rel="preload"
+      href="/dsfr/fonts/Marianne-Regular.woff2"
+      as="font"
+      crossorigin="anonymous"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MonAideCyber - Maintenance</title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+
+    <style>
+      body {
+        margin: 0;
+        background-color: #5d2a9d;
+        padding: 0 5%;
+        color: white;
+        font-family: Marianne, arial, sans-serif;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        text-align: center;
+        font-size: 2rem;
+      }
+    </style>
+  </head>
+
+  <body>
+    MonAideCyber est en maintenance aujourd'hui de 12h à 14h.<br />
+    Nous vous invitons à revenir dès que la maintenance sera terminée.
+  </body>
+</html>

--- a/mon-aide-cyber-api/src/serveur.ts
+++ b/mon-aide-cyber-api/src/serveur.ts
@@ -57,10 +57,12 @@ export type ConfigurationServeur = {
     reponse: Response
   ) => string | undefined;
   adaptateurMetabase: AdaptateurMetabase;
+  estEnMaintenance: boolean;
 };
 
 const creeApp = (config: ConfigurationServeur) => {
   const app = express();
+
   config.gestionnaireErreurs.initialise(app);
   app.set('trust proxy', 1);
   app.use(
@@ -81,6 +83,13 @@ const creeApp = (config: ConfigurationServeur) => {
 
   const limiteurTrafficUI = adaptateurConfigurationLimiteurTraffic('STANDARD');
   app.use(limiteurTrafficUI);
+
+  if (config.estEnMaintenance) {
+    app.use((_: Request, reponse: Response) =>
+      reponse.sendFile(path.join(__dirname, './maintenance/maintenance.html'))
+    );
+  }
+
   app.use((_: Request, reponse: Response, suite: NextFunction) => {
     reponse.setHeader('Content-Security-Policy', process.env.MAC_CSP || '*');
     reponse.setHeader(

--- a/mon-aide-cyber-api/test/api/testeurIntegration.ts
+++ b/mon-aide-cyber-api/test/api/testeurIntegration.ts
@@ -103,6 +103,7 @@ class TesteurIntegrationMAC {
       adaptateurMetabase: this.adaptateurMetabase,
       adaptateurDeVerificationDeRelations:
         this.adaptateurDeVerificationDeRelations,
+      estEnMaintenance: false,
     });
     const portEcoute = fakerFR.number.int({ min: 10000, max: 20000 });
     // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
Cette PR permet de passer la totalité de MAC en mode maintenance si `process.env.MAINTENANCE_EST_ACTIVE` vaut `true`.

La seule page servie devient 👇 

![image](https://github.com/user-attachments/assets/93d11570-41a1-4fa3-b4ab-8b94e27958bc)

Le créneau « aujourd'hui de 12h à 14h » est hard-codé… Ça me semble suffisant pour notre besoin.