### PR TITLE
[CORRECTION] Corrige l'exécution du script

### DIFF
--- a/mon-aide-cyber-ui/index.html
+++ b/mon-aide-cyber-ui/index.html
@@ -41,7 +41,7 @@
     <script type="text/javascript">
       const insertMetaTag = () => {
         const contenuMeta = "%VITE_GOOGLE_SEARCH_CONSOLE_VERIFICATION%"
-        if(contenuMeta) {
+        if(contenuMeta !== "false") {
           const tagMeta = document.createElement("meta");
           tagMeta.name = "google-site-verification";
           tagMeta.content = contenuMeta;


### PR DESCRIPTION
- La variable 'VITE_GOOGLE_SEARCH_CONSOLE_VERIFICATION' n'est pas valorisée si elle n'existe pas, le SHA du script change donc et les CSP ne passent plus. Du coup on crée cette variable et on met false comme valeur par défaut