### PR TITLE
[CORRECTION][MODALES] Affiche une modale en un seul click

### DIFF
--- a/mon-aide-cyber-ui/src/composants/modale/PortailModale.tsx
+++ b/mon-aide-cyber-ui/src/composants/modale/PortailModale.tsx
@@ -18,6 +18,9 @@ export const PortailModale = ({ children }: PropsWithChildren) => {
   );
   const [modaleOuverte, setModaleOuverte] = useState<boolean>(false);
   const ref = useRef<HTMLDialogElement | null>(null);
+  const [dialog, setDialog] = useState<React.ReactElement>(
+    <dialog aria-labelledby="titre-modale" id="modale" className="fr-modal" />
+  );
 
   const fermeModale = useCallback(() => {
     setModaleOuverte(false);
@@ -72,6 +75,18 @@ export const PortailModale = ({ children }: PropsWithChildren) => {
     }
   }, [fermeModale, modaleOuverte]);
 
+  useEffect(() => {
+    setDialog(
+      <dialog
+        aria-labelledby="titre-modale"
+        id="modale"
+        className={`fr-modal ${modaleOuverte ? 'fr-modal--opened' : ''}`}
+        aria-modal={modaleOuverte}
+        open={modaleOuverte}
+      />
+    );
+  }, [modaleOuverte]);
+
   return (
     <ContexteModale.Provider
       value={{
@@ -83,13 +98,7 @@ export const PortailModale = ({ children }: PropsWithChildren) => {
       }}
     >
       {children}
-      <dialog
-        aria-labelledby="titre-modale"
-        id="modale"
-        className={`fr-modal ${modaleOuverte ? 'fr-modal--opened' : ''}`}
-        aria-modal={modaleOuverte}
-        open={modaleOuverte}
-      />
+      {dialog}
       {elementModale
         ? createPortal(
             <Modale


### PR DESCRIPTION
**Contexte**
Ouverture de modales

**Reproduction**
- Se connecter à MAC
- Se rendre sur le TDB Aidant
- Cliquer sur le bouton `Créer un diagnostic`

**Résultat constaté**
Le premier clique ne lance pas la modale, il faut cliquer une seconde fois

**Résultat attendu**
Un seul click suffit pour ouvrir une modale

**NB**
Il est nécessaire de cliquer 2 fois à chaque rafraichissement de page, c’est à dire que le contexte React n’est pas chargé correctement à l’affichage d’une page en ce qui concerne les modales. Il faut investiguer sur le comportement lié aux portal React