### PR TITLE
[CORRECTION][CONNEXION] Permets de se déconnecter après s’être connecté via le formulaire MonAideCyber

### DIFF
--- a/mon-aide-cyber-api/src/api/routesAPIAuthentification.ts
+++ b/mon-aide-cyber-api/src/api/routesAPIAuthentification.ts
@@ -50,6 +50,7 @@ export const routesAPIAuthentification = (
         .then((utilisateurAuthentifie: UtilisateurAuthentifie) => {
           let reponseHATEOAS = constructeurActionsHATEOAS()
             .pour({ contexte: 'aidant:acceder-aux-informations-utilisateur' })
+            .pour({ contexte: 'se-deconnecter' })
             .construis();
           return unServiceAidant(entrepots.aidants())
             .parIdentifiant(utilisateurAuthentifie.identifiant)

--- a/mon-aide-cyber-api/test/api/routesAPIAuthentification.spec.ts
+++ b/mon-aide-cyber-api/test/api/routesAPIAuthentification.spec.ts
@@ -71,6 +71,11 @@ describe("Le serveur MAC, sur les routes d'authentification", () => {
               url: '/api/aidant/preferences',
               methode: 'GET',
             },
+            'se-deconnecter': {
+              methode: 'DELETE',
+              typeAppel: 'API',
+              url: '/api/token',
+            },
           },
         });
         const cookieRecu = (
@@ -130,6 +135,11 @@ describe("Le serveur MAC, sur les routes d'authentification", () => {
             'afficher-preferences': {
               url: '/api/aidant/preferences',
               methode: 'GET',
+            },
+            'se-deconnecter': {
+              methode: 'DELETE',
+              typeAppel: 'API',
+              url: '/api/token',
             },
           },
         });


### PR DESCRIPTION
**Contexte**
Déconnexion après s’être connecté via le formulaire de connexion MonAideCyber

**Reproduction**
- Se connecter via le formulaire de connexion
- Cliquer sur le bouton `Se déconnecter`

**Résultat constaté**
L’Aidant n’est pas déconnecté

**Résultat attendu**
L’Aidant est déconnecté