### PR TITLE
[SENTRY] Variabilise le pourcentage de traces envoyées vers Sentry

### DIFF
--- a/mon-aide-cyber-api/.env.template
+++ b/mon-aide-cyber-api/.env.template
@@ -14,6 +14,7 @@
 
 #SENTRY_DSN= # le DSN Sentry
 #SENTRY_ENVIRONNEMENT= # L'environnement pour distinguer sur Sentry
+#SENTRY_TRACES_SAMPLE_RATE= # Décimal entre 0 et 1. La valeur de `tracesSampleRate` de Sentry. https://docs.sentry.io/platforms/javascript/guides/express/tracing/#configure
 #MAINTENANCE_EST_ACTIVE= # 'true' pour afficher systématiquement une page de maintenance sur toutes les routes. Toute autre valeur désactive la maintenance.
 
 #########################################################

--- a/mon-aide-cyber-api/src/adaptateurs/adaptateurEnvironnement.ts
+++ b/mon-aide-cyber-api/src/adaptateurs/adaptateurEnvironnement.ts
@@ -1,6 +1,7 @@
 const sentry = () => ({
   dsn: () => process.env.SENTRY_DSN,
   environnement: () => process.env.SENTRY_ENVIRONNEMENT,
+  tracesSampleRate: () => Number(process.env.SENTRY_TRACES_SAMPLE_RATE) || 0,
 });
 
 const messagerie = () => ({

--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurGestionnaireErreursSentry.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurGestionnaireErreursSentry.ts
@@ -22,7 +22,7 @@ export class AdaptateurGestionnaireErreursSentry
         new Sentry.Integrations.Postgres(),
         ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
       ],
-      tracesSampleRate: 1.0,
+      tracesSampleRate: sentry().tracesSampleRate(),
     });
 
     applicationExpress.use(Sentry.Handlers.requestHandler());


### PR DESCRIPTION
… pour éviter d'en envoyer 100K+ par semaine depuis la PROD.

Actuellement, MAC envoie bcp de traces par semaine 👇 
![image](https://github.com/user-attachments/assets/8cca0779-112d-403f-8e44-087a08f40c04)

ℹ️ J'ai déjà créé les variables d'env en DEMO et PROD.