### PR TITLE
[DEMANDE AIDE] Gère les demandes d’aides incomplètes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,12 +28,11 @@ services:
 
   api:
     container_name: mon-aide-cyber-api
+    env_file:
+      - ./mon-aide-cyber-api/.env
     build:
       context: .
       dockerfile: Dockerfile-api
-    environment:
-      - URL_SERVEUR_BASE_DONNEES=postgres://postgres@mon-aide-cyber-bd/mac
-      - URL_JOURNALISATION_BASE_DONNEES=postgres://postgres@mac-journal-db/mac-journal
     ports:
       - 8081:8081
     volumes:

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurCommandeCreerDemandeAide.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurCommandeCreerDemandeAide.ts
@@ -10,6 +10,7 @@ export type CommandeCreerDemandeAide = Omit<Commande, 'type'> & {
   departement: Departement;
   email: string;
   raisonSociale?: string;
+  etat?: 'INCOMPLET';
 };
 
 export class CapteurCommandeCreerDemandeAide
@@ -26,7 +27,9 @@ export class CapteurCommandeCreerDemandeAide
       ...(commande.raisonSociale && { raisonSociale: commande.raisonSociale }),
     };
 
-    await this.entrepots.demandesAides().persiste(aide);
+    await this.entrepots
+      .demandesAides()
+      .persiste(aide, commande.etat === 'INCOMPLET');
 
     return Promise.resolve(aide);
   }

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurSagaDemandeAide.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurSagaDemandeAide.ts
@@ -102,6 +102,7 @@ export class CapteurSagaDemandeAide
         departement: saga.departement,
         email: saga.email,
         ...(saga.raisonSociale && { raisonSociale: saga.raisonSociale }),
+        ...(aide.etat === 'INCOMPLET' && { etat: 'INCOMPLET' }),
       };
 
       await this.busCommande

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurSagaDemandeAide.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurSagaDemandeAide.ts
@@ -129,8 +129,6 @@ export class CapteurSagaDemandeAide
             },
           });
         });
-
-      return Promise.resolve();
     } catch (erreur) {
       return Promise.reject("Votre demande d'aide n'a pu aboutir");
     }

--- a/mon-aide-cyber-api/src/infrastructure/entrepots/memoire/EntrepotMemoire.ts
+++ b/mon-aide-cyber-api/src/infrastructure/entrepots/memoire/EntrepotMemoire.ts
@@ -153,13 +153,24 @@ export class EntrepotAideMemoire
   extends EntrepotMemoire<DemandeAide>
   implements EntrepotDemandeAide
 {
+  async persiste(demandeAide: DemandeAide): Promise<void> {
+    const demandesExistantes = Array.from(this.entites.entries())
+      .filter(([, valeur]) => valeur.email === demandeAide.email)
+      .map(([clef]) => clef);
+    demandesExistantes.forEach((clef) => this.entites.delete(clef));
+    super.persiste(demandeAide);
+  }
+
   async rechercheParEmail(email: string): Promise<RechercheDemandeAide> {
     const aides = Array.from(this.entites.values()).filter(
       (aide) => aide.email === email
     );
 
     return aides.length > 0
-      ? { demandeAide: aides[0], etat: 'COMPLET' }
+      ? {
+          demandeAide: aides[0],
+          etat: !aides[0].identifiant ? 'INCOMPLET' : 'COMPLET',
+        }
       : { etat: 'INEXISTANT' };
   }
 }

--- a/mon-aide-cyber-api/test/gestion-demandes/aide/ConstructeurDemandeAide.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/aide/ConstructeurDemandeAide.ts
@@ -7,20 +7,29 @@ import { departements } from '../../../src/gestion-demandes/departements';
 
 class ConstructeurDemandeAide implements Constructeur<DemandeAide> {
   private dateSignatureCGU: Date = FournisseurHorloge.maintenant();
+  private demandeIncomplete = false;
+
   construis(): DemandeAide {
-    return {
-      identifiant: crypto.randomUUID(),
-      dateSignatureCGU: this.dateSignatureCGU,
-      email: fakerFR.internet.email(),
-      raisonSociale: fakerFR.company.name(),
-      departement: departements[fakerFR.number.int({ min: 1, max: 99 })],
-    };
+    return this.demandeIncomplete
+      ? ({ email: fakerFR.internet.email() } as DemandeAide)
+      : {
+          identifiant: crypto.randomUUID(),
+          dateSignatureCGU: this.dateSignatureCGU,
+          email: fakerFR.internet.email(),
+          raisonSociale: fakerFR.company.name(),
+          departement: departements[fakerFR.number.int({ min: 1, max: 99 })],
+        };
   }
 
   avecUneDateDeSignatureDesCGU(
     dateSignatureCGU: Date
   ): ConstructeurDemandeAide {
     this.dateSignatureCGU = dateSignatureCGU;
+    return this;
+  }
+
+  incomplete(): ConstructeurDemandeAide {
+    this.demandeIncomplete = true;
     return this;
   }
 }


### PR DESCRIPTION
- Pour lesquelles nous n’obtenons pas les métadonnées depuis Brevo :
   - Une nouvelle demande d’Aide est crée
   - Le contact Brevo est mis à jour avec les métadonnées manquantes
   - Les mails restent les mêmes que ceux d’une demande d’Aide originale

Cela a un impacte au niveau communication car des mails sont envoyés aux COT, à MAC pouvant faire penser à une demande d’Aide initiale à affecter :
```
Bonjour,

Votre demande pour bénéficier de MonAideCyber a été prise en compte.
Un Aidant de proximité vous contactera sur l’adresse email que vous nous avez communiquée dans les meilleurs délais.

Voici les informations que vous avez renseignées :
- Signature des CGU le 04.03.2025 à 15:19
- Département : Gironde
- Raison sociale : OKIWI

Toute l’équipe reste à votre disposition,

L'équipe MonAideCyber
monaidecyber@ssi.gouv.fr
```