### PR TITLE
[CORRECTION][CI] Force l'utilisation de Ubuntu 22.04 pour vérifier que cela corrige la CI

### DIFF
--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -3,7 +3,7 @@ on: push
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
La Ci ne fonctionne plus depuis le 16/01/2025 15H00. Je soupçonne une MAJ des runners GitHub :

![Capture d’écran 2025-01-16 à 17 17 45](https://github.com/user-attachments/assets/b1421971-4e8a-4eca-b982-1743fc452214)
