### PR TITLE
[RELAIS ASSOCIATIFS] Supprime les relais Campus Cyber de Toulon et Sophia pointant vers les universités correspondantes

### DIFF
--- a/mon-aide-cyber-api/src/api/associations/referentiel.yaml
+++ b/mon-aide-cyber-api/src/api/associations/referentiel.yaml
@@ -116,10 +116,6 @@ regional:
   provenceAlpesCotesDAzur:
     nom: 'Provence-Alpes-Côte d’Azur'
     associations:
-      - nom: 'Campus régional de cybersécurité Sophia Antipolis'
-        urlSite: 'https://univ-cotedazur.fr/'
-      - nom: 'Campus régional de cybersécurité Toulon'
-        urlSite: 'https://www.univ-tln.fr/'
       - nom: 'Clusir Sud Paca'
         urlSite: 'https://clusir-sud.fr/'
       - nom: 'Telecom Valley'


### PR DESCRIPTION
Suite au mail De Kevin :

<img width="1306" alt="Capture d’écran 2025-03-13 à 10 29 39" src="https://github.com/user-attachments/assets/806f3a73-08ab-4f22-9339-c2bc9003db84" />
