### PR TITLE
[CORRECTION][CHARTE AIDANT] Retire les mentions Lu et approuvé en bas de charte WEB

### DIFF
--- a/mon-aide-cyber-ui/src/vues/CharteAidant.tsx
+++ b/mon-aide-cyber-ui/src/vues/CharteAidant.tsx
@@ -346,11 +346,6 @@ const ContenuCharteAidant = () => (
       non-respect des prérequis, pour être Aidant cyber entraînera la
       suppression de mes accès au service MonAideCyber.
     </p>
-    <p dir="auto"></p>
-    <p dir="auto">Fait à</p>
-    <p dir="auto">Le</p>
-    <p dir="auto">Signature</p>
-    <p dir="auto">Précédée de la mention "Lu et approuvé"</p>
   </div>
 );
 


### PR DESCRIPTION
Contexte
Affichage de la charte Aidant web. Depuis les derniers changements du 31 Janvier 2025, la charte comporte l'encart de signature et de mention Lu et approuvé à la fin du contenu. Cette zone n'est destinée qu'au fichier PDF.

Reproduction

Accéder à la page web de la charte de l'Aidant.
<img width="1705" alt="image" src="https://github.com/user-attachments/assets/630dd462-f98c-43e7-9e0e-4f86fc7e8185" />


Résultat attendu
La zone de signature PDF n'est plus présente
