### PR TITLE
[CORRECTION][TRI DES AIDANTS] Rends l'entité optionnelle si l'utilisateur choisit une Association ou qu'il est en attente d'adhésion

### DIFF
--- a/mon-aide-cyber-api/src/api/routesAPIUtilisateur.ts
+++ b/mon-aide-cyber-api/src/api/routesAPIUtilisateur.ts
@@ -74,10 +74,12 @@ const validateurEntite = () => {
     entite: async (__: any, { req }: Meta) => {
       const entite: CorpsEntite = req.body.entite;
       if (
-        ['ServicePublic', 'ServiceEtat', 'Association'].includes(entite.type) &&
+        ['ServicePublic', 'ServiceEtat'].includes(entite.type) &&
         entite.nom.trim().length > 0 &&
         entite.siret.trim().length > 0
       ) {
+        return true;
+      } else if (['Association'].includes(entite.type)) {
         return true;
       }
       throw new Error('L’entité fournie n’est pas cohérente');

--- a/mon-aide-cyber-api/src/api/routesAPIUtilisateur.ts
+++ b/mon-aide-cyber-api/src/api/routesAPIUtilisateur.ts
@@ -118,6 +118,7 @@ export const routesAPIUtilisateur = (configuration: ConfigurationServeur) => {
     busCommande,
     busEvenement,
     serviceDeChiffrement,
+    adaptateurEnvoiMessage,
     adaptateurRelations,
   } = configuration;
 
@@ -364,9 +365,13 @@ export const routesAPIUtilisateur = (configuration: ConfigurationServeur) => {
         });
       }
       return unServiceAidant(entrepots.aidants())
-        .valideProfilAidant(requete.identifiantUtilisateurCourant!, {
-          ...requete.body,
-        })
+        .valideProfilAidant(
+          requete.identifiantUtilisateurCourant!,
+          {
+            ...requete.body,
+          },
+          adaptateurEnvoiMessage
+        )
         .then(() =>
           reponse.status(200).json({
             ...constructeurActionsHATEOAS()

--- a/mon-aide-cyber-api/src/espace-aidant/Aidant.ts
+++ b/mon-aide-cyber-api/src/espace-aidant/Aidant.ts
@@ -49,8 +49,8 @@ type Preferences = {
 export type TypeEntite = 'ServicePublic' | 'ServiceEtat' | 'Association';
 
 export type EntiteAidant = {
-  nom: string;
-  siret: string;
+  nom?: string;
+  siret?: string;
   type: TypeEntite;
 };
 export type Aidant = Aggregat & {

--- a/mon-aide-cyber-api/src/espace-aidant/ServiceAidant.ts
+++ b/mon-aide-cyber-api/src/espace-aidant/ServiceAidant.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import { Siret } from './Aidant';
+import { AdaptateurEnvoiMail } from '../adaptateurs/AdaptateurEnvoiMail';
 
 export type AidantDTO = {
   identifiant: crypto.UUID;
@@ -27,6 +28,7 @@ export interface ServiceAidant {
 
   valideProfilAidant(
     identifiantAidant: crypto.UUID,
-    informationsProfil: InformationsProfil
+    informationsProfil: InformationsProfil,
+    adaptateurEnvoiMail: AdaptateurEnvoiMail
   ): Promise<void>;
 }

--- a/mon-aide-cyber-api/src/espace-aidant/ServiceAidant.ts
+++ b/mon-aide-cyber-api/src/espace-aidant/ServiceAidant.ts
@@ -12,8 +12,8 @@ export type AidantDTO = {
 
 export type InformationsProfil = {
   entite: {
-    nom: string;
-    siret: string;
+    nom?: string;
+    siret?: string;
     type: 'ServicePublic' | 'ServiceEtat' | 'Association';
   };
 };

--- a/mon-aide-cyber-api/src/espace-aidant/ServiceAidantMAC.ts
+++ b/mon-aide-cyber-api/src/espace-aidant/ServiceAidantMAC.ts
@@ -2,6 +2,11 @@ import crypto from 'crypto';
 import { Aidant, EntrepotAidant } from './Aidant';
 import { AidantDTO, InformationsProfil, ServiceAidant } from './ServiceAidant';
 import { FournisseurHorloge } from '../infrastructure/horloge/FournisseurHorloge';
+import { AdaptateurEnvoiMail } from '../adaptateurs/AdaptateurEnvoiMail';
+import { adaptateurCorpsMessage } from './adaptateurCorpsMessage';
+import { fabriqueAnnuaireCOT } from '../infrastructure/adaptateurs/fabriqueAnnuaireCOT';
+import { Departement } from '../gestion-demandes/departements';
+import { adaptateurEnvironnement } from '../adaptateurs/adaptateurEnvironnement';
 
 class ServiceAidantMAC implements ServiceAidant {
   constructor(private readonly entrepotAidant: EntrepotAidant) {}
@@ -31,13 +36,42 @@ class ServiceAidantMAC implements ServiceAidant {
 
   valideProfilAidant(
     identifiantAidant: crypto.UUID,
-    informationsProfil: InformationsProfil
+    informationsProfil: InformationsProfil,
+    adaptateurEnvoiMail: AdaptateurEnvoiMail,
+    annuaireCOT: () => {
+      rechercheEmailParDepartement: (departement: Departement) => string;
+    } = fabriqueAnnuaireCOT().annuaireCOT
   ): Promise<void> {
     return this.entrepotAidant.lis(identifiantAidant).then(async (aidant) => {
       aidant.dateSignatureCGU = FournisseurHorloge.maintenant();
       aidant.dateSignatureCharte = FournisseurHorloge.maintenant();
       aidant.entite = informationsProfil.entite;
-      return await this.entrepotAidant.persiste(aidant);
+      return this.entrepotAidant.persiste(aidant).then(() => {
+        if (
+          aidant.entite?.type === 'Association' &&
+          !aidant.entite.nom &&
+          !aidant.entite.siret
+        ) {
+          const destinataireEnCopie =
+            !!aidant.preferences.departements &&
+            aidant.preferences.departements.length > 0
+              ? annuaireCOT().rechercheEmailParDepartement(
+                  aidant.preferences.departements[0]
+                )
+              : adaptateurEnvironnement.messagerie().emailMAC();
+
+          return adaptateurEnvoiMail.envoie({
+            objet:
+              'MonAideCyber - Votre inscription au dispositif est confirmée',
+            corps: adaptateurCorpsMessage
+              .confirmationProfilAidantSansAssociation()
+              .genereCorpsMessage(aidant),
+            destinataire: { email: aidant.email },
+            copie: destinataireEnCopie,
+          });
+        }
+        return;
+      });
     });
   }
 

--- a/mon-aide-cyber-api/src/espace-aidant/adaptateurCorpsMessage.ts
+++ b/mon-aide-cyber-api/src/espace-aidant/adaptateurCorpsMessage.ts
@@ -1,0 +1,40 @@
+import { Aidant } from './Aidant';
+import { FournisseurHorloge } from '../infrastructure/horloge/FournisseurHorloge';
+import { adaptateurEnvironnement } from '../adaptateurs/adaptateurEnvironnement';
+
+function genereCorpsConfirmationProfilAidantSansAssociation(aidant: Aidant) {
+  return (
+    '<html lang="fr">' +
+    '<body>' +
+    `Bonjour ${aidant.nomPrenom}\n` +
+    '\n' +
+    `Suite à votre dernière connexion, vous avez choisi d’utiliser le dispositif MonAideCyber en tant qu'Aidant cyber et nous vous en remercions.` +
+    `Vous avez accepté les nouvelles conditions générales d’utilisation en ligne le ${aidant.dateSignatureCGU ? FournisseurHorloge.formateDate(aidant.dateSignatureCGU).date : ''}. \n` +
+    'Nous avons bien reçu votre souhait d’adhérer à une association à but non lucratif et d’utiliser le dispositif en étant référencé Aidant cyber. \n' +
+    `Si vous êtes membre d’une association non politique ou cultuelle, faites nous parvenir à l’adresse <a href="mailto:${adaptateurEnvironnement.messagerie().emailMAC()}">MonAideCyber</a> les informations suivantes :` +
+    '\n' +
+    '<ul>' +
+    '<li>le nom</li>' +
+    '<li>le département</li>' +
+    '<li>une adresse mail de contact</li>' +
+    '</ul>' +
+    '\n' +
+    `Sinon contactez l’équipe à l’adresse mail <a href="mailto:${adaptateurEnvironnement.messagerie().emailMAC()}">MonAideCyber</a> si vous souhaitez  recevoir une liste d’associations déjà identifiées par l’équipe.` +
+    '\n' +
+    '\n' +
+    'Toute l’équipe reste à votre disposition,' +
+    '\n' +
+    '\n' +
+    `Pour toute remarque ou question, n’hésitez pas à nous contacter sur <a href="mailto:${adaptateurEnvironnement.messagerie().emailMAC()}">MonAideCyber</a> \n` +
+    '</body>' +
+    '</html>'
+  );
+}
+
+const adaptateurCorpsMessage = {
+  confirmationProfilAidantSansAssociation: () => ({
+    genereCorpsMessage: (aidant: Aidant): string =>
+      genereCorpsConfirmationProfilAidantSansAssociation(aidant),
+  }),
+};
+export { adaptateurCorpsMessage };


### PR DESCRIPTION
Cas : 

-> Un Aidant se connecte pour la première fois depuis le 31 Janvier. 
-> L'outil lui demande de sélectionner son choix d'utilisation de l'outil
-> L'utilisateur choisit de rester Aidant
-> Au moment de choisir le type d'Aidant, l'utilisateur se rend compte qu'il n'adhère pas encore à une association
-> Il sélectionne donc le dernier choix (cf: capture d'écran ci-dessous)

<img width="1323" alt="image" src="https://github.com/user-attachments/assets/52f6076f-56cf-480d-8a39-044e05563a83" />

-> L'utilisateur clique sur le bouton "Suivant"
-> Il valide la Charte de l'Aidant ainsi que les nouvelles CGU
-> Au moment de cliquer sur le bouton "Suivant", dont le rôle est de valider le profil de l'Aidant, il ne se passe rien

Ci-dessous, des captures d'écran descriptives de l'erreur (vues lors d'une visio avec une Aidante)

![image](https://github.com/user-attachments/assets/d04b87bb-8bd5-4ce3-9c63-61cc9dab156b)
![image](https://github.com/user-attachments/assets/4b83e4cb-57e9-408d-b29c-37545efaa9a1)

