### PR TITLE
[CORRECTION][DEMANDE DEVENIR AIDANT] Corrige la création d'une demande alors qu'une erreur a été remontée

### DIFF
--- a/mon-aide-cyber-api/src/api/demandes/routeAPIDemandeDevenirAidant.ts
+++ b/mon-aide-cyber-api/src/api/demandes/routeAPIDemandeDevenirAidant.ts
@@ -145,7 +145,7 @@ export const routesAPIDemandesDevenirAidant = (
         const resultatsValidation: Result<FieldValidationError> =
           validationResult(requete) as Result<FieldValidationError>;
         if (!resultatsValidation.isEmpty()) {
-          reponse.status(422).json({
+          return reponse.status(422).json({
             message: resultatsValidation
               .array()
               .map((resultatValidation) => resultatValidation.msg)
@@ -162,8 +162,7 @@ export const routesAPIDemandesDevenirAidant = (
         };
 
         await configuration.busCommande.publie(commande);
-        reponse.status(200);
-        return reponse.send();
+        return reponse.status(200).send();
       } catch (error) {
         return suite(error);
       }

--- a/mon-aide-cyber-api/test/api/demandes/routeAPIDemandeDevenirAidant.spec.ts
+++ b/mon-aide-cyber-api/test/api/demandes/routeAPIDemandeDevenirAidant.spec.ts
@@ -127,6 +127,7 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
     });
 
     describe('Valide les paramètres de la requête', () => {
+      const testeurMAC = testeurIntegration();
       let donneesServeur: { portEcoute: number; app: Express };
 
       beforeEach(() => {
@@ -147,6 +148,9 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
         );
 
         expect(reponse.statusCode).toStrictEqual(422);
+        expect(
+          await testeurMAC.entrepots.demandesDevenirAidant().tous()
+        ).toHaveLength(0);
       });
 
       it("Précise l'erreur dans un message, si une erreur est rencontrée", async () => {


### PR DESCRIPTION
**Contexte**
Demande devenir Aidant

**Reproduction**
- Effectuer une demande devenir Aidan via un curl `curl 'http://localhost:8081/api/demandes/devenir-aidant' \
  -H 'Accept: application/json' \
  --data-raw '{"nom":"Nouveau parcours II","prenom":"Test","mail":"test-nouveau-parcours_02@yopmail.com","departement":"Inconnu","cguValidees":true}'`
  
**Résultat constaté**
- Une erreur est remontée
- La demande correspondante est persistée

**Résultat attendu**
- Une erreur est remontée
- Aucune demande correspondante n'est persistée

