### PR TITLE
[CORRECTION][STATISTIQUES PUBLIQUES] Ne prends pas en compte les diagnostics en libre accès dans les résultats retournés

### DIFF
--- a/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotStatistiquesPostgres.ts
+++ b/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotStatistiquesPostgres.ts
@@ -25,7 +25,7 @@ export class EntrepotStatistiquesPostgres implements EntrepotStatistiques {
         `SELECT COUNT(avec_departements)
          FROM (SELECT id, jsonb_path_query(donnees -> 'referentiel' -> 'contexte', '$.questions[*]\\?(@.identifiant == "contexte-departement-tom-siege-social").reponseDonnee\\?(@.reponseUnique != null)')
                FROM diagnostics d) AS avec_departements
-         WHERE avec_departements.id::text IN (SELECT donnees -> 'objet' ->> 'identifiant' FROM relations as id);
+         WHERE avec_departements.id::text IN (SELECT donnees -> 'objet' ->> 'identifiant' FROM relations as id WHERE donnees -> 'objet' ->> 'type' = 'diagnostic');
         `
       )
       .then(({ rows }: { rows: Count[] }) => {


### PR DESCRIPTION
**Contexte**
Statistiques publiques

**Reproduction**
- Se rendre sur la page des statistiques publiques
- Se rendre sur le TDB Metabase `Suivi weekly objectifs`

**Résultat constaté**
Il y a une différence de 500 diags entre ce qui est affiché en public et Metabase
 
![Capture d’écran 2025-03-31 à 14 13 45](https://github.com/user-attachments/assets/8ef044dd-fec9-4c9c-954a-274681e920ce)
![Capture d’écran 2025-03-31 à 14 14 07](https://github.com/user-attachments/assets/1bc624b5-d6c1-4986-97a1-9b65a72eb980)


**Résultat attendu**
Les statistiques sur Metabase et sur MAC affichent le même ordre de grandeur et non 500 diagnostics de différence