### PR TITLE
[CORRECTION][PARCOURS DEVENIR AIDANT] Corrige l'affichage du nom de l'Aidant dans l'entête

### DIFF
--- a/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotUtilisateurMACPostgres.ts
+++ b/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotUtilisateurMACPostgres.ts
@@ -7,6 +7,7 @@ import crypto from 'crypto';
 import { estSiretGendarmerie } from '../../../espace-aidant/Aidant';
 import { AggregatNonTrouve } from '../../../domaine/Aggregat';
 import { FournisseurHorloge } from '../../horloge/FournisseurHorloge';
+import { ServiceDeChiffrement } from '../../../securite/ServiceDeChiffrement';
 
 type UtilisateurMACDTO = DTO & {
   type: 'AIDANT' | 'UTILISATEUR_INSCRIT';
@@ -21,6 +22,9 @@ export class EntrepotUtilisateurMACPostgres
   extends EntrepotPostgres<UtilisateurMAC, UtilisateurMACDTO>
   implements EntrepotUtilisateursMAC
 {
+  constructor(private readonly serviceDeChiffrement: ServiceDeChiffrement) {
+    super();
+  }
   rechercheParMail(email: string): Promise<UtilisateurMAC> {
     const critere = `WHERE donnees ->> 'email' = ?`;
     return this.rechercheParCritere(critere, email);
@@ -59,7 +63,7 @@ export class EntrepotUtilisateurMACPostgres
     return {
       identifiant: dto.id,
       profil,
-      nomPrenom: dto.nom_prenom,
+      nomPrenom: this.serviceDeChiffrement.dechiffre(dto.nom_prenom),
       ...(dto.date_validation_cgu && {
         dateValidationCGU: FournisseurHorloge.enDate(dto.date_validation_cgu),
       }),

--- a/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotsMAC.ts
+++ b/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotsMAC.ts
@@ -50,7 +50,7 @@ export class EntrepotsMAC implements Entrepots {
   private entrepotDemandeDiagnosticLibreAcces: EntrepotDemandeDiagnosticLibreAcces =
     new EntrepotDemandeDiagnosticLibreAccesPostgres();
   private entrepotUtilisateursMAC: EntrepotUtilisateursMAC =
-    new EntrepotUtilisateurMACPostgres();
+    new EntrepotUtilisateurMACPostgres(adaptateurServiceChiffrement());
 
   diagnostic(): EntrepotDiagnostic {
     return this.entrepotDiagnostic;

--- a/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotsPostgres.spec.ts
+++ b/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotsPostgres.spec.ts
@@ -1217,12 +1217,15 @@ describe('Entrepot profil aidant', () => {
 });
 
 describe('Entrepot Utilisateurs MAC', () => {
+  const serviceDeChiffrementClair = new ServiceDeChiffrementClair();
   const entrepotAidantPostgres = new EntrepotAidantPostgres(
     new ServiceDeChiffrementClair()
   );
   const entrepotUtilisateurInscritPostgres =
     new EntrepotUtilisateurInscritPostgres(new ServiceDeChiffrementClair());
-  const entrepotUtilisateurMACPostgres = new EntrepotUtilisateurMACPostgres();
+  const entrepotUtilisateurMACPostgres = new EntrepotUtilisateurMACPostgres(
+    serviceDeChiffrementClair
+  );
 
   beforeEach(async () => {
     nettoieLaBaseDeDonneesAidants();
@@ -1244,6 +1247,7 @@ describe('Entrepot Utilisateurs MAC', () => {
         nomPrenom: aidant.nomPrenom,
         dateValidationCGU: aidant.dateSignatureCGU!,
       });
+      expect(serviceDeChiffrementClair.dechiffreAEteAppele()).toBe(true);
     });
 
     it('Retourne un utilisateur au profil Gendarme', async () => {
@@ -1262,6 +1266,7 @@ describe('Entrepot Utilisateurs MAC', () => {
         dateValidationCGU: aidant.dateSignatureCGU!,
       });
     });
+
     it('Retourne un utilisateur au profil Utilisateur Inscrit', async () => {
       const utilisateurInscrit = unUtilisateurInscrit().construis();
       await entrepotUtilisateurInscritPostgres.persiste(utilisateurInscrit);
@@ -1317,6 +1322,7 @@ describe('Entrepot Utilisateurs MAC', () => {
         nomPrenom: aidant.nomPrenom,
         dateValidationCGU: aidant.dateSignatureCGU!,
       });
+      expect(serviceDeChiffrementClair.dechiffreAEteAppele()).toBe(true);
     });
 
     it('Retourne un utilisateur au profil Gendarme', async () => {

--- a/mon-aide-cyber-api/test/infrastructure/securite/ServiceDeChiffrementClair.ts
+++ b/mon-aide-cyber-api/test/infrastructure/securite/ServiceDeChiffrementClair.ts
@@ -1,11 +1,17 @@
 import { ServiceDeChiffrement } from '../../../src/securite/ServiceDeChiffrement';
 
 export class ServiceDeChiffrementClair implements ServiceDeChiffrement {
+  private _dechiffreAEteAppele = false;
   chiffre(chaine: string): string {
     return chaine;
   }
 
   dechiffre(chaine: string): string {
+    this._dechiffreAEteAppele = true;
     return chaine;
+  }
+
+  dechiffreAEteAppele(): boolean {
+    return this._dechiffreAEteAppele;
   }
 }


### PR DESCRIPTION
**Contexte**
Affichage du nom de l'Aidant / Utilisateur Inscrit dans l'entête de MAC

**Reproduction**
- Se connecter sur MAC
- Faire un rafraichissement de la page

**Résultat constaté**
Le nom apparaît avec des chiffres et des lettres 
<img width="1376" alt="Capture d’écran 2025-01-30 à 12 46 55" src="https://github.com/user-attachments/assets/9b924497-8e44-42f5-b42e-6089d88cb83e" />

**Résultat attendu**
Le nom est affiché correctement

**NB**
Il s'agit de l'affichage chiffré du nom de nos utilisateurs