### PR TITLE
[JOURNAL] Ajoute un script de rattrapage pour insérer des données correspondant aux diags Excel et aux diags de démo

### DIFF
--- a/mon-aide-cyber-api/package.json
+++ b/mon-aide-cyber-api/package.json
@@ -6,6 +6,7 @@
     "build": "knex migrate:latest --knexfile src/infrastructure/entrepots/postgres/knexfile.ts --migrations-directory migrations",
     "start": "ts-node --transpile-only --require dotenv/config index.ts",
     "dev": "knex migrate:latest --knexfile src/infrastructure/entrepots/postgres/knexfile.ts --migrations-directory migrations && nodemon --require dotenv/config index.ts",
+    "administration:rattrapage-journalisation-excel-demo": "ts-node --transpile-only --require dotenv/config src/administration/journal/rattrapage/commande.ts",
     "administration:initialise-creation-espaces-aidants": "ts-node --transpile-only --require dotenv/config src/administration/aidants/espace-aidant/commande.ts",
     "administration:envoi-mail-creation-compte-aidant": "ts-node --transpile-only --require dotenv/config src/administration/gestion-demandes/creation-compte/commande.ts",
     "administration:rapport-demandes-aidants": "ts-node --transpile-only --require dotenv/config src/administration/gestion-demandes/demandes-en-cours/commande.ts",

--- a/mon-aide-cyber-api/src/administration/journal/rattrapage/commande.ts
+++ b/mon-aide-cyber-api/src/administration/journal/rattrapage/commande.ts
@@ -1,0 +1,52 @@
+import { program } from 'commander';
+import crypto from 'crypto';
+import { EntrepotJournalisationPostgres } from '../../../infrastructure/entrepots/postgres/EntrepotJournalisationPostgres';
+import configurationJournalisation from '../../../infrastructure/entrepots/postgres/configurationJournalisation';
+import { FournisseurHorloge } from '../../../infrastructure/horloge/FournisseurHorloge';
+import { Publication } from '../../../journalisation/Publication';
+
+const entrepotJournalisation = new EntrepotJournalisationPostgres(
+  configurationJournalisation
+);
+
+const command = program.description(
+  'Exécute le rattrapage des événements (diagnostics Excel et environnement de Démo)'
+);
+
+command.action(async () => {
+  console.log('Démarrage du rattrapage Excel');
+  for (let i = 0; i < 300; i++) {
+    console.log(`${i}/199`);
+    const evt: Publication = {
+      identifiant: crypto.randomUUID(),
+      type: 'DIAGNOSTIC_LANCE',
+      date: FournisseurHorloge.enDate('2024-04-10T08:00:00'),
+      donnees: {
+        identifiantDiagnostic: crypto.randomUUID(),
+        profil: 'AIDANT',
+        identifiantUtilisateur: 'AIDANT_RATTRAPAGE_EXCEL',
+      },
+    };
+    await entrepotJournalisation.persiste(evt);
+  }
+
+  console.log('Démarrage du rattrapage Démo');
+  for (let i = 0; i < 200; i++) {
+    console.log(`${i}/199`);
+    const evt: Publication = {
+      identifiant: crypto.randomUUID(),
+      type: 'DIAGNOSTIC_LANCE',
+      date: FournisseurHorloge.enDate('2024-04-10T08:00:00'),
+      donnees: {
+        identifiantDiagnostic: crypto.randomUUID(),
+        profil: 'AIDANT',
+        identifiantUtilisateur: 'AIDANT_RATTRAPAGE_DEMO',
+      },
+    };
+    await entrepotJournalisation.persiste(evt);
+  }
+
+  process.exit(0);
+});
+
+program.parse();


### PR DESCRIPTION
Avec la commande `npm run -w mon-aide-cyber-api administration:rattrapage-journalisation-excel-demo`