### PR TITLE
[CORRECTION][COMPOSANT AUTOCOMPLETION] Masque l'autocomplétion du navigateur client lors du click pour déplier les éléments

### DIFF
--- a/mon-aide-cyber-ui/src/composants/auto-completion/AutoCompletion.tsx
+++ b/mon-aide-cyber-ui/src/composants/auto-completion/AutoCompletion.tsx
@@ -128,6 +128,7 @@ export const AutoCompletion = <T extends object | string>(
     <div className="autocomplete fr-col-12" ref={referenceConteneur}>
       <div className="autocomplete-labellise">
         <input
+          autoComplete="off"
           className="fr-input"
           ref={referenceChampSaisie}
           placeholder={proprietes.placeholder}


### PR DESCRIPTION
Comportement observé en démo :
Les suggestions déjà tapées par le client s'affichent par dessus la liste des résultats.

<img width="708" alt="image" src="https://github.com/user-attachments/assets/cfe1c1dc-6cbe-464d-90d2-e5e1b81c120d" />

Attendu : 
Pas de suggestions navigateur pour ne pas gâcher la vue du client sur les résultats de l'autocomplétion.

<img width="777" alt="image" src="https://github.com/user-attachments/assets/e8fa75fe-8436-45b6-919a-c4d7c6ff3ea7" />

