### PR TITLE
[CORRECTION][SUITE CYBER] Intégration suite cyber nouveau header

### DIFF
--- a/mon-aide-cyber-ui/src/assets/styles/_commun.scss
+++ b/mon-aide-cyber-ui/src/assets/styles/_commun.scss
@@ -150,6 +150,10 @@ fieldset {
   justify-content: center;
 }
 
+.justify-end {
+  justify-content: end;
+}
+
 .items-center {
   align-items: center;
 }
@@ -173,4 +177,25 @@ fieldset {
 
 .m-0 {
   margin: 0;
+}
+
+.visible-desktop {
+  display: none;
+  @include a-partir-de(lg) {
+    display: unset;
+  }
+}
+
+.boutons-sans-fond {
+  .fr-btn {
+    background-color: transparent !important;
+    color: var(--text-action-high-blue-france);
+  }
+}
+
+.fr-btn {
+  gap: 0.5rem;
+}
+.fr-btn:hover {
+  background-color: rgba(0, 0, 0, 0.04) !important;
 }

--- a/mon-aide-cyber-ui/src/assets/styles/_header.scss
+++ b/mon-aide-cyber-ui/src/assets/styles/_header.scss
@@ -8,6 +8,7 @@ header.public {
 
 .entete-lien-se-connecter {
   font-size: 14px;
+  cursor: pointer;
 }
 
 .barre-navigation {

--- a/mon-aide-cyber-ui/src/composants/layout/Header.tsx
+++ b/mon-aide-cyber-ui/src/composants/layout/Header.tsx
@@ -95,10 +95,10 @@ export const Header = ({
               <div className="fr-header__service fr-col-md-5">{lienMAC}</div>
             </div>
             {!enteteSimple ? (
-              <div className="fr-header__tools">
-                <div className="fr-header__tools-links">
-                  <lab-anssi-bouton-suite-cyber-navigation sourceUtm="MonAideCyber"></lab-anssi-bouton-suite-cyber-navigation>
+              <div className="fr-header__tools boutons-sans-fond visible-desktop">
+                <div className="flex justify-end items-center">
                   <div className="flex justify-center items-center">
+                    <lab-anssi-bouton-suite-cyber-navigation sourceUtm="MonAideCyber"></lab-anssi-bouton-suite-cyber-navigation>
                     {utilisateur ? (
                       <ComposantMenuUtilisateur utilisateur={utilisateur} />
                     ) : (

--- a/mon-aide-cyber-ui/src/composants/utilisateur/ComposantMenuUtilisateur.tsx
+++ b/mon-aide-cyber-ui/src/composants/utilisateur/ComposantMenuUtilisateur.tsx
@@ -63,19 +63,19 @@ export const ComposantMenuUtilisateur = ({
 
   const boutonSeDeconnecter =
     ressource && ressource.typeAppel === 'DIRECT' ? (
-      <a className="element" href={ressource.url}>
+      <a className="fr-btn entete-lien-se-connecter" href={ressource.url}>
         <span className="fr-icon-logout-box-r-line" aria-hidden="true"></span>
         <div>Se déconnecter</div>
       </a>
     ) : (
-      <div className="element" onClick={deconnecter}>
+      <div className="fr-btn entete-lien-se-connecter" onClick={deconnecter}>
         <span className="fr-icon-logout-box-r-line" aria-hidden="true"></span>
         <div>Se déconnecter</div>
       </div>
     );
   return (
-    <div className="menu-utilisateur">
-      <div className="element" onClick={afficherProfil}>
+    <div className="fr-ml-1w">
+      <div className="fr-btn entete-lien-se-connecter" onClick={afficherProfil}>
         <span className="fr-icon-user-line" aria-hidden="true"></span>
         <span>{nomUtilisateur}</span>
       </div>


### PR DESCRIPTION
**Contexte**
Affichage des pages publiques en mode connecté

**Reproduction**
- Se rendre sur MAC (pour les devs, le commit `90cd08eb87330891adbc3eb233f0c0f363f93cbb` a fait apparaître problème)
- Se connecter
- Se rendre sur la page d’accueil ou toute autre page publique de MAC

**Résultat constaté**
- Une page d’erreur est affichée sur toutes les pages publiques 
   <img width="1291" alt="Capture d’écran 2025-04-01 à 17 57 43" src="https://github.com/user-attachments/assets/90ad8bfe-30f0-4476-927d-09be5b74bf3b" />
- L’espace Aidant / Utilisateur inscrit n’est pas impacté 
   <img width="2322" alt="Capture d’écran 2025-04-01 à 17 57 52" src="https://github.com/user-attachments/assets/c8b92245-7f97-4307-8cb0-c8456b56551d" />

**Résultat attendu**
Les pages publique s’affichent correctement lorsque l’on est connecté

**NB**
Durant l’investigation @CadiChris et @firefly33 se sont rendus compte que la classe crr `fr-header__tools-links` avait un impact avec l’intégration du composant web de la suite cyber.
Le menu est redessiné lorsque l’utilisateur est connecté et qu’il se rend sur les pages publiques, on suppose qu’une fonction js du dsfr veut supprimer des noeuds enfants et provoque cette erreur

