### PR TITLE
Filtrage ip

### DIFF
--- a/mon-aide-cyber-api/.env.template
+++ b/mon-aide-cyber-api/.env.template
@@ -62,3 +62,4 @@ PRO_CONNECT_ACTIF=true
 #                                                       #
 #########################################################
 # RESEAU_TRUST_PROXY = # optionnel (0 par défaut) nombre de proxies en amont du service ou configuration plus fine de trust proxy, Cf.  https://expressjs.com/en/guide/behind-proxies.html
+# RESEAU_ADRESSES_IP_AUTORISEES = # Seules ces IP seront autorisées. Les autres ne seront pas servies. Séparées par des ',' s'il y en a plusieurs. Supprimer la variable d'env pour désactiver le filtrage.

--- a/mon-aide-cyber-api/package.json
+++ b/mon-aide-cyber-api/package.json
@@ -35,6 +35,7 @@
     "dotenv": "^16.3.1",
     "exceljs": "^4.4.0",
     "express": "^4.21.2",
+    "express-ipfilter": "^1.3.2",
     "express-rate-limit": "^6.7.0",
     "express-validator": "^7.0.1",
     "jsonwebtoken": "^9.0.2",

--- a/mon-aide-cyber-api/src/adaptateurs/adaptateurEnvironnement.ts
+++ b/mon-aide-cyber-api/src/adaptateurs/adaptateurEnvironnement.ts
@@ -51,7 +51,7 @@ const parametresDeHash = () => ({
   sel: () => process.env.HASH_SEL || '',
 });
 
-const reseauTrustProxy = (): number | string => {
+const trustProxy = (): number | string => {
   const trustProxyEnChaine = process.env.RESEAU_TRUST_PROXY || '0';
   const trustProxyEnNombre = Number(trustProxyEnChaine);
   if (isNaN(trustProxyEnNombre)) {
@@ -64,6 +64,9 @@ const reseauTrustProxy = (): number | string => {
   }
 };
 
+const ipAutorisees = (): false | string[] =>
+  process.env.RESEAU_ADRESSES_IP_AUTORISEES?.split(',') ?? false;
+
 const adaptateurEnvironnement = {
   messagerie,
   mac,
@@ -73,7 +76,8 @@ const adaptateurEnvironnement = {
   apiRechercheEntreprise,
   nouveauParcoursDevenirAidant,
   parametresDeHash,
-  reseauTrustProxy,
+  reseauTrustProxy: trustProxy,
+  ipAutorisees,
 };
 
 export { sentry, adaptateurEnvironnement };

--- a/mon-aide-cyber-api/src/api/gestionnaires/erreurs.ts
+++ b/mon-aide-cyber-api/src/api/gestionnaires/erreurs.ts
@@ -23,6 +23,7 @@ import { ErreurRequeteHTTP } from '../recherche-entreprise/routesAPIRechercheEnt
 import { ErreurAidantNonTrouve } from '../../espace-utilisateur-inscrit/ServiceUtilisateurInscritMAC';
 import { RequeteUtilisateur } from '../routesAPI';
 import { ErreurLectureReferentielAssociations } from '../associations/routesAssociations';
+import { IpDeniedError } from 'express-ipfilter';
 
 const HTTP_ACCEPTE = 202;
 const HTTP_MAUVAISE_REQUETE = 400;
@@ -330,6 +331,9 @@ export const gestionnaireErreurGeneralisee = (
           construisReponseErreurServeur();
           suite(erreur);
         }
+      } else if (erreur instanceof IpDeniedError) {
+        reponse.status(401);
+        reponse.end();
       } else {
         construisReponseErreurServeur();
         suite(erreur);

--- a/mon-aide-cyber-api/src/infrastructure/securite/Reseau.ts
+++ b/mon-aide-cyber-api/src/infrastructure/securite/Reseau.ts
@@ -1,0 +1,24 @@
+import { IpFilter } from 'express-ipfilter';
+import { RequestHandler } from 'express';
+
+export const filtreIp = (ipAutorisees: string[]): RequestHandler => {
+  return IpFilter(ipAutorisees, {
+    detectIp: (request) => {
+      const forwardedFor = request.headers['x-forwarded-for'];
+      if (typeof forwardedFor === 'string') {
+        const ips = forwardedFor
+          .split(',')
+          .map((ip) => ip.trim())
+          .filter((ip) => ip !== '');
+
+        if (ips.length > 0) {
+          const ipWaf = ips[ips.length - 1];
+          return ipWaf;
+        }
+      }
+      return 'interdire';
+    },
+    mode: 'allow',
+    log: false,
+  });
+};

--- a/mon-aide-cyber-api/src/serveur.ts
+++ b/mon-aide-cyber-api/src/serveur.ts
@@ -36,6 +36,7 @@ import { AdaptateurDeVerificationDeDemande } from './adaptateurs/AdaptateurDeVer
 import { AdaptateurAseptisation } from './adaptateurs/AdaptateurAseptisation';
 import { RepertoireDeContacts } from './contacts/RepertoireDeContacts';
 import { adaptateurEnvironnement } from './adaptateurs/adaptateurEnvironnement';
+import { filtreIp } from './infrastructure/securite/Reseau';
 
 const ENDPOINTS_SANS_CSRF = ['/api/token'];
 
@@ -75,6 +76,10 @@ const creeApp = (config: ConfigurationServeur) => {
 
   config.gestionnaireErreurs.initialise(app);
   app.set('trust proxy', adaptateurEnvironnement.reseauTrustProxy());
+
+  const ipAutorisees = adaptateurEnvironnement.ipAutorisees();
+  if (ipAutorisees) app.use(filtreIp(ipAutorisees));
+
   app.use(
     CookieSession({
       sameSite: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "dotenv": "^16.3.1",
         "exceljs": "^4.4.0",
         "express": "^4.21.2",
+        "express-ipfilter": "^1.3.2",
         "express-rate-limit": "^6.7.0",
         "express-validator": "^7.0.1",
         "jsonwebtoken": "^9.0.2",
@@ -13181,6 +13182,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-ipfilter": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.2.tgz",
+      "integrity": "sha512-yMzCWGuVMnR8CFlsIC2spHWoQYp9vtyZXUgS/JdV5GOJgrz6zmKOEZsA4eF1XrxkOIVzaVk6yzTBk65pBhliNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip": "^2.0.1",
+        "lodash": "^4.17.11",
+        "proxy-addr": "^2.0.7",
+        "range_check": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
     "node_modules/express-rate-limit": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
@@ -14981,6 +14997,12 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
+      "license": "MIT"
+    },
     "node_modules/ip-address": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -14997,6 +15019,15 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+    },
+    "node_modules/ip6": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/ip6/-/ip6-0.2.11.tgz",
+      "integrity": "sha512-OmTP7FyIp+ZoNvZ7Xr97bWrCgypa3BeuYuRFNTOPT8Y11cxMW1pW1VC70kHZP1onSHHMotADcjdg5QyECiIMUw==",
+      "license": "MIT",
+      "bin": {
+        "ip6": "ip6-cli.js"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -20169,6 +20200,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
+      }
+    },
+    "node_modules/range_check": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/range_check/-/range_check-2.0.4.tgz",
+      "integrity": "sha512-aed0ocXXj+SIiNNN9b+mZWA3Ow2GXHtftOGk2xQwshK5GbEZAvUcPWNQBLTx/lPcdFRIUFlFCRtHTQNIFMqynQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "ip6": "^0.2.0",
+        "ipaddr.js": "^1.9.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/range-parser": {


### PR DESCRIPTION
Filtre les IP qui ont le droit d'accéder à MAC 

On permet au serveur de filtrer les IPs qui ont le droit d'effectuer des requêtes.
    
Si le paramètre n'est pas positionné, aucun filtrage n'a lieu. Si le paramètre est positionné, on va vérifié que la dernière IP forwarded for, positionnée par le reverse proxy, est bien autorisée à accéder au service.
    
On adapte le gestionnaire d'erreur pour retourner 401 et terminer le traitement de la requête en cas de IpDeniedError.
