### PR TITLE
[CORRECTION][TESTS] Corrige les échecs aléatoires EADDRINUSE:

### DIFF
--- a/mon-aide-cyber-api/test/ConsignateurErreurs.spec.ts
+++ b/mon-aide-cyber-api/test/ConsignateurErreurs.spec.ts
@@ -5,7 +5,7 @@ import { executeRequete } from './api/executeurRequete';
 
 describe("Consignateur de gestion d'erreurr", () => {
   const testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
 
   beforeEach(() => {
     donneesServeur = testeurMAC.initialise();
@@ -21,7 +21,6 @@ describe("Consignateur de gestion d'erreurr", () => {
         donneesServeur.app,
         'PATCH',
         `/api/diagnostic/ed89a4fa-6db5-48d9-a4e2-1b424acd3b47`,
-        donneesServeur.portEcoute,
         {
           chemin: 'contexte',
           identifiant: 'une-question-',

--- a/mon-aide-cyber-api/test/api/aidant/routesAPIAidantPreferences.spec.ts
+++ b/mon-aide-cyber-api/test/api/aidant/routesAPIAidantPreferences.spec.ts
@@ -15,7 +15,7 @@ import {
 
 describe('Le serveur MAC sur les routes /api/aidant', () => {
   const testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
 
   beforeEach(() => {
     donneesServeur = testeurMAC.initialise();
@@ -42,8 +42,7 @@ describe('Le serveur MAC sur les routes /api/aidant', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/aidant/preferences`,
-        donneesServeur.portEcoute
+        `/api/aidant/preferences`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -89,8 +88,7 @@ describe('Le serveur MAC sur les routes /api/aidant', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/aidant/preferences`,
-        donneesServeur.portEcoute
+        `/api/aidant/preferences`
       );
 
       expect((await reponse.json()).liens['se-deconnecter']).toStrictEqual({
@@ -118,8 +116,7 @@ describe('Le serveur MAC sur les routes /api/aidant', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/aidant/preferences`,
-        donneesServeur.portEcoute
+        `/api/aidant/preferences`
       );
 
       const reponsePreferences =
@@ -150,8 +147,7 @@ describe('Le serveur MAC sur les routes /api/aidant', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/aidant/preferences`,
-        donneesServeur.portEcoute
+        `/api/aidant/preferences`
       );
 
       const reponsePreferences =
@@ -185,8 +181,7 @@ describe('Le serveur MAC sur les routes /api/aidant', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/aidant/preferences`,
-        donneesServeur.portEcoute
+        `/api/aidant/preferences`
       );
 
       const reponsePreferences =
@@ -200,8 +195,7 @@ describe('Le serveur MAC sur les routes /api/aidant', () => {
       await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/aidant/preferences`,
-        donneesServeur.portEcoute
+        `/api/aidant/preferences`
       );
 
       expect(testeurMAC.adaptateurDeVerificationDeCGU.verifiePassage()).toBe(
@@ -213,8 +207,7 @@ describe('Le serveur MAC sur les routes /api/aidant', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/aidant/preferences`,
-        donneesServeur.portEcoute
+        `/api/aidant/preferences`
       );
 
       expect(reponse.statusCode).toBe(404);
@@ -243,7 +236,6 @@ describe('Le serveur MAC sur les routes /api/aidant', () => {
         donneesServeur.app,
         'PATCH',
         `/api/aidant/preferences`,
-        donneesServeur.portEcoute,
         {
           preferencesAidant: {
             secteursActivite: ['Administration', 'Transports'],
@@ -262,7 +254,6 @@ describe('Le serveur MAC sur les routes /api/aidant', () => {
         donneesServeur.app,
         'PATCH',
         `/api/aidant/preferences`,
-        donneesServeur.portEcoute,
         {
           preferencesAidant: {
             typesEntites: ['Organisations publiques', 'Associations'],
@@ -280,7 +271,6 @@ describe('Le serveur MAC sur les routes /api/aidant', () => {
         donneesServeur.app,
         'PATCH',
         `/api/aidant/preferences`,
-        donneesServeur.portEcoute,
         {
           preferencesAidant: {
             typesEntites: ['Organisations publiques', 'Associations'],
@@ -310,7 +300,6 @@ describe('Le serveur MAC sur les routes /api/aidant', () => {
           donneesServeur.app,
           'PATCH',
           `/api/aidant/preferences`,
-          donneesServeur.portEcoute,
           {
             preferencesAidant: {
               secteursActivite: ['Inconnu', 'Inexistant'],
@@ -339,7 +328,6 @@ describe('Le serveur MAC sur les routes /api/aidant', () => {
           donneesServeur.app,
           'PATCH',
           `/api/aidant/preferences`,
-          donneesServeur.portEcoute,
           {
             preferencesAidant: {
               departements: ['Inconnu', 'Inexistant'],
@@ -368,7 +356,6 @@ describe('Le serveur MAC sur les routes /api/aidant', () => {
           donneesServeur.app,
           'PATCH',
           `/api/aidant/preferences`,
-          donneesServeur.portEcoute,
           {
             preferencesAidant: {
               typesEntites: ['Inconnu', 'Inexistant'],

--- a/mon-aide-cyber-api/test/api/aidant/routesAPIProfil.spec.ts
+++ b/mon-aide-cyber-api/test/api/aidant/routesAPIProfil.spec.ts
@@ -16,7 +16,7 @@ import { Aidant } from '../../../src/espace-aidant/Aidant';
 
 describe('le serveur MAC sur les routes /api/profil', () => {
   const testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
 
   beforeEach(() => {
     donneesServeur = testeurMAC.initialise();
@@ -52,8 +52,7 @@ describe('le serveur MAC sur les routes /api/profil', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          `/api/profil/`,
-          donneesServeur.portEcoute
+          `/api/profil/`
         );
 
         expect(reponse.statusCode).toBe(200);
@@ -92,12 +91,7 @@ describe('le serveur MAC sur les routes /api/profil', () => {
       });
 
       it('Vérifie la signature des CGU', async () => {
-        await executeRequete(
-          donneesServeur.app,
-          'GET',
-          `/api/profil/`,
-          donneesServeur.portEcoute
-        );
+        await executeRequete(donneesServeur.app, 'GET', `/api/profil/`);
 
         expect(testeurMAC.adaptateurDeVerificationDeCGU.verifiePassage()).toBe(
           true
@@ -107,7 +101,7 @@ describe('le serveur MAC sur les routes /api/profil', () => {
 
     describe("Dans le cas d'un Utilisateur Inscrit", () => {
       const testeurMAC = testeurIntegration();
-      let donneesServeur: { portEcoute: number; app: Express };
+      let donneesServeur: { app: Express };
       beforeEach(async () => {
         donneesServeur = testeurMAC.initialise();
         testeurMAC.adaptateurDeVerificationDeSession.reinitialise();
@@ -127,8 +121,7 @@ describe('le serveur MAC sur les routes /api/profil', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          `/api/profil/`,
-          donneesServeur.portEcoute
+          `/api/profil/`
         );
 
         expect(await reponse.json()).toStrictEqual<Profil>({
@@ -169,8 +162,7 @@ describe('le serveur MAC sur les routes /api/profil', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          `/api/profil/`,
-          donneesServeur.portEcoute
+          `/api/profil/`
         );
 
         expect(await reponse.json()).toStrictEqual<Profil>({
@@ -204,8 +196,7 @@ describe('le serveur MAC sur les routes /api/profil', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/profil/`,
-        donneesServeur.portEcoute
+        `/api/profil/`
       );
 
       expect(reponse.statusCode).toBe(404);
@@ -217,7 +208,7 @@ describe('le serveur MAC sur les routes /api/profil', () => {
 
   describe('Dans le cadre de la connexion proconnect', () => {
     const testeurMAC = testeurIntegration();
-    let donneesServeur: { portEcoute: number; app: Express };
+    let donneesServeur: { app: Express };
     let aidantConnecte: Aidant;
 
     beforeEach(async () => {
@@ -240,8 +231,7 @@ describe('le serveur MAC sur les routes /api/profil', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/profil/`,
-        donneesServeur.portEcoute
+        `/api/profil/`
       );
 
       expect(await reponse.json()).toStrictEqual<Profil>({
@@ -278,7 +268,6 @@ describe('le serveur MAC sur les routes /api/profil', () => {
         donneesServeur.app,
         'PATCH',
         `/api/profil`,
-        donneesServeur.portEcoute,
         {
           consentementAnnuaire: true,
         }
@@ -305,7 +294,6 @@ describe('le serveur MAC sur les routes /api/profil', () => {
         donneesServeur.app,
         'PATCH',
         '/api/profil',
-        donneesServeur.portEcoute,
         {
           consentementAnnuaire: true,
         }
@@ -333,7 +321,6 @@ describe('le serveur MAC sur les routes /api/profil', () => {
         donneesServeur.app,
         'PATCH',
         '/api/profil',
-        donneesServeur.portEcoute,
         {
           consentementAnnuaire: false,
         }
@@ -361,7 +348,6 @@ describe('le serveur MAC sur les routes /api/profil', () => {
         donneesServeur.app,
         'PATCH',
         '/api/profil',
-        donneesServeur.portEcoute,
         {
           consentementAnnuaire: false,
         }
@@ -385,15 +371,9 @@ describe('le serveur MAC sur les routes /api/profil', () => {
         utilisateur.identifiant
       );
 
-      await executeRequete(
-        donneesServeur.app,
-        'PATCH',
-        '/api/profil',
-        donneesServeur.portEcoute,
-        {
-          consentementAnnuaire: true,
-        }
-      );
+      await executeRequete(donneesServeur.app, 'PATCH', '/api/profil', {
+        consentementAnnuaire: true,
+      });
 
       expect(testeurMAC.adaptateurDeVerificationDeCGU.verifiePassage()).toBe(
         true
@@ -415,7 +395,6 @@ describe('le serveur MAC sur les routes /api/profil', () => {
         donneesServeur.app,
         'PATCH',
         '/api/profil',
-        donneesServeur.portEcoute,
         {
           consentemetAnnaire: 'true',
         }
@@ -446,7 +425,6 @@ describe('le serveur MAC sur les routes /api/profil', () => {
         donneesServeur.app,
         'POST',
         '/api/profil/modifier-mot-de-passe',
-        donneesServeur.portEcoute,
         {
           ancienMotDePasse: utilisateur.motDePasse,
           motDePasse: nouveauMotDePasse,
@@ -477,7 +455,6 @@ describe('le serveur MAC sur les routes /api/profil', () => {
         donneesServeur.app,
         'POST',
         '/api/profil/modifier-mot-de-passe',
-        donneesServeur.portEcoute,
         {
           ancienMotDePasse: utilisateur.motDePasse,
           motDePasse: nouveauMotDePasse,
@@ -665,7 +642,6 @@ describe('le serveur MAC sur les routes /api/profil', () => {
           donneesServeur.app,
           'POST',
           '/api/profil/modifier-mot-de-passe',
-          donneesServeur.portEcoute,
           {
             ...test.corps,
           }

--- a/mon-aide-cyber-api/test/api/annuaire-aidants/routeAPIAnnuaireAidants.spec.ts
+++ b/mon-aide-cyber-api/test/api/annuaire-aidants/routeAPIAnnuaireAidants.spec.ts
@@ -11,7 +11,7 @@ import { departements } from '../../../src/gestion-demandes/departements';
 
 describe('le serveur MAC sur les routes /api/annuaire-aidant', () => {
   let testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
 
   beforeEach(() => {
     testeurMAC = testeurIntegration();
@@ -29,8 +29,7 @@ describe('le serveur MAC sur les routes /api/annuaire-aidant', () => {
     const reponse = await executeRequete(
       donneesServeur.app,
       'GET',
-      `/api/annuaire-aidants?departement=${aidant.departements[0].nom}`,
-      donneesServeur.portEcoute
+      `/api/annuaire-aidants?departement=${aidant.departements[0].nom}`
     );
 
     expect(reponse.statusCode).toBe(200);
@@ -45,8 +44,7 @@ describe('le serveur MAC sur les routes /api/annuaire-aidant', () => {
     const reponse = await executeRequete(
       donneesServeur.app,
       'GET',
-      '/api/annuaire-aidants',
-      donneesServeur.portEcoute
+      '/api/annuaire-aidants'
     );
 
     expect(reponse.statusCode).toBe(200);
@@ -75,8 +73,7 @@ describe('le serveur MAC sur les routes /api/annuaire-aidant', () => {
     const reponse = await executeRequete(
       donneesServeur.app,
       'GET',
-      '/api/annuaire-aidants?departement=Corrèze',
-      donneesServeur.portEcoute
+      '/api/annuaire-aidants?departement=Corrèze'
     );
 
     expect(reponse.statusCode).toBe(200);
@@ -98,8 +95,7 @@ describe('le serveur MAC sur les routes /api/annuaire-aidant', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          '/api/annuaire-aidants?departement=Gironde',
-          donneesServeur.portEcoute
+          '/api/annuaire-aidants?departement=Gironde'
         );
 
         expect(reponse.statusCode).toBe(200);
@@ -121,8 +117,7 @@ describe('le serveur MAC sur les routes /api/annuaire-aidant', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          '/api/annuaire-aidants?departement=Gironde',
-          donneesServeur.portEcoute
+          '/api/annuaire-aidants?departement=Gironde'
         );
 
         expect(reponse.statusCode).toBe(200);
@@ -154,8 +149,7 @@ describe('le serveur MAC sur les routes /api/annuaire-aidant', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          '/api/annuaire-aidants?departement=Collectivit%C3%A9%20de%20Wallis%20%26%20Futuna',
-          donneesServeur.portEcoute
+          '/api/annuaire-aidants?departement=Collectivit%C3%A9%20de%20Wallis%20%26%20Futuna'
         );
 
         expect(reponse.statusCode).toBe(200);
@@ -180,8 +174,7 @@ describe('le serveur MAC sur les routes /api/annuaire-aidant', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          '/api/annuaire-aidants?departement=Mauvais-département',
-          donneesServeur.portEcoute
+          '/api/annuaire-aidants?departement=Mauvais-département'
         );
 
         expect(reponse.statusCode).toBe(400);

--- a/mon-aide-cyber-api/test/api/auto-diagnostic/routesAPIDiagnosticLibreAcces.spec.ts
+++ b/mon-aide-cyber-api/test/api/auto-diagnostic/routesAPIDiagnosticLibreAcces.spec.ts
@@ -30,7 +30,7 @@ import { add } from 'date-fns';
 
 describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
   const testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
 
   beforeEach(() => {
     testeurMAC.adaptateurDeVerificationDeRelations.reinitialise();
@@ -50,8 +50,10 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
         donneesServeur.app,
         'POST',
         '/api/diagnostic-libre-acces',
-        donneesServeur.portEcoute,
-        { email: 'jean.dujardin@email.com', cguSignees: true }
+        {
+          email: 'jean.dujardin@email.com',
+          cguSignees: true,
+        }
       );
 
       expect(reponse.statusCode).toBe(201);
@@ -70,8 +72,10 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
         donneesServeur.app,
         'POST',
         '/api/diagnostic-libre-acces',
-        donneesServeur.portEcoute,
-        { email: 'jean.dupont@mail.com', cguSignees: true }
+        {
+          email: 'jean.dupont@mail.com',
+          cguSignees: true,
+        }
       );
 
       expect(
@@ -88,7 +92,6 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
           donneesServeur.app,
           'POST',
           '/api/diagnostic-libre-acces',
-          donneesServeur.portEcoute,
           { email: 'jean.dupont@mail.com' }
         );
 
@@ -122,8 +125,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic-libre-acces/${diagnostic.identifiant}`,
-        donneesServeur.portEcoute
+        `/api/diagnostic-libre-acces/${diagnostic.identifiant}`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -146,8 +148,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic-libre-acces/id-inexistant`,
-        donneesServeur.portEcoute
+        `/api/diagnostic-libre-acces/id-inexistant`
       );
 
       expect(reponse.statusCode).toBe(404);
@@ -167,8 +168,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
       await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic-libre-acces/${crypto.randomUUID()}`,
-        donneesServeur.portEcoute
+        `/api/diagnostic-libre-acces/${crypto.randomUUID()}`
       );
 
       expect(
@@ -187,8 +187,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic-libre-acces/${diagnostic.identifiant}`,
-        donneesServeur.portEcoute
+        `/api/diagnostic-libre-acces/${diagnostic.identifiant}`
       );
 
       expect(reponse.statusCode).toBe(404);
@@ -227,7 +226,6 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
         donneesServeur.app,
         'PATCH',
         `/api/diagnostic-libre-acces/${diagnostic.identifiant}`,
-        donneesServeur.portEcoute,
         {
           chemin: 'contexte',
           identifiant: 'une-question-',
@@ -268,7 +266,6 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
         donneesServeur.app,
         'PATCH',
         `/api/diagnostic-libre-acces/ed89a4fa-6db5-48d9-a4e2-1b424acd3b47`,
-        donneesServeur.portEcoute,
         {
           chemin: 'contexte',
           identifiant: 'une-question-',
@@ -289,8 +286,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
       await executeRequete(
         donneesServeur.app,
         'PATCH',
-        `/api/diagnostic-libre-acces/${diagnostic.identifiant}`,
-        donneesServeur.portEcoute
+        `/api/diagnostic-libre-acces/${diagnostic.identifiant}`
       );
 
       expect(
@@ -309,8 +305,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'PATCH',
-        `/api/diagnostic-libre-acces/${diagnostic.identifiant}`,
-        donneesServeur.portEcoute
+        `/api/diagnostic-libre-acces/${diagnostic.identifiant}`
       );
 
       expect(reponse.statusCode).toBe(404);
@@ -351,8 +346,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic-libre-acces/${restitution.identifiant}/restitution`,
-        donneesServeur.portEcoute
+        `/api/diagnostic-libre-acces/${restitution.identifiant}/restitution`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -399,7 +393,6 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
         donneesServeur.app,
         'GET',
         `/api/diagnostic-libre-acces/${restitution.identifiant}/restitution`,
-        donneesServeur.portEcoute,
         undefined,
         { accept: 'application/pdf' }
       );
@@ -413,8 +406,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic-libre-acces/${crypto.randomUUID()}/restitution`,
-        donneesServeur.portEcoute
+        `/api/diagnostic-libre-acces/${crypto.randomUUID()}/restitution`
       );
 
       expect(reponse.statusCode).toBe(404);
@@ -430,8 +422,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
       await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic-libre-acces/${diagnostic.identifiant}/restitution`,
-        donneesServeur.portEcoute
+        `/api/diagnostic-libre-acces/${diagnostic.identifiant}/restitution`
       );
 
       expect(
@@ -450,8 +441,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic-libre-acces', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic-libre-acces/${diagnostic.identifiant}/restitution`,
-        donneesServeur.portEcoute
+        `/api/diagnostic-libre-acces/${diagnostic.identifiant}/restitution`
       );
 
       expect(reponse.statusCode).toBe(404);

--- a/mon-aide-cyber-api/test/api/demandes/routeAPIDemandeDevenirAidant.spec.ts
+++ b/mon-aide-cyber-api/test/api/demandes/routeAPIDemandeDevenirAidant.spec.ts
@@ -18,7 +18,7 @@ import { adaptateurEnvironnement } from '../../../src/adaptateurs/adaptateurEnvi
 
 describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () => {
   const testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
 
   beforeEach(() => {
     donneesServeur = testeurMAC.initialise();
@@ -31,8 +31,7 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        '/api/demandes/devenir-aidant',
-        donneesServeur.portEcoute
+        '/api/demandes/devenir-aidant'
       );
 
       expect(await reponse.json()).toStrictEqual({
@@ -51,7 +50,7 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
   });
 
   describe('Quand une requête POST est reçue /api/demandes/devenir-aidant', () => {
-    let donneesServeur: { portEcoute: number; app: Express };
+    let donneesServeur: { app: Express };
 
     beforeEach(() => {
       donneesServeur = testeurMAC.initialise();
@@ -63,7 +62,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
         donneesServeur.app,
         'POST',
         '/api/demandes/devenir-aidant',
-        donneesServeur.portEcoute,
         uneRequeteDemandeDevenirAidant()
           .dansLeDepartement('Hautes-Alpes')
           .ayantSigneLaCharte()
@@ -86,7 +84,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
         donneesServeur.app,
         'POST',
         '/api/demandes/devenir-aidant',
-        donneesServeur.portEcoute,
         uneRequeteDemandeDevenirAidant()
           .avecUnMail('JeaN.DupOnT@mail.com')
           .dansLeDepartement('Hautes-Alpes')
@@ -106,7 +103,7 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
 
     describe('Valide les paramètres de la requête', () => {
       const testeurMAC = testeurIntegration();
-      let donneesServeur: { portEcoute: number; app: Express };
+      let donneesServeur: { app: Express };
 
       beforeEach(() => {
         donneesServeur = testeurMAC.initialise();
@@ -121,7 +118,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
           donneesServeur.app,
           'POST',
           '/api/demandes/devenir-aidant',
-          donneesServeur.portEcoute,
           corpsDeRequeteInvalide
         );
 
@@ -140,7 +136,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
           donneesServeur.app,
           'POST',
           '/api/demandes/devenir-aidant',
-          donneesServeur.portEcoute,
           corpsDeRequeteAvecMailInvalide
         );
 
@@ -160,7 +155,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
           donneesServeur.app,
           'POST',
           '/api/demandes/devenir-aidant',
-          donneesServeur.portEcoute,
           corpsDeRequeteAvecMailEtNomInvalides
         );
 
@@ -174,7 +168,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
           donneesServeur.app,
           'POST',
           '/api/demandes/devenir-aidant',
-          donneesServeur.portEcoute,
           {
             nom: 'nom',
             prenom: 'prenom',
@@ -203,7 +196,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
         donneesServeur.app,
         'POST',
         '/api/demandes/devenir-aidant/creation-espace-aidant',
-        donneesServeur.portEcoute,
         {
           motDePasse: 'mon_Mot-D3p4ssee',
           confirmationMotDePasse: 'mon_Mot-D3p4ssee',
@@ -259,7 +251,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
         donneesServeur.app,
         'POST',
         '/api/demandes/devenir-aidant/creation-espace-aidant',
-        donneesServeur.portEcoute,
         {
           motDePasse: 'mon_Mot-D3p4ssee',
           confirmationMotDePasse: 'mon_Mot-D3p4ssee',
@@ -286,7 +277,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
           donneesServeur.app,
           'POST',
           '/api/demandes/devenir-aidant/creation-espace-aidant',
-          donneesServeur.portEcoute,
           {
             motDePasse: 'mon_Mot-D3p4sse',
             confirmationMotDePasse: 'mon_Mot-D3p4sseeeeeee',
@@ -313,7 +303,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
           donneesServeur.app,
           'POST',
           '/api/demandes/devenir-aidant/creation-espace-aidant',
-          donneesServeur.portEcoute,
           {
             motDePasse: 'mon_Mot-D3p4ssee',
             confirmationMotDePasse: 'mon_Mot-D3p4ssee',
@@ -353,7 +342,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
             donneesServeur.app,
             'POST',
             '/api/demandes/devenir-aidant/creation-espace-aidant',
-            donneesServeur.portEcoute,
             {
               motDePasse: 'mon_Mot-D3p4ssee',
               confirmationMotDePasse: 'mon_Mot-D3p4ssee',
@@ -388,7 +376,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
             donneesServeur.app,
             'POST',
             '/api/demandes/devenir-aidant/creation-espace-aidant',
-            donneesServeur.portEcoute,
             {
               motDePasse: 'mon_Mot-D3p4ssee',
               confirmationMotDePasse: 'mon_Mot-D3p4ssee',
@@ -423,7 +410,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
             donneesServeur.app,
             'POST',
             '/api/demandes/devenir-aidant/creation-espace-aidant',
-            donneesServeur.portEcoute,
             {
               motDePasse: 'mon_Mot-D3p4ssee',
               confirmationMotDePasse: 'mon_Mot-D3p4ssee',
@@ -444,7 +430,7 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
 
   describe('Dans le cadre de la mise en place des profils Aidants / Utilisateurs inscrits à partir du 31/01/2025', () => {
     const testeurMAC = testeurIntegration();
-    let donneesServeur: { portEcoute: number; app: Express };
+    let donneesServeur: { app: Express };
 
     beforeEach(() => {
       FournisseurHorlogeDeTest.initialise(
@@ -468,7 +454,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
           donneesServeur.app,
           'POST',
           '/api/demandes/devenir-aidant',
-          donneesServeur.portEcoute,
           corpsDeRequete
         );
 
@@ -488,7 +473,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
           donneesServeur.app,
           'POST',
           '/api/demandes/devenir-aidant',
-          donneesServeur.portEcoute,
           corpsDeRequete
         );
 
@@ -508,7 +492,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
           donneesServeur.app,
           'POST',
           '/api/demandes/devenir-aidant',
-          donneesServeur.portEcoute,
           corpsDeRequete
         );
 
@@ -527,7 +510,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
           donneesServeur.app,
           'POST',
           '/api/demandes/devenir-aidant',
-          donneesServeur.portEcoute,
           corpsDeRequete
         );
 
@@ -555,7 +537,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
           donneesServeur.app,
           'POST',
           '/api/demandes/devenir-aidant/creation-espace-aidant',
-          donneesServeur.portEcoute,
           {
             token,
             cguSignees: true,
@@ -578,7 +559,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
           donneesServeur.app,
           'POST',
           '/api/demandes/devenir-aidant/creation-espace-aidant',
-          donneesServeur.portEcoute,
           {
             token,
             cguSignees: true,
@@ -621,7 +601,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
           donneesServeur.app,
           'POST',
           '/api/demandes/devenir-aidant/creation-espace-aidant',
-          donneesServeur.portEcoute,
           {
             token,
           }

--- a/mon-aide-cyber-api/test/api/demandes/routesAPIDemandeEtreAide.spec.ts
+++ b/mon-aide-cyber-api/test/api/demandes/routesAPIDemandeEtreAide.spec.ts
@@ -8,7 +8,7 @@ import { departements } from '../../../src/gestion-demandes/departements';
 
 describe('Le serveur MAC, sur les routes de demande d’aide de la part de l’Aidé', () => {
   const testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
 
   beforeEach(() => {
     donneesServeur = testeurMAC.initialise();
@@ -26,7 +26,6 @@ describe('Le serveur MAC, sur les routes de demande d’aide de la part de l’A
           donneesServeur.app,
           'POST',
           '/api/demandes/etre-aide',
-          donneesServeur.portEcoute,
           {
             cguValidees: true,
             email: 'jean.dupont@aide.com',
@@ -46,14 +45,12 @@ describe('Le serveur MAC, sur les routes de demande d’aide de la part de l’A
 
       it('Renvoie une erreur si la demande n’a pu aller au bout', async () => {
         const testeurMAC = testeurIntegration();
-        const donneesServeur: { portEcoute: number; app: Express } =
-          testeurMAC.initialise();
+        const donneesServeur: { app: Express } = testeurMAC.initialise();
         testeurMAC.adaptateurEnvoieMessage.envoie = () => Promise.reject();
         const reponse = await executeRequete(
           donneesServeur.app,
           'POST',
           '/api/demandes/etre-aide',
-          donneesServeur.portEcoute,
           {
             cguValidees: true,
             email: 'jean.dupont@aide.com',
@@ -70,7 +67,7 @@ describe('Le serveur MAC, sur les routes de demande d’aide de la part de l’A
 
       describe("En ce qui concerne les informations envoyées par l'Aidé", () => {
         const testeurMAC = testeurIntegration();
-        let donneesServeur: { portEcoute: number; app: Express };
+        let donneesServeur: { app: Express };
 
         beforeEach(() => {
           donneesServeur = testeurMAC.initialise();
@@ -82,7 +79,6 @@ describe('Le serveur MAC, sur les routes de demande d’aide de la part de l’A
             donneesServeur.app,
             'POST',
             '/api/demandes/etre-aide',
-            donneesServeur.portEcoute,
             {
               cguValidees: false,
               email: 'jean.dupont@aide.com',
@@ -108,7 +104,6 @@ describe('Le serveur MAC, sur les routes de demande d’aide de la part de l’A
             donneesServeur.app,
             'POST',
             '/api/demandes/etre-aide',
-            donneesServeur.portEcoute,
             {
               cguValidees: true,
               email: 'ceci-n-est-pas-un-email',
@@ -134,7 +129,6 @@ describe('Le serveur MAC, sur les routes de demande d’aide de la part de l’A
             donneesServeur.app,
             'POST',
             '/api/demandes/etre-aide',
-            donneesServeur.portEcoute,
             {
               cguValidees: true,
               email: 'jean.dupont@aide.com',
@@ -164,7 +158,6 @@ describe('Le serveur MAC, sur les routes de demande d’aide de la part de l’A
             donneesServeur.app,
             'POST',
             '/api/demandes/etre-aide',
-            donneesServeur.portEcoute,
             {
               cguValidees: true,
               email: 'jean.dupont@aide.com',
@@ -185,7 +178,6 @@ describe('Le serveur MAC, sur les routes de demande d’aide de la part de l’A
             donneesServeur.app,
             'POST',
             '/api/demandes/etre-aide',
-            donneesServeur.portEcoute,
             {
               cguValidees: true,
               email: 'jean.dupont@aide.com',
@@ -214,8 +206,7 @@ describe('Le serveur MAC, sur les routes de demande d’aide de la part de l’A
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          '/api/demandes/etre-aide',
-          donneesServeur.portEcoute
+          '/api/demandes/etre-aide'
         );
 
         expect(reponse.statusCode).toBe(200);
@@ -231,8 +222,7 @@ describe('Le serveur MAC, sur les routes de demande d’aide de la part de l’A
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          '/api/demandes/etre-aide',
-          donneesServeur.portEcoute
+          '/api/demandes/etre-aide'
         );
 
         expect((await reponse.json()).departements).toStrictEqual(

--- a/mon-aide-cyber-api/test/api/demandes/routesAPIDemandeSolliciterAide.spec.ts
+++ b/mon-aide-cyber-api/test/api/demandes/routesAPIDemandeSolliciterAide.spec.ts
@@ -11,7 +11,7 @@ import { unAidant } from '../../constructeurs/constructeursAidantUtilisateurInsc
 
 describe('Le serveur MAC, sur les routes de sollicitation d’aide de la part de l’Aidé pour un Aidant donné', () => {
   const testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
 
   beforeEach(() => {
     donneesServeur = testeurMAC.initialise();
@@ -37,7 +37,6 @@ describe('Le serveur MAC, sur les routes de sollicitation d’aide de la part de
         donneesServeur.app,
         'POST',
         '/api/demandes/solliciter-aide',
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
           email: 'jean.dupont@aide.com',
@@ -59,7 +58,6 @@ describe('Le serveur MAC, sur les routes de sollicitation d’aide de la part de
         donneesServeur.app,
         'POST',
         '/api/demandes/solliciter-aide',
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
           email: 'jean.dupont@aide.com',
@@ -98,7 +96,6 @@ describe('Le serveur MAC, sur les routes de sollicitation d’aide de la part de
         donneesServeur.app,
         'POST',
         '/api/demandes/solliciter-aide',
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
           email: 'jean.dupont@aide.com',
@@ -139,7 +136,6 @@ describe('Le serveur MAC, sur les routes de sollicitation d’aide de la part de
         donneesServeur.app,
         'POST',
         '/api/demandes/solliciter-aide',
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
           email: 'jean.dupont@aide.com',
@@ -179,7 +175,6 @@ describe('Le serveur MAC, sur les routes de sollicitation d’aide de la part de
         donneesServeur.app,
         'POST',
         '/api/demandes/solliciter-aide',
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
           email: 'jean.dupont@aide.com',
@@ -221,7 +216,6 @@ describe('Le serveur MAC, sur les routes de sollicitation d’aide de la part de
         donneesServeur.app,
         'POST',
         '/api/demandes/solliciter-aide',
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
           email: 'jean.dupont@aide.com',
@@ -256,7 +250,6 @@ describe('Le serveur MAC, sur les routes de sollicitation d’aide de la part de
         donneesServeur.app,
         'POST',
         '/api/demandes/solliciter-aide',
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
           email: '',
@@ -299,7 +292,6 @@ describe('Le serveur MAC, sur les routes de sollicitation d’aide de la part de
         donneesServeur.app,
         'POST',
         '/api/demandes/solliciter-aide',
-        donneesServeur.portEcoute,
         {
           cguValidees: false,
           email: 'mail@mail.com',

--- a/mon-aide-cyber-api/test/api/executeurRequete.ts
+++ b/mon-aide-cyber-api/test/api/executeurRequete.ts
@@ -7,7 +7,6 @@ export const executeRequete = (
   app: Express,
   verbe: 'DELETE' | 'GET' | 'POST' | 'PATCH',
   chemin: string,
-  port: number,
   corps: object | undefined = undefined,
   headers: IncomingHttpHeaders | undefined = undefined
 ): Promise<Response> => {
@@ -17,7 +16,6 @@ export const executeRequete = (
     method: verbe,
     url: {
       pathname: pathAndQuery[0],
-      port,
       ...(pathAndQuery[1] !== undefined && {
         query: qs.parse(pathAndQuery[1]) as { [key: string]: string },
       }),

--- a/mon-aide-cyber-api/test/api/pro-connect/routeProConnect.spec.ts
+++ b/mon-aide-cyber-api/test/api/pro-connect/routeProConnect.spec.ts
@@ -22,7 +22,7 @@ const enObjet = <T extends { [clef: string]: string }>(cookie: string): T =>
 
 describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
   const testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
 
   beforeEach(() => {
     donneesServeur = testeurMAC.initialise();
@@ -45,8 +45,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        '/pro-connect/connexion',
-        donneesServeur.portEcoute
+        '/pro-connect/connexion'
       );
 
       expect(reponse.statusCode).toStrictEqual(302);
@@ -59,12 +58,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
     });
 
     it('Le cookie de l’utilisateur est supprimé', async () => {
-      await executeRequete(
-        donneesServeur.app,
-        'GET',
-        '/pro-connect/connexion',
-        donneesServeur.portEcoute
-      );
+      await executeRequete(donneesServeur.app, 'GET', '/pro-connect/connexion');
 
       expect(testeurMAC.adaptateurDeGestionDeCookies.aSupprime).toBe(true);
     });
@@ -91,8 +85,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        '/pro-connect/apres-authentification',
-        donneesServeur.portEcoute
+        '/pro-connect/apres-authentification'
       );
 
       expect(reponse.statusCode).toStrictEqual(302);
@@ -114,8 +107,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        '/pro-connect/apres-authentification',
-        donneesServeur.portEcoute
+        '/pro-connect/apres-authentification'
       );
 
       expect(reponse.statusCode).toStrictEqual(401);
@@ -134,8 +126,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        '/pro-connect/apres-authentification',
-        donneesServeur.portEcoute
+        '/pro-connect/apres-authentification'
       );
 
       expect(reponse.statusCode).toStrictEqual(302);
@@ -170,8 +161,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          '/pro-connect/apres-authentification',
-          donneesServeur.portEcoute
+          '/pro-connect/apres-authentification'
         );
 
         expect(reponse.statusCode).toStrictEqual(302);
@@ -211,8 +201,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          '/pro-connect/apres-authentification',
-          donneesServeur.portEcoute
+          '/pro-connect/apres-authentification'
         );
 
         expect(reponse.statusCode).toStrictEqual(302);
@@ -240,8 +229,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
         await executeRequete(
           donneesServeur.app,
           'GET',
-          '/pro-connect/apres-authentification',
-          donneesServeur.portEcoute
+          '/pro-connect/apres-authentification'
         );
 
         const aidantTrouve = await unServiceAidant(
@@ -268,8 +256,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          '/pro-connect/apres-authentification',
-          donneesServeur.portEcoute
+          '/pro-connect/apres-authentification'
         );
 
         expect(reponse.statusCode).toStrictEqual(302);
@@ -304,8 +291,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          '/pro-connect/apres-authentification',
-          donneesServeur.portEcoute
+          '/pro-connect/apres-authentification'
         );
 
         expect(reponse.headers['location']).toStrictEqual(
@@ -329,8 +315,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          '/pro-connect/apres-authentification',
-          donneesServeur.portEcoute
+          '/pro-connect/apres-authentification'
         );
 
         expect(reponse.headers['location']).toStrictEqual(
@@ -346,8 +331,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
           const reponse = await executeRequete(
             donneesServeur.app,
             'GET',
-            '/pro-connect/apres-authentification',
-            donneesServeur.portEcoute
+            '/pro-connect/apres-authentification'
           );
 
           expect(reponse.headers['location']).toStrictEqual(
@@ -373,8 +357,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        '/pro-connect/apres-deconnexion?state=etat',
-        donneesServeur.portEcoute
+        '/pro-connect/apres-deconnexion?state=etat'
       );
 
       const objet = enObjet<{ ProConnectInfo: string; [clef: string]: string }>(
@@ -392,8 +375,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        '/pro-connect/apres-deconnexion?state=etat2',
-        donneesServeur.portEcoute
+        '/pro-connect/apres-deconnexion?state=etat2'
       );
 
       expect(reponse.statusCode).toBe(401);
@@ -405,8 +387,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        '/pro-connect/apres-deconnexion?state=etat2',
-        donneesServeur.portEcoute
+        '/pro-connect/apres-deconnexion?state=etat2'
       );
 
       expect(reponse.statusCode).toBe(401);
@@ -433,8 +414,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        '/pro-connect/deconnexion',
-        donneesServeur.portEcoute
+        '/pro-connect/deconnexion'
       );
 
       expect(reponse.statusCode).toBe(302);
@@ -453,8 +433,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        '/pro-connect/deconnexion',
-        donneesServeur.portEcoute
+        '/pro-connect/deconnexion'
       );
 
       expect(reponse.statusCode).toBe(401);
@@ -471,8 +450,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        '/pro-connect/deconnexion',
-        donneesServeur.portEcoute
+        '/pro-connect/deconnexion'
       );
 
       expect(reponse.statusCode).toBe(401);

--- a/mon-aide-cyber-api/test/api/recherche-entreprise/routesAPIRechercheEntreprise.spec.ts
+++ b/mon-aide-cyber-api/test/api/recherche-entreprise/routesAPIRechercheEntreprise.spec.ts
@@ -6,7 +6,7 @@ import { ReponseRechercheEntreprise } from '../../../src/api/recherche-entrepris
 
 describe('Le serveur MAC, sur les routes de recherche entreprise', () => {
   const testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
 
   beforeEach(() => {
     donneesServeur = testeurMAC.initialise();
@@ -30,8 +30,7 @@ describe('Le serveur MAC, sur les routes de recherche entreprise', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        '/api/recherche-entreprise?nom=beta',
-        donneesServeur.portEcoute
+        '/api/recherche-entreprise?nom=beta'
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -59,8 +58,7 @@ describe('Le serveur MAC, sur les routes de recherche entreprise', () => {
       await executeRequete(
         donneesServeur.app,
         'GET',
-        '/api/recherche-entreprise?nom=agence%20nationale%20de%20s%C3%A9curit%C3%A9%20des%20syst%C3%A8mes%20d%E2%80%99information',
-        donneesServeur.portEcoute
+        '/api/recherche-entreprise?nom=agence%20nationale%20de%20s%C3%A9curit%C3%A9%20des%20syst%C3%A8mes%20d%E2%80%99information'
       );
 
       expect(testeurMAC.adaptateurDeRequeteHTTP.requeteAttendue).toStrictEqual(
@@ -76,8 +74,7 @@ describe('Le serveur MAC, sur les routes de recherche entreprise', () => {
       await executeRequete(
         donneesServeur.app,
         'GET',
-        '/api/recherche-entreprise?nom=beta&est_association=true',
-        donneesServeur.portEcoute
+        '/api/recherche-entreprise?nom=beta&est_association=true'
       );
 
       expect(testeurMAC.adaptateurDeRequeteHTTP.requeteAttendue).toStrictEqual(
@@ -96,8 +93,7 @@ describe('Le serveur MAC, sur les routes de recherche entreprise', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        '/api/recherche-entreprise?nom=agence%20nationale%20de%20s%C3%A9curit%C3%A9%20des%20syst%C3%A8mes%20d%E2%80%99information',
-        donneesServeur.portEcoute
+        '/api/recherche-entreprise?nom=agence%20nationale%20de%20s%C3%A9curit%C3%A9%20des%20syst%C3%A8mes%20d%E2%80%99information'
       );
 
       expect(reponse.statusCode).toBe(400);

--- a/mon-aide-cyber-api/test/api/routeAPIContexte.spec.ts
+++ b/mon-aide-cyber-api/test/api/routeAPIContexte.spec.ts
@@ -12,7 +12,7 @@ import { unConstructeurDeJwtPayload } from '../constructeurs/constructeurJwtPayl
 
 describe('Route contexte', () => {
   const testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
 
   beforeEach(() => {
     donneesServeur = testeurMAC.initialise();
@@ -26,8 +26,7 @@ describe('Route contexte', () => {
     const reponse = await executeRequete(
       donneesServeur.app,
       'GET',
-      `/api/contexte`,
-      donneesServeur.portEcoute
+      `/api/contexte`
     );
 
     expect(reponse.statusCode).toBe(200);
@@ -40,8 +39,7 @@ describe('Route contexte', () => {
     const reponse = await executeRequete(
       donneesServeur.app,
       'GET',
-      `/api/contexte?contexte=demande-devenir-aidant:finalise-creation-espace-aidant`,
-      donneesServeur.portEcoute
+      `/api/contexte?contexte=demande-devenir-aidant:finalise-creation-espace-aidant`
     );
 
     expect(reponse.statusCode).toBe(200);
@@ -57,7 +55,7 @@ describe('Route contexte', () => {
 
   describe('Dans le cas d’un Aidant avec espace ayant une session', () => {
     const testeurMAC = testeurIntegration();
-    let donneesServeur: { portEcoute: number; app: Express };
+    let donneesServeur: { app: Express };
 
     beforeEach(async () => {
       donneesServeur = testeurMAC.initialise();
@@ -75,8 +73,7 @@ describe('Route contexte', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/contexte`,
-        donneesServeur.portEcoute
+        `/api/contexte`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -94,8 +91,7 @@ describe('Route contexte', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/contexte?contexte=afficher-statistiques`,
-        donneesServeur.portEcoute
+        `/api/contexte?contexte=afficher-statistiques`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -132,8 +128,7 @@ describe('Route contexte', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          `/api/contexte`,
-          donneesServeur.portEcoute
+          `/api/contexte`
         );
 
         expect(reponse.statusCode).toBe(200);

--- a/mon-aide-cyber-api/test/api/routeContact.spec.ts
+++ b/mon-aide-cyber-api/test/api/routeContact.spec.ts
@@ -6,7 +6,7 @@ import { AdaptateurEnvoiMailMemoire } from '../../src/infrastructure/adaptateurs
 
 describe('le serveur MAC sur les routes /contact', () => {
   let testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
 
   beforeEach(() => {
     testeurMAC = testeurIntegration();
@@ -23,7 +23,6 @@ describe('le serveur MAC sur les routes /contact', () => {
         donneesServeur.app,
         'POST',
         '/contact/',
-        donneesServeur.portEcoute,
         {
           nom: 'Jean Dupont',
           email: 'jean-dupont@email.com',
@@ -51,7 +50,6 @@ describe('le serveur MAC sur les routes /contact', () => {
         donneesServeur.app,
         'POST',
         '/contact/',
-        donneesServeur.portEcoute,
         {
           nom: 'Jean Dupont',
           email: 'jean-dupont@email.com',
@@ -71,7 +69,6 @@ describe('le serveur MAC sur les routes /contact', () => {
           donneesServeur.app,
           'POST',
           '/contact/',
-          donneesServeur.portEcoute,
           {
             nom: ' ',
             email: 'jean-dupont@email.com',
@@ -91,7 +88,6 @@ describe('le serveur MAC sur les routes /contact', () => {
           donneesServeur.app,
           'POST',
           '/contact/',
-          donneesServeur.portEcoute,
           {
             nom: 'Jean Dupont',
             email: 'mauvais-email.com',
@@ -111,7 +107,6 @@ describe('le serveur MAC sur les routes /contact', () => {
           donneesServeur.app,
           'POST',
           '/contact/',
-          donneesServeur.portEcoute,
           {
             nom: 'Jean Dupont',
             email: 'jean-dupont@email.com',
@@ -133,7 +128,6 @@ describe('le serveur MAC sur les routes /contact', () => {
           donneesServeur.app,
           'POST',
           '/contact/',
-          donneesServeur.portEcoute,
           {
             nom: 'Jean <b>Dupont</b>',
             email: 'jean-dupont@email.com',
@@ -158,7 +152,6 @@ describe('le serveur MAC sur les routes /contact', () => {
           donneesServeur.app,
           'POST',
           '/contact/',
-          donneesServeur.portEcoute,
           {
             nom: 'Jean Dupont',
             email: 'jean-dupont@email.com',

--- a/mon-aide-cyber-api/test/api/routesAPIAuthentification.spec.ts
+++ b/mon-aide-cyber-api/test/api/routesAPIAuthentification.spec.ts
@@ -15,7 +15,7 @@ import { FournisseurHorlogeDeTest } from '../infrastructure/horloge/FournisseurH
 
 describe("Le serveur MAC, sur les routes d'authentification", () => {
   const testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
 
   beforeEach(() => {
     donneesServeur = testeurMAC.initialise();
@@ -54,7 +54,6 @@ describe("Le serveur MAC, sur les routes d'authentification", () => {
             donneesServeur.app,
             'POST',
             '/api/token',
-            donneesServeur.portEcoute,
             {
               identifiant: 'martin.dupont@email.com',
               motDePasse: 'mon_Mot-D3p4sse',
@@ -116,7 +115,6 @@ describe("Le serveur MAC, sur les routes d'authentification", () => {
             donneesServeur.app,
             'POST',
             '/api/token',
-            donneesServeur.portEcoute,
             {
               identifiant: 'martin.dupont@email.com',
               motDePasse: 'mon_Mot-D3p4sse',
@@ -170,7 +168,6 @@ describe("Le serveur MAC, sur les routes d'authentification", () => {
             donneesServeur.app,
             'POST',
             '/api/token',
-            donneesServeur.portEcoute,
             {
               identifiant: 'martin.dupont@email.com',
               motDePasse: 'mon_Mot-D3p4sse',
@@ -208,7 +205,6 @@ describe("Le serveur MAC, sur les routes d'authentification", () => {
           donneesServeur.app,
           'POST',
           '/api/token',
-          donneesServeur.portEcoute,
           {
             identifiant: 'existe@pas.fr',
             motDePasse: 'mon_Mot-D3p4sse',
@@ -237,7 +233,6 @@ describe("Le serveur MAC, sur les routes d'authentification", () => {
           donneesServeur.app,
           'POST',
           '/api/token',
-          donneesServeur.portEcoute,
           {
             identifiant: 'MARTIN.DUPONT@EMAIL.COM',
             motDePasse: 'mon_Mot-D3p4sse',
@@ -286,7 +281,6 @@ describe("Le serveur MAC, sur les routes d'authentification", () => {
           donneesServeur.app,
           'POST',
           '/api/token',
-          donneesServeur.portEcoute,
           {
             identifiant: 'jean.dujardin@email.com',
             motDePasse: 'mon_Mot-D3p4sse',
@@ -317,7 +311,6 @@ describe("Le serveur MAC, sur les routes d'authentification", () => {
           donneesServeur.app,
           'DELETE',
           '/api/token',
-          donneesServeur.portEcoute,
           undefined,
           { 'set-cookie': [] }
         );

--- a/mon-aide-cyber-api/test/api/routesAPIDiagnostic.spec.ts
+++ b/mon-aide-cyber-api/test/api/routesAPIDiagnostic.spec.ts
@@ -31,7 +31,7 @@ import {
 
 describe('Le serveur MAC sur les routes /api/diagnostic', () => {
   const testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
 
   beforeEach(() => {
     testeurMAC.adaptateurDeVerificationDeSession.reinitialise();
@@ -63,8 +63,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic/${diagnostic.identifiant}`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/${diagnostic.identifiant}`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -91,8 +90,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic/id-inexistant`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/id-inexistant`
       );
 
       expect(reponse.statusCode).toBe(404);
@@ -106,8 +104,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic/ed89a4fa-6db5-48d9-a4e2-1b424acd3b47`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/ed89a4fa-6db5-48d9-a4e2-1b424acd3b47`
       );
 
       expect(
@@ -119,8 +116,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic/ed89a4fa-6db5-48d9-a4e2-1b424acd3b47`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/ed89a4fa-6db5-48d9-a4e2-1b424acd3b47`
       );
 
       expect(testeurMAC.adaptateurDeVerificationDeCGU.verifiePassage()).toBe(
@@ -139,8 +135,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic/${identifiantDiagnostic}`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/${identifiantDiagnostic}`
       );
 
       expect(
@@ -163,8 +158,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic/${identifiantDiagnostic}`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/${identifiantDiagnostic}`
       );
 
       expect(
@@ -185,8 +179,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'POST',
-        '/api/diagnostic',
-        donneesServeur.portEcoute
+        '/api/diagnostic'
       );
 
       expect(reponse.statusCode).toBe(201);
@@ -203,16 +196,14 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       const reponseCreation = await executeRequete(
         donneesServeur.app,
         'POST',
-        '/api/diagnostic',
-        donneesServeur.portEcoute
+        '/api/diagnostic'
       );
       const lien = reponseCreation.headers['link'] as string;
 
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `${lien}`,
-        donneesServeur.portEcoute
+        `${lien}`
       );
 
       const diagnosticRetourne = await reponse.json();
@@ -227,8 +218,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'POST',
-        '/api/diagnostic',
-        donneesServeur.portEcoute
+        '/api/diagnostic'
       );
 
       expect(reponse.statusCode).toBe(500);
@@ -238,12 +228,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
     });
 
     it('La route est protégée', async () => {
-      await executeRequete(
-        donneesServeur.app,
-        'POST',
-        `/api/diagnostic/`,
-        donneesServeur.portEcoute
-      );
+      await executeRequete(donneesServeur.app, 'POST', `/api/diagnostic/`);
 
       expect(
         testeurMAC.adaptateurDeVerificationDeSession.verifiePassage()
@@ -251,12 +236,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
     });
 
     it('Vérifie que les CGU et la charte ont été signées', async () => {
-      await executeRequete(
-        donneesServeur.app,
-        'POST',
-        `/api/diagnostic/`,
-        donneesServeur.portEcoute
-      );
+      await executeRequete(donneesServeur.app, 'POST', `/api/diagnostic/`);
 
       expect(testeurMAC.adaptateurDeVerificationDeCGU.verifiePassage()).toBe(
         true
@@ -287,7 +267,6 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
         donneesServeur.app,
         'PATCH',
         `/api/diagnostic/${diagnostic.identifiant}`,
-        donneesServeur.portEcoute,
         {
           chemin: 'contexte',
           identifiant: 'une-question-',
@@ -328,7 +307,6 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
         donneesServeur.app,
         'PATCH',
         `/api/diagnostic/ed89a4fa-6db5-48d9-a4e2-1b424acd3b47`,
-        donneesServeur.portEcoute,
         {
           chemin: 'contexte',
           identifiant: 'une-question-',
@@ -346,8 +324,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       await executeRequete(
         donneesServeur.app,
         'PATCH',
-        `/api/diagnostic/ed89a4fa-6db5-48d9-a4e2-1b424acd3b47`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/ed89a4fa-6db5-48d9-a4e2-1b424acd3b47`
       );
 
       expect(
@@ -359,8 +336,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       await executeRequete(
         donneesServeur.app,
         'PATCH',
-        `/api/diagnostic/ed89a4fa-6db5-48d9-a4e2-1b424acd3b47`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/ed89a4fa-6db5-48d9-a4e2-1b424acd3b47`
       );
 
       expect(testeurMAC.adaptateurDeVerificationDeCGU.verifiePassage()).toBe(
@@ -372,8 +348,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       await executeRequete(
         donneesServeur.app,
         'PATCH',
-        `/api/diagnostic/ed89a4fa-6db5-48d9-a4e2-1b424acd3b47`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/ed89a4fa-6db5-48d9-a4e2-1b424acd3b47`
       );
 
       expect(
@@ -396,8 +371,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       await executeRequete(
         donneesServeur.app,
         'PATCH',
-        `/api/diagnostic/${identifiantDiagnostic}`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/${identifiantDiagnostic}`
       );
 
       expect(
@@ -428,8 +402,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic/${identifiant}/restitution`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/${identifiant}/restitution`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -501,8 +474,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic/${identifiant}/restitution`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/${identifiant}/restitution`
       );
 
       expect((await reponse.json()).liens['se-deconnecter']).toStrictEqual({
@@ -527,7 +499,6 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
         donneesServeur.app,
         'GET',
         `/api/diagnostic/${restitution.identifiant}/restitution`,
-        donneesServeur.portEcoute,
         undefined,
         { accept: 'application/pdf' }
       );
@@ -541,8 +512,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic/${crypto.randomUUID()}/restitution`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/${crypto.randomUUID()}/restitution`
       );
 
       expect(
@@ -554,8 +524,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic/${crypto.randomUUID()}/restitution`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/${crypto.randomUUID()}/restitution`
       );
 
       expect(testeurMAC.adaptateurDeVerificationDeCGU.verifiePassage()).toBe(
@@ -567,8 +536,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic/${crypto.randomUUID()}/restitution`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/${crypto.randomUUID()}/restitution`
       );
 
       expect(reponse.statusCode).toBe(404);
@@ -581,8 +549,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic/ed89a4fa-6db5-48d9-a4e2-1b424acd3b47/restitution`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/ed89a4fa-6db5-48d9-a4e2-1b424acd3b47/restitution`
       );
 
       expect(
@@ -605,8 +572,7 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/diagnostic/${identifiantDiagnostic}/restitution`,
-        donneesServeur.portEcoute
+        `/api/diagnostic/${identifiantDiagnostic}/restitution`
       );
 
       expect(

--- a/mon-aide-cyber-api/test/api/routesAPIUtilisateur.spec.ts
+++ b/mon-aide-cyber-api/test/api/routesAPIUtilisateur.spec.ts
@@ -32,7 +32,7 @@ import { UtilisateurInscrit } from '../../src/espace-utilisateur-inscrit/Utilisa
 
 describe('Le serveur MAC sur les routes /api/utilisateur', () => {
   const testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
   let adaptateurDeVerificationDeSession: AdaptateurDeVerificationDeSessionDeTest;
 
   beforeEach(() => {
@@ -63,8 +63,7 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          `/api/utilisateur/`,
-          donneesServeur.portEcoute
+          `/api/utilisateur/`
         );
 
         expect(reponse.statusCode).toBe(200);
@@ -114,8 +113,7 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          `/api/utilisateur/`,
-          donneesServeur.portEcoute
+          `/api/utilisateur/`
         );
 
         expect(reponse.statusCode).toBe(200);
@@ -159,8 +157,7 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/utilisateur/`,
-        donneesServeur.portEcoute
+        `/api/utilisateur/`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -186,8 +183,7 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/utilisateur/`,
-        donneesServeur.portEcoute
+        `/api/utilisateur/`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -222,8 +218,7 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/utilisateur/`,
-        donneesServeur.portEcoute
+        `/api/utilisateur/`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -258,8 +253,7 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/utilisateur/`,
-        donneesServeur.portEcoute
+        `/api/utilisateur/`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -296,8 +290,7 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/utilisateur/`,
-        donneesServeur.portEcoute
+        `/api/utilisateur/`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -335,8 +328,7 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/utilisateur/`,
-        donneesServeur.portEcoute
+        `/api/utilisateur/`
       );
 
       expect(reponse.statusCode).toBe(404);
@@ -364,8 +356,7 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          `/api/utilisateur?contexte=demande-devenir-aidant:finalise-creation-espace-aidant`,
-          donneesServeur.portEcoute
+          `/api/utilisateur?contexte=demande-devenir-aidant:finalise-creation-espace-aidant`
         );
 
         expect(reponse.statusCode).toBe(403);
@@ -383,7 +374,7 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
 
     describe('Dans le cas du nouveau parcours devenir Aidant', () => {
       const testeurMAC = testeurIntegration();
-      let donneesServeur: { portEcoute: number; app: Express };
+      let donneesServeur: { app: Express };
       let adaptateurDeVerificationDeSession: AdaptateurDeVerificationDeSessionDeTest;
 
       beforeEach(() => {
@@ -415,8 +406,7 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          `/api/utilisateur/`,
-          donneesServeur.portEcoute
+          `/api/utilisateur/`
         );
 
         expect(reponse.statusCode).toBe(200);
@@ -455,8 +445,7 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         const reponse = await executeRequete(
           donneesServeur.app,
           'GET',
-          `/api/utilisateur/`,
-          donneesServeur.portEcoute
+          `/api/utilisateur/`
         );
 
         expect(reponse.statusCode).toBe(200);
@@ -504,7 +493,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'POST',
         `/api/utilisateur/reinitialisation-mot-de-passe`,
-        donneesServeur.portEcoute,
         {
           email: utilisateur.identifiantConnexion,
         }
@@ -518,7 +506,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'POST',
         `/api/utilisateur/reinitialisation-mot-de-passe`,
-        donneesServeur.portEcoute,
         {
           email: 'email-inconnu',
         }
@@ -532,7 +519,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'POST',
         `/api/utilisateur/reinitialisation-mot-de-passe`,
-        donneesServeur.portEcoute,
         {
           email: 'email-inconnu',
         }
@@ -566,7 +552,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'PATCH',
         `/api/utilisateur/reinitialiser-mot-de-passe`,
-        donneesServeur.portEcoute,
         {
           motDePasse: 'n0uv3eaU-M0D3passe',
           confirmationMotDePasse: 'n0uv3eaU-M0D3passe',
@@ -605,7 +590,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'PATCH',
         `/api/utilisateur/reinitialiser-mot-de-passe`,
-        donneesServeur.portEcoute,
         {
           motDePasse: 'n0uv3eaU-M0D3passe',
           confirmationMotDePasse: 'n0uv3eaU-M0D3passe',
@@ -639,7 +623,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
           donneesServeur.app,
           'PATCH',
           `/api/utilisateur/reinitialiser-mot-de-passe`,
-          donneesServeur.portEcoute,
           {
             motDePasse: 'n0uV3eaU-M0D3passe',
             confirmationMotDePasse: 'n0uv3eaU-M0D3passe',
@@ -667,7 +650,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
           donneesServeur.app,
           'PATCH',
           `/api/utilisateur/reinitialiser-mot-de-passe`,
-          donneesServeur.portEcoute,
           {
             motDePasse: 'n0uv3eaU-M0D3passe',
             confirmationMotDePasse: 'n0uv3eaU-M0D3passe',
@@ -685,7 +667,7 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
 
   describe("Lorsqu'une requête POST est reçue sur /utilisateur/valider-signature-cgu", () => {
     const testeurMAC = testeurIntegration();
-    let donneesServeur: { portEcoute: number; app: Express };
+    let donneesServeur: { app: Express };
     beforeEach(() => {
       testeurMAC.adaptateurDeVerificationDeSession =
         new AdaptateurDeVerificationDeSessionDeTest();
@@ -705,7 +687,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'POST',
         `/api/utilisateur/valider-signature-cgu`,
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
         }
@@ -731,7 +712,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
           donneesServeur.app,
           'POST',
           `/api/utilisateur/valider-signature-cgu`,
-          donneesServeur.portEcoute,
           {
             cguValidees: true,
           }
@@ -761,7 +741,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
           donneesServeur.app,
           'POST',
           `/api/utilisateur/valider-signature-cgu`,
-          donneesServeur.portEcoute,
           {
             cguValidees: true,
           }
@@ -809,7 +788,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
           donneesServeur.app,
           'POST',
           `/api/utilisateur/valider-signature-cgu`,
-          donneesServeur.portEcoute,
           {
             cguValidees: true,
           }
@@ -838,7 +816,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
           donneesServeur.app,
           'POST',
           `/api/utilisateur/valider-signature-cgu`,
-          donneesServeur.portEcoute,
           {
             cguValidees: false,
           }
@@ -877,7 +854,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
           donneesServeur.app,
           'POST',
           `/api/utilisateur/valider-signature-cgu`,
-          donneesServeur.portEcoute,
           {
             cguValidees: true,
           }
@@ -910,7 +886,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
           donneesServeur.app,
           'POST',
           `/api/utilisateur/valider-signature-cgu`,
-          donneesServeur.portEcoute,
           {
             cguValidees: true,
           }
@@ -952,7 +927,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
           donneesServeur.app,
           'POST',
           `/api/utilisateur/valider-signature-cgu`,
-          donneesServeur.portEcoute,
           {
             cguValidees: true,
           }
@@ -969,7 +943,7 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
 
   describe('Quand une requête POST est reçue sur /api/utilisateur/valider-profil-aidant', () => {
     const testeurMAC = testeurIntegration();
-    let donneesServeur: { portEcoute: number; app: Express };
+    let donneesServeur: { app: Express };
 
     beforeEach(() => {
       donneesServeur = testeurMAC.initialise();
@@ -999,7 +973,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'POST',
         `/api/utilisateur/valider-profil-aidant`,
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
           signatureCharte: true,
@@ -1058,7 +1031,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'POST',
         `/api/utilisateur/valider-profil-aidant`,
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
           signatureCharte: true,
@@ -1108,7 +1080,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'POST',
         `/api/utilisateur/valider-profil-aidant`,
-        donneesServeur.portEcoute,
         {
           cguValidees: false,
           signatureCharte: true,
@@ -1156,7 +1127,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'POST',
         `/api/utilisateur/valider-profil-aidant`,
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
           signatureCharte: false,
@@ -1190,7 +1160,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'POST',
         `/api/utilisateur/valider-profil-aidant`,
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
           signatureCharte: true,
@@ -1217,7 +1186,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'POST',
         `/api/utilisateur/valider-profil-aidant`,
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
           signatureCharte: true,
@@ -1235,7 +1203,7 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
 
   describe('Quand une requête POST est reçue sur /api/utilisateur/valider-profil-utilisateur-inscrit', () => {
     const testeurMAC = testeurIntegration();
-    let donneesServeur: { portEcoute: number; app: Express };
+    let donneesServeur: { app: Express };
 
     beforeEach(() => {
       donneesServeur = testeurMAC.initialise();
@@ -1263,7 +1231,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'POST',
         `/api/utilisateur/valider-profil-utilisateur-inscrit`,
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
         }
@@ -1310,7 +1277,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'POST',
         `/api/utilisateur/valider-profil-utilisateur-inscrit`,
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
         }
@@ -1347,7 +1313,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'POST',
         `/api/utilisateur/valider-profil-utilisateur-inscrit`,
-        donneesServeur.portEcoute,
         {
           cguValidees: false,
         }
@@ -1382,7 +1347,6 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
         donneesServeur.app,
         'POST',
         `/api/utilisateur/valider-profil-utilisateur-inscrit`,
-        donneesServeur.portEcoute,
         {
           cguValidees: true,
         }

--- a/mon-aide-cyber-api/test/api/statistiques/routesStatistiques.spec.ts
+++ b/mon-aide-cyber-api/test/api/statistiques/routesStatistiques.spec.ts
@@ -40,7 +40,7 @@ const unConstructeurDeStatistiques = () => new ConstructeurDeStatistiques();
 
 describe('Le serveur MAC sur les routes /statistiques', () => {
   const testeurMAC = testeurIntegration();
-  let donneesServeur: { portEcoute: number; app: Express };
+  let donneesServeur: { app: Express };
 
   beforeEach(() => {
     testeurMAC.entrepots = new EntrepotsMemoire();
@@ -64,8 +64,7 @@ describe('Le serveur MAC sur les routes /statistiques', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/statistiques`,
-        donneesServeur.portEcoute
+        `/statistiques`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -87,8 +86,7 @@ describe('Le serveur MAC sur les routes /statistiques', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/statistiques`,
-        donneesServeur.portEcoute
+        `/statistiques`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -108,8 +106,7 @@ describe('Le serveur MAC sur les routes /statistiques', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/statistiques`,
-        donneesServeur.portEcoute
+        `/statistiques`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -131,8 +128,7 @@ describe('Le serveur MAC sur les routes /statistiques', () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/statistiques`,
-        donneesServeur.portEcoute
+        `/statistiques`
       );
 
       const corprDeReponse: ReponseStatistiques = await reponse.json();

--- a/mon-aide-cyber-api/test/api/tableau-de-bord/routesAPITableauDeBord.spec.ts
+++ b/mon-aide-cyber-api/test/api/tableau-de-bord/routesAPITableauDeBord.spec.ts
@@ -14,7 +14,7 @@ import { ReponseDiagnostics } from '../../../src/api/tableau-de-bord/routesAPITa
 describe('le serveur MAC sur les routes /api/mon-espace/tableau-de-bord', () => {
   describe('quand une requête GET est reçue sur /', () => {
     const testeurMAC = testeurIntegration();
-    let donneesServeur: { portEcoute: number; app: Express };
+    let donneesServeur: { app: Express };
 
     beforeEach(() => {
       donneesServeur = testeurMAC.initialise();
@@ -39,8 +39,7 @@ describe('le serveur MAC sur les routes /api/mon-espace/tableau-de-bord', () => 
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/mon-espace/tableau-de-bord`,
-        donneesServeur.portEcoute
+        `/api/mon-espace/tableau-de-bord`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -79,8 +78,7 @@ describe('le serveur MAC sur les routes /api/mon-espace/tableau-de-bord', () => 
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/mon-espace/tableau-de-bord`,
-        donneesServeur.portEcoute
+        `/api/mon-espace/tableau-de-bord`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -124,8 +122,7 @@ describe('le serveur MAC sur les routes /api/mon-espace/tableau-de-bord', () => 
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/mon-espace/tableau-de-bord`,
-        donneesServeur.portEcoute
+        `/api/mon-espace/tableau-de-bord`
       );
 
       expect(reponse.statusCode).toBe(200);
@@ -175,8 +172,7 @@ describe('le serveur MAC sur les routes /api/mon-espace/tableau-de-bord', () => 
       await executeRequete(
         donneesServeur.app,
         'GET',
-        `/api/mon-espace/tableau-de-bord`,
-        donneesServeur.portEcoute
+        `/api/mon-espace/tableau-de-bord`
       );
 
       expect(testeurMAC.adaptateurDeVerificationDeCGU.verifiePassage()).toBe(

--- a/mon-aide-cyber-api/test/api/testeurIntegration.ts
+++ b/mon-aide-cyber-api/test/api/testeurIntegration.ts
@@ -3,7 +3,6 @@ import { AdaptateurReferentielDeTest } from '../adaptateurs/AdaptateurReferentie
 import { AdaptateurTranscripteurDeTest } from '../adaptateurs/adaptateurTranscripteur';
 import { AdaptateurMesuresTest } from '../adaptateurs/AdaptateurMesuresTest';
 import { Express } from 'express';
-import { fakerFR } from '@faker-js/faker';
 import { EntrepotsMemoire } from '../../src/infrastructure/entrepots/memoire/EntrepotsMemoire';
 import { BusEvenementDeTest } from '../infrastructure/bus/BusEvenementDeTest';
 import { AdaptateurGestionnaireErreursMemoire } from '../../src/infrastructure/adaptateurs/AdaptateurGestionnaireErreursMemoire';
@@ -28,6 +27,8 @@ import { AdaptateurDeVerificationDuTypeDeRelationDeTest } from '../adaptateurs/A
 import { AdaptateurProConnect } from '../../src/adaptateurs/pro-connect/adaptateurProConnect';
 import { AdaptateurProConnectDeTest } from '../adaptateurs/pro-connect/AdaptateurProConnectDeTest';
 import { AdaptateurDeRequeteHTTPMemoire } from '../adaptateurs/AdaptateurDeRequeteHTTPMemoire';
+
+const PORT_DISPONIBLE = 0;
 
 class TesteurIntegrationMAC {
   private serveurDeTest:
@@ -108,7 +109,7 @@ class TesteurIntegrationMAC {
       adaptateurDeRequeteHTTP: this.adaptateurDeRequeteHTTP,
       estEnMaintenance: false,
     });
-    const portEcoute = fakerFR.number.int({ min: 10000, max: 20000 });
+    const portEcoute = PORT_DISPONIBLE;
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     this.serveurDeTest.ecoute(portEcoute, () => {});
     return { portEcoute: portEcoute, app: this.serveurDeTest.app };


### PR DESCRIPTION
- Les tests échouaient de manière aléatoire malgré la génération aléatoire d'un nombre compris entre 10_000 et 20_000
- La configuration du port express à 0 a comme effet de rechercher le premier port libre