### PR TITLE
[CORRECTION][PRO CONNECT] Ajoute un middleware de redirection afin de s’assurer que les utilisateurs seront toujours sur l’URL de MAC et éviter les erreurs de connexion ProConnect

### DIFF
--- a/mon-aide-cyber-api/index.ts
+++ b/mon-aide-cyber-api/index.ts
@@ -23,6 +23,7 @@ import { AdaptateurDeVerificationDeTypeDeRelationMAC } from './src/adaptateurs/A
 import { adaptateurProConnect } from './src/adaptateurs/pro-connect/adaptateurProConnect';
 import { adaptateurEnvironnement } from './src/adaptateurs/adaptateurEnvironnement';
 import { AdaptateurDeRequeteHTTP } from './src/infrastructure/adaptateurs/adaptateurDeRequeteHTTP';
+import { redirigeVersUrlBase } from './src/infrastructure/middlewares/middlewares';
 
 const gestionnaireDeJeton = new GestionnaireDeJetonJWT(
   process.env.CLEF_SECRETE_SIGNATURE_JETONS_SESSIONS || 'clef-par-defaut'
@@ -88,6 +89,7 @@ const serveurMAC = serveur.creeServeur({
   adaptateurProConnect: adaptateurProConnect,
   estEnMaintenance: adaptateurEnvironnement.modeMaintenance().estActif(),
   adaptateurDeRequeteHTTP: new AdaptateurDeRequeteHTTP(),
+  redirigeVersUrlBase: redirigeVersUrlBase,
 });
 
 const port = process.env.PORT || 8081;

--- a/mon-aide-cyber-api/src/infrastructure/middlewares/middlewares.ts
+++ b/mon-aide-cyber-api/src/infrastructure/middlewares/middlewares.ts
@@ -1,0 +1,20 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express';
+import { adaptateurEnvironnement } from '../../adaptateurs/adaptateurEnvironnement';
+
+const redirigeVersUrlBase: RequestHandler = (
+  requete: Request,
+  reponse: Response,
+  suite: NextFunction
+): void => {
+  if (
+    requete.headers.host ===
+    new URL(adaptateurEnvironnement.mac().urlMAC()).host
+  ) {
+    return suite();
+  }
+  return reponse.redirect(
+    `${adaptateurEnvironnement.mac().urlMAC()}${requete.originalUrl}`
+  );
+};
+
+export { redirigeVersUrlBase };

--- a/mon-aide-cyber-api/src/serveur.ts
+++ b/mon-aide-cyber-api/src/serveur.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import express, { Request, Response } from 'express';
+import express, { Request, RequestHandler, Response } from 'express';
 import * as http from 'http';
 import routesAPI from './api/routesAPI';
 import { AdaptateurTranscripteur } from './adaptateurs/AdaptateurTranscripteur';
@@ -37,6 +37,7 @@ const ENDPOINTS_SANS_CSRF = ['/api/token'];
 const COOKIE_DUREE_SESSION = 180 * 60 * 1000;
 
 export type ConfigurationServeur = {
+  redirigeVersUrlBase: RequestHandler;
   adaptateurRelations: AdaptateurRelations;
   adaptateurEnvoiMessage: AdaptateurEnvoiMail;
   adaptateurReferentiel: Adaptateur<Referentiel>;
@@ -81,6 +82,8 @@ const creeApp = (config: ConfigurationServeur) => {
     app.use(csrf({ blocklist: ENDPOINTS_SANS_CSRF }));
 
   app.use(config.gestionnaireErreurs.controleurRequete());
+
+  app.use(config.redirigeVersUrlBase);
 
   const limiteurTrafficUI = adaptateurConfigurationLimiteurTraffic('STANDARD');
   app.use(limiteurTrafficUI);

--- a/mon-aide-cyber-api/test/api/testeurIntegration.ts
+++ b/mon-aide-cyber-api/test/api/testeurIntegration.ts
@@ -2,7 +2,7 @@ import serveur from '../../src/serveur';
 import { AdaptateurReferentielDeTest } from '../adaptateurs/AdaptateurReferentielDeTest';
 import { AdaptateurTranscripteurDeTest } from '../adaptateurs/adaptateurTranscripteur';
 import { AdaptateurMesuresTest } from '../adaptateurs/AdaptateurMesuresTest';
-import { Express } from 'express';
+import { Express, NextFunction, Request, Response } from 'express';
 import { EntrepotsMemoire } from '../../src/infrastructure/entrepots/memoire/EntrepotsMemoire';
 import { BusEvenementDeTest } from '../infrastructure/bus/BusEvenementDeTest';
 import { AdaptateurGestionnaireErreursMemoire } from '../../src/infrastructure/adaptateurs/AdaptateurGestionnaireErreursMemoire';
@@ -108,6 +108,11 @@ class TesteurIntegrationMAC {
       adaptateurProConnect: this.adaptateurProConnect,
       adaptateurDeRequeteHTTP: this.adaptateurDeRequeteHTTP,
       estEnMaintenance: false,
+      redirigeVersUrlBase: (
+        _requete: Request,
+        _reponse: Response,
+        suite: NextFunction
+      ) => suite(),
     });
     const portEcoute = PORT_DISPONIBLE;
     // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/mon-aide-cyber-api/test/infrastructure/middlewares/middlewares.spec.ts
+++ b/mon-aide-cyber-api/test/infrastructure/middlewares/middlewares.spec.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { NextFunction, Request, Response } from 'express';
+import { redirigeVersUrlBase } from '../../../src/infrastructure/middlewares/middlewares';
+import { adaptateurEnvironnement } from '../../../src/adaptateurs/adaptateurEnvironnement';
+
+describe('Les middlewares', () => {
+  describe('De redirection', () => {
+    const requete: Request = {} as Request;
+    const reponse: Response = {} as Response;
+    const suite: NextFunction = () => null;
+
+    beforeEach(() => {
+      adaptateurEnvironnement.mac = () => ({
+        urlMAC: () => 'http://domaine:1234',
+      });
+    });
+
+    it("Redirige l'utilisateur vers l'url de base s'il vient d'un sous domaine", () => {
+      requete.headers = { host: 'sousdomaine.domaine:1234' };
+      requete.originalUrl = '/monUrlDemandee';
+      let urlRecue = '';
+      reponse.redirect = (url) => {
+        urlRecue = url as string;
+      };
+
+      redirigeVersUrlBase(requete, reponse, suite);
+
+      expect(urlRecue).toStrictEqual('http://domaine:1234/monUrlDemandee');
+    });
+
+    it("Ne redirige pas l'utilisateur vers l'url de base s'il en provient déjà", () => {
+      let passeDansLaSuite = false;
+      const suite: NextFunction = () => {
+        passeDansLaSuite = true;
+      };
+      requete.headers = { host: 'domaine:1234' };
+      requete.originalUrl = '/monUrlDemandee';
+
+      redirigeVersUrlBase(requete, reponse, suite);
+
+      expect(passeDansLaSuite).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
**Contexte**
Connexion via ProConnect

**Reproduction**
- se rendre sur https://monaidecyber.ssi.gouv.fr 
- se connecter via ProConnect

**Résultat constaté**
L’utilisateur est redirigé vers la page de connexion, un message d’erreur est affiché disant que l’authentification a échoué

**Résultat attendu**
L’utilisateur lorsqu’il se rend sur https://monaidecyber.ssi.gouv.fr est redirigé automatiquement vers https://monaide.cyber.gouv.fr et peut se connecter à ProConnect sans souci