### PR TITLE
[CORRECTION][STATISTIQUES] Corrige le nombre d’Aidants retourné dans les statistiques publiques

### DIFF
--- a/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotStatistiquesPostgres.ts
+++ b/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotStatistiquesPostgres.ts
@@ -17,6 +17,7 @@ export class EntrepotStatistiquesPostgres implements EntrepotStatistiques {
   async lis(): Promise<Statistiques> {
     const nombreAidants: Count = await this.knex
       .from('utilisateurs_mac')
+      .where('type', 'AIDANT')
       .count({ count: '*' })
       .first();
     const nombreDiagnostics: Count = await this.knex

--- a/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotsPostgres.spec.ts
+++ b/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotsPostgres.spec.ts
@@ -91,6 +91,9 @@ describe('Entrepots Postgres', () => {
     const entrepotAidant = new EntrepotAidantPostgres(
       new ServiceDeChiffrementClair()
     );
+    const entrepotUtilisateurInscrit = new EntrepotUtilisateurInscritPostgres(
+      new ServiceDeChiffrementClair()
+    );
     const entrepotDiagnosticPostgres = new EntrepotDiagnosticPostgres();
     const entrepotRelationPostgres = new EntrepotRelationPostgres();
 
@@ -111,6 +114,9 @@ describe('Entrepots Postgres', () => {
       const quatriemeDiagnosticEnGironde = unDiagnosticEnGironde().construis();
       await entrepotAidant.persiste(unAidant().construis());
       await entrepotAidant.persiste(unAidant().construis());
+      await entrepotUtilisateurInscrit.persiste(
+        unUtilisateurInscrit().construis()
+      );
       await entrepotDiagnosticPostgres.persiste(premierDiagnosticEnGironde);
       await entrepotDiagnosticPostgres.persiste(deuxiemeDiagnosticEnGironde);
       await entrepotDiagnosticPostgres.persiste(troisiemeDiagnosticEnGironde);


### PR DESCRIPTION
**Contexte**
Statistiques publiques

**Reproduction**
- Se rendre sur la page des statistiques publiques
- La statistique `Aidants Cyber référencés` remonte tous les utilisateurs quelque soit leur profil

**Résultat constaté** 
- Il y a environ 220 Utilisateurs inscrits comptabilisés dans la statistique
<img width="1233" alt="Capture d’écran 2025-02-20 à 10 36 59" src="https://github.com/user-attachments/assets/d87c95cd-2823-4279-b695-40d7b2c5896a" />

**Résultat attendu**
- Les Utilisateurs inscrits ne doivent pas être remontés dans les status 
