### PR TITLE
[CORRECTION] Renvoie systématiquement index.html référençant le bundle React à jour

### DIFF
--- a/mon-aide-cyber-api/src/serveur.ts
+++ b/mon-aide-cyber-api/src/serveur.ts
@@ -119,17 +119,9 @@ const creeApp = (config: ConfigurationServeur) => {
     suite();
   });
 
-  const indexBrutCache = lisLeFichierIndex();
-  const indexAvecLeNonce = (reponse: Response) => {
-    const indexAvecNonce = indexBrutCache.replace(
-      '%%NONCE%%',
-      reponse.locals['nonce']
-    );
-
-    reponse.setHeader('Content-Type', 'text/html').send(indexAvecNonce);
-  };
-
-  app.get('/', (_: Request, reponse: Response) => indexAvecLeNonce(reponse));
+  app.get('/', (_: Request, reponse: Response) =>
+    envoieIndexAvecNonce(reponse)
+  );
 
   app.use(
     express.static(path.join(__dirname, './../../mon-aide-cyber-ui/dist'))
@@ -141,7 +133,9 @@ const creeApp = (config: ConfigurationServeur) => {
   app.use('/contact', routeContact(config));
   app.use('/statistiques', routesStatistiques(config));
 
-  app.get('*', (_: Request, reponse: Response) => indexAvecLeNonce(reponse));
+  app.get('*', (_: Request, reponse: Response) =>
+    envoieIndexAvecNonce(reponse)
+  );
 
   app.use(
     gestionnaireErreurGeneralisee(config.gestionnaireErreurs.consignateur())
@@ -157,6 +151,15 @@ const lisLeFichierIndex = () => {
     './../../mon-aide-cyber-ui/dist/index.html'
   );
   return fs.readFileSync(cheminIndex, 'utf8');
+};
+
+const envoieIndexAvecNonce = (reponse: Response) => {
+  const indexAvecLeNonce = lisLeFichierIndex().replace(
+    '%%NONCE%%',
+    reponse.locals['nonce']
+  );
+
+  reponse.setHeader('Content-Type', 'text/html').send(indexAvecLeNonce);
 };
 
 const creeServeur = (config: ConfigurationServeur) => {


### PR DESCRIPTION

… au lieu d'un index.html référençant l'ancienne version du bundle React.

Depuis 51f52d1520ee82d11538926df154242b51a3f19c le fichier index.html était lu, avec du cache, pour remplacer %%NONCE%% par une valeur.

Bug :
 - Déployer la version A
 - Voir qu'index.html contient un script src=/assets/index-A.js
 - Ici, tout va bien
 - Déployer la version B (en local, ça signifie simplement faire une modif de JSX qui déclenche un re-build du bundle React)
 - Rafraîchir la page dans le navigateur

Attendu : index.html inclut un script src=/assets/index-B.js (noter le B.js au lieu de A.js).

Observé : c'est encore index-A.js qui est référencé, et la page web est blanche, car A.js n'existe même plus sur le serveur.

Cause : c'est la lecture d'index.html en cache qui posait problème. La version en cache référençait toujours A.js.