### PR TITLE
[CORRECTION][PARCOURS DEVENIR AIDANT] Corrige la mise à jour d'une demande déjà existante

### DIFF
--- a/mon-aide-cyber-api/src/gestion-demandes/devenir-aidant/CapteurCommandeDevenirAidant.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/devenir-aidant/CapteurCommandeDevenirAidant.ts
@@ -71,10 +71,16 @@ export class CapteurCommandeDevenirAidant
       );
     }
 
+    const demandeEnCours = await this.entrepots
+      .demandesDevenirAidant()
+      .rechercheDemandeEnCoursParMail(commande.mail);
+
     const demandeDevenirAidant: DemandeDevenirAidant = {
       date: FournisseurHorloge.maintenant(),
       departement: commande.departement,
-      identifiant: crypto.randomUUID(),
+      identifiant: demandeEnCours
+        ? demandeEnCours.identifiant
+        : crypto.randomUUID(),
       mail: mailDemandeur,
       nom: commande.nom,
       prenom: commande.prenom,

--- a/mon-aide-cyber-api/test/gestion-demandes/devenir-aidant/CapteurCommandeDevenirAidant.spec.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/devenir-aidant/CapteurCommandeDevenirAidant.spec.ts
@@ -352,7 +352,7 @@ describe('Capteur de commande demande devenir aidant', () => {
             .construis()
         );
 
-      const demandeDevenirAidant = await new CapteurCommandeDevenirAidant(
+      await new CapteurCommandeDevenirAidant(
         entrepots,
         new BusEvenementDeTest(),
         new AdaptateurEnvoiMailMemoire(),
@@ -371,7 +371,9 @@ describe('Capteur de commande demande devenir aidant', () => {
         type: 'CommandeDevenirAidant',
       });
 
-      expect(demandeDevenirAidant).toStrictEqual<DemandeDevenirAidant>({
+      const demandes = await entrepots.demandesDevenirAidant().tous();
+      expect(demandes).toHaveLength(1);
+      expect(demandes[0]).toStrictEqual<DemandeDevenirAidant>({
         departement: ardennes,
         mail: 'email-existant@mail.com',
         nom: 'nom',


### PR DESCRIPTION
**Contexte**
Mise à jour d'une demande existante

**Reproduction**
- Faire une demande sur le parcours actuel [ici](http://localhost:8081/devenir-aidant)
- Modifier la variable d'environnement `DATE_NOUVEAU_PARCOURS_DEMANDE_DEVENIR_AIDANT` en la mettant à une date antérieure à la date du test
- Redémarrer le serveur MAC
- Se positionner sur la branche `parcours-devenir-aidant`
- Faire une nouvelle demande sur le nouveau parcours [ici](http://localhost:8081/demandes/devenir-aidant)

**Résultat constaté**
L'ancienne demande n'est pas mise à jour avec les informations du nouveau Parcours

**Résultat attendu**
L'ancienne demande est complétée avec les nouvelles informations et / ou celles modifiées