### PR TITLE
[MISE EN RELATION] Modifie le nom du paramètre fourni dans l’URL de demande d’Aide

### DIFF
--- a/mon-aide-cyber-ui/src/composants/diagnostic/ComposantLancerDiagnostic.tsx
+++ b/mon-aide-cyber-ui/src/composants/diagnostic/ComposantLancerDiagnostic.tsx
@@ -84,7 +84,7 @@ const RealiserUnDiagnostic = (proprietesRealiserUnDiagnostic: {
     const urlMesServicesCyber = import.meta.env['VITE_URL_MSC'];
     if (urlMesServicesCyber) {
       const email = partageEmail().encodePourMSC(utilisateur!.email);
-      return `${urlMesServicesCyber}/cyberdepart?${email}#formulaire-demande-aide`;
+      return `${urlMesServicesCyber}/cyberdepart?${email}`;
     }
     const email = partageEmail().encodePourMAC(utilisateur!.email);
     return `${import.meta.env['VITE_URL_MAC']}/beneficier-du-dispositif/etre-aide?${email}#formulaire-demande-aide`;

--- a/mon-aide-cyber-ui/src/domaine/gestion-demandes/etre-aide/EtreAide.ts
+++ b/mon-aide-cyber-ui/src/domaine/gestion-demandes/etre-aide/EtreAide.ts
@@ -35,7 +35,7 @@ export const partageEmail = () => {
 
   return {
     encodePourMAC: (email: string) => encode(email, 'utilisateur'),
-    encodePourMSC: (email: string) => encode(email, 'utilisateur-mac'),
+    encodePourMSC: (email: string) => encode(email, 'email-utilisateur-mac'),
     encodeIdentifiantPourMSC: (nomPrenom: string, identifiant: UUID) =>
       `${encode(nomPrenom, 'nom-usage')}&identifiant-utilisateur-mac=${identifiant}`,
     decodePourMAC: (queryString: URLSearchParams) => {

--- a/mon-aide-cyber-ui/test/domaine/gestion-demandes/etre-aide/EtreAide.spec.ts
+++ b/mon-aide-cyber-ui/test/domaine/gestion-demandes/etre-aide/EtreAide.spec.ts
@@ -17,7 +17,7 @@ describe('EtreAide', () => {
         'utilisateur@societe.fr'
       );
       expect(apresEncodage).toBe(
-        'utilisateur-mac=dXRpbGlzYXRldXJAc29jaWV0ZS5mcg%3D%3D'
+        'email-utilisateur-mac=dXRpbGlzYXRldXJAc29jaWV0ZS5mcg%3D%3D'
       );
     });
 


### PR DESCRIPTION
Supprime l’ancre dans le lien de la modale pour partager l’URL de demande d’Aide correspondant à l’Aidant