### PR TITLE
[CORRECTION] Passe systématiquement les emails ProConnect en minuscules lors de l'authentification

### DIFF
--- a/mon-aide-cyber-api/src/api/pro-connect/routeProConnect.ts
+++ b/mon-aide-cyber-api/src/api/pro-connect/routeProConnect.ts
@@ -117,7 +117,7 @@ export const routesProConnect = (configuration: ConfigurationServeur) => {
 
         const utilisateur = await uneRechercheUtilisateursMAC(
           entrepots.utilisateursMAC()
-        ).rechercheParMail(email!);
+        ).rechercheParMail(email!.toLowerCase());
 
         if (utilisateur) {
           let redirection = '/mon-espace/tableau-de-bord';

--- a/mon-aide-cyber-api/test/constructeurs/constructeursAidantUtilisateurInscritUtilisateur.ts
+++ b/mon-aide-cyber-api/test/constructeurs/constructeursAidantUtilisateurInscritUtilisateur.ts
@@ -188,7 +188,7 @@ class ConstructeurUtilisateurInscrit
   implements Constructeur<UtilisateurInscrit>
 {
   private dateSignatureCGU: Date | undefined = fakerFR.date.anytime();
-  private email: string = fakerFR.internet.email();
+  private email: string = fakerFR.internet.email().toLowerCase();
   private entite: EntiteUtilisateurInscrit | undefined = {};
   private identifiant: crypto.UUID = crypto.randomUUID();
   private nomPrenom: string = fakerFR.person.fullName();


### PR DESCRIPTION
Sans ça MAC se retrouve à créer un compte pour Jean.Dupont@mail.fr quand il connaît déjà jean.dupont@mail.fr

C'est un bug qu'un utilisateur nous a remonté via le support.