### PR TITLE
[CORRECTION][EXTRACTION COT] Corrige l’affichage du nom de l’entité morale dans l’onglet Leste des Aidants

### DIFF
--- a/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotStatistiquesAidantPostgres.ts
+++ b/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotStatistiquesAidantPostgres.ts
@@ -75,7 +75,9 @@ export class EntrepotStatistiquesAidantPostgres
       ...(aidant.donnees.dateSignatureCGU && {
         compteCree: FournisseurHorloge.enDate(aidant.donnees.dateSignatureCGU),
       }),
-      entite: aidant.donnees.entite?.nom || '',
+      entite: aidant.donnees.entite?.nom
+        ? this.serviceDeChiffrement.dechiffre(aidant.donnees.entite.nom)
+        : '',
       departements: aidant.donnees.preferences.departements.map((d) =>
         rechercheParNomDepartement(d)
       ),
@@ -125,7 +127,9 @@ export class EntrepotStatistiquesAidantPostgres
               aidant.donnees.dateSignatureCGU
             ),
           }),
-          entite: aidant.donnees.entite?.nom || '',
+          entite: aidant.donnees.entite?.nom
+            ? this.serviceDeChiffrement.dechiffre(aidant.donnees.entite.nom)
+            : '',
           departements: aidant.donnees.preferences.departements.map((d) =>
             rechercheParNomDepartement(d)
           ),

--- a/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotsPostgres.spec.ts
+++ b/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotsPostgres.spec.ts
@@ -897,10 +897,18 @@ describe('EntrepotStatistiquesAidant', () => {
       .faisantPartieDeEntite('ServicePublic')
       .ayantPourDepartements([gironde, allier])
       .construis();
+    const serviceDeChiffrement = new FauxServiceDeChiffrement(
+      new Map([
+        [aidant.nomPrenom, 'abcd'],
+        [aidant.email, 'efgh'],
+        [aidant.entite!.nom!, 'ijkl'],
+      ])
+    );
+    const entrepotAidant = new EntrepotAidantPostgres(serviceDeChiffrement);
     await entrepotAidant.persiste(aidant);
 
     const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
-      adaptateurServiceChiffrement()
+      serviceDeChiffrement
     );
 
     expect(
@@ -922,10 +930,18 @@ describe('EntrepotStatistiquesAidant', () => {
       .faisantPartieDeEntite('ServicePublic')
       .ayantPourDepartements([gironde, allier])
       .construis();
+    const serviceDeChiffrement = new FauxServiceDeChiffrement(
+      new Map([
+        [aidant.nomPrenom, 'mnop'],
+        [aidant.email, 'qrst'],
+        [aidant.entite!.nom!, 'uvwx'],
+      ])
+    );
+    const entrepotAidant = new EntrepotAidantPostgres(serviceDeChiffrement);
     await entrepotAidant.persiste(aidant);
 
     const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
-      adaptateurServiceChiffrement()
+      serviceDeChiffrement
     );
 
     expect(


### PR DESCRIPTION
**contexte**
Extraction hebdomadaire pour les COT

**Reproduction**
- Ouvrir le fichier d’extraction envoyé le 17/02/2025
- Aller sur l’onglet `Liste des Aidants`

**Résultat constaté**
Le nom de l’entité morale apparaît chiffré

**Résultat attendu**
Le nom de l’entité morale ne doit pas être chiffré