### PR TITLE
[CORRECTION][MON ESPACE] Masque le lien vers le kit des Aidants pour un utilisateur inscrit qui se connecte pour la première fois.

### DIFF
--- a/mon-aide-cyber-api/src/api/hateoas/contextesUtilisateur.ts
+++ b/mon-aide-cyber-api/src/api/hateoas/contextesUtilisateur.ts
@@ -134,11 +134,13 @@ export const contextesUtilisateur: () => ContextesUtilisateur = () => ({
       ...afficherTableauDeBord,
       ...modifierMotDePasse,
       ...seDeconnecter,
+      ...demandeDevenirAidant['demande-devenir-aidant'],
     },
     'pro-connect-acceder-au-profil': {
       ...lancerDiagnostic,
       ...afficherTableauDeBord,
       ...seDeconnecterDeProConnect,
+      ...demandeDevenirAidant['demande-devenir-aidant'],
     },
   },
   'valider-signature-cgu': {

--- a/mon-aide-cyber-api/test/api/aidant/routesAPIProfil.spec.ts
+++ b/mon-aide-cyber-api/test/api/aidant/routesAPIProfil.spec.ts
@@ -193,6 +193,18 @@ describe('le serveur MAC sur les routes /api/profil', () => {
               typeAppel: 'DIRECT',
               url: '/pro-connect/deconnexion',
             },
+            'demande-devenir-aidant': {
+              methode: 'GET',
+              url: '/api/demandes/devenir-aidant',
+            },
+            'envoyer-demande-devenir-aidant': {
+              methode: 'POST',
+              url: '/api/demandes/devenir-aidant',
+            },
+            'rechercher-entreprise': {
+              methode: 'GET',
+              url: '/api/recherche-entreprise',
+            },
           },
         });
       });
@@ -237,6 +249,18 @@ describe('le serveur MAC sur les routes /api/profil', () => {
               url: '/api/token',
               methode: 'DELETE',
               typeAppel: 'API',
+            },
+            'demande-devenir-aidant': {
+              methode: 'GET',
+              url: '/api/demandes/devenir-aidant',
+            },
+            'envoyer-demande-devenir-aidant': {
+              methode: 'POST',
+              url: '/api/demandes/devenir-aidant',
+            },
+            'rechercher-entreprise': {
+              methode: 'GET',
+              url: '/api/recherche-entreprise',
             },
           },
         });

--- a/mon-aide-cyber-api/test/api/routesAPIUtilisateur.spec.ts
+++ b/mon-aide-cyber-api/test/api/routesAPIUtilisateur.spec.ts
@@ -952,6 +952,18 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
               url: '/api/token',
               typeAppel: 'API',
             },
+            'demande-devenir-aidant': {
+              methode: 'GET',
+              url: '/api/demandes/devenir-aidant',
+            },
+            'envoyer-demande-devenir-aidant': {
+              methode: 'POST',
+              url: '/api/demandes/devenir-aidant',
+            },
+            'rechercher-entreprise': {
+              methode: 'GET',
+              url: '/api/recherche-entreprise',
+            },
           },
         });
       });
@@ -1338,6 +1350,18 @@ describe('Le serveur MAC sur les routes /api/utilisateur', () => {
             methode: 'DELETE',
             url: '/api/token',
             typeAppel: 'API',
+          },
+          'demande-devenir-aidant': {
+            methode: 'GET',
+            url: '/api/demandes/devenir-aidant',
+          },
+          'envoyer-demande-devenir-aidant': {
+            methode: 'POST',
+            url: '/api/demandes/devenir-aidant',
+          },
+          'rechercher-entreprise': {
+            methode: 'GET',
+            url: '/api/recherche-entreprise',
           },
         },
       });


### PR DESCRIPTION
**Contexte**
Connexion via ProConnect pour la première fois pour un Utilisateur Inscrit

**Reproduction**
- Pré-requis : utiliser un compte ProConnect dont l’utilisateur n’est pas encore connu par MAC 
- Ouvrir les outils développeur du navigateur, onglet réseau
- Se connecter avec ProConnect 

**Résultat constaté**
- Le lien `Kit de communication des Aidants` est disponible dans le menu de navigation gauche de l’espace Utilisateur
   ![Capture d’écran 2025-02-27 à 16 21 55](https://github.com/user-attachments/assets/5de900ad-0611-42f0-b43b-cdec0274b197)
- HATEOAS ne remonte pas l’action `demande-devenir-aidant`

**Résultat attendu**
- Le lien `Kit de communication des Aidants` n’est pas visible dans le menu de navigation gauche de l’espace Utilisateur
- Un lien `Devenir Aidant` est visible dans le menu de navigation gauche de l’espace Utilisateur
   ![Capture d’écran 2025-02-27 à 16 22 01](https://github.com/user-attachments/assets/3fe92f25-6968-418e-a3c1-d19cadc82d4a)
- HATEOAS ne remonte pas l’action `demande-devenir-aidant`