### PR TITLE
[SOIN][TECH] Supprime l’exposition du port 3000 du container UI de MAC

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-ui
-    ports:
-      - 3000:3000
     volumes:
       - ./mon-aide-cyber-ui:/usr/src/app/mon-aide-cyber-ui
     networks:


### PR DESCRIPTION
Avec l’ajout de MSC dans nos environnements de dev, il y a un conflit au niveau des ports utilisés par les applications. 

En effet, le container UI de MAC expose le port 3000, or ce dernier n’a pas la nécessité d’être exposé. 
On utilise ce container comme environnement de build automatisé (pour être ISO prod), les sources sont transpilées à la volée à chaque changement et distribuée dans le répertoire dist du serveur MAC