### PR TITLE
[CORRECTION][MISE EN RELATION] Retourne une seule ligne par Aidant lorsque l’on a plusieurs secteurs d’activité correspondant à une entité Aidée

### DIFF
--- a/mon-aide-cyber-api/src/gestion-demandes/aide/adaptateursCorpsMessage.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/adaptateursCorpsMessage.ts
@@ -30,9 +30,7 @@ const genereCorpsRecapitulatifDemandeAide = (
   const miseEnRelation = relationUtilisateur
     ? '- Est déjà en relation avec un Aidant\n'
     : '';
-  const aidantsQuiMatchent = aidants.map(
-    (a) => `- ${a.nomPrenom} (${a.email})\n`
-  );
+  const aidantsQuiMatchent = aidants.map((a) => `- ${a.email}\n`);
   return (
     'Bonjour,\n' +
     '\n' +

--- a/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotsPostgres.spec.ts
+++ b/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotsPostgres.spec.ts
@@ -875,6 +875,40 @@ describe('Entrepot Aidant', () => {
         unAidantEnGirondeDansLesTransportsAssociatifs,
       ]);
     });
+
+    it('recherche les Aidants de manière disctincte', async () => {
+      const unAidantEnGirondeDansLesTransportsAssociatifs = unAidant()
+        .ayantPourDepartements([gironde])
+        .ayantPourSecteursActivite([{ nom: 'Transports' }])
+        .ayantPourTypesEntite([associations])
+        .construis();
+      const unAidantEnAllierPourAdministrationPublique = unAidant()
+        .ayantPourDepartements([allier])
+        .ayantPourTypesEntite([entitesPubliques])
+        .ayantPourSecteursActivite([
+          { nom: 'Administration' },
+          { nom: 'Tertiaire' },
+        ])
+        .construis();
+      const entrepotAidant = new EntrepotAidantPostgres(
+        new ServiceDeChiffrementClair()
+      );
+      await entrepotAidant.persiste(
+        unAidantEnGirondeDansLesTransportsAssociatifs
+      );
+      await entrepotAidant.persiste(unAidantEnAllierPourAdministrationPublique);
+
+      const aidantsTrouvesEnGironde =
+        await entrepotAidant.rechercheParPreferences({
+          departement: allier,
+          secteursActivite: [{ nom: 'Administration' }, { nom: 'Tertiaire' }],
+          typeEntite: entitesPubliques,
+        });
+
+      expect(aidantsTrouvesEnGironde).toStrictEqual<Aidant[]>([
+        unAidantEnAllierPourAdministrationPublique,
+      ]);
+    });
   });
 });
 


### PR DESCRIPTION
**Contexte**
Mise en relation, mail envoyé aux COTs.

**Reproduction**
- Effectuer une demande d’Aide pour une administration publique (le mapping fait en interne pour correspondre au secteur d’activité retourné par recherche entreprise donne `["Adiministration", "Tertiaire"]`)
- Vérifier le mail envoyé aux COTs (via Brevo)

**Résultat constaté**
Certains Aidants apparaissent en double dans le mail
<img width="986" alt="aidants_double" src="https://github.com/user-attachments/assets/bdb94f44-8030-4b45-a02a-c0aa07b8e8ff" />

**Résultat attendu**
Les Aidants n’apparaissent pas en double