### PR TITLE
[REMANIEMENT][MISE EN RELATION] Extrais une fonction d’envoi de mail récapitulatif pour les COT spécifiquement pour la mise en relation directe

### DIFF
--- a/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurSagaDemandeAide.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurSagaDemandeAide.ts
@@ -151,7 +151,7 @@ export class CapteurSagaDemandeAide
             this.fabriqueMiseEnRelation.fabrique(utilisateurMAC);
           const resultat = await miseEnRelation.execute({
             demandeAide: aide,
-            siret: '12345',
+            siret: entreprise[0].siret,
             secteursActivite: entreprise[0].secteursActivite,
             typeEntite: entreprise[0].typeEntite,
           });

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationDirecteAidant.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationDirecteAidant.ts
@@ -4,8 +4,8 @@ import { UtilisateurMACDTO } from '../../recherche-utilisateurs-mac/rechercheUti
 import {
   DirecteAidant,
   DonneesMiseEnRelation,
+  envoieAuCotRecapitulatifDemandeAideDirecteAidant,
   envoieConfirmationDemandeAide,
-  envoieRecapitulatifDemandeAide,
   MiseEnRelation,
   ResultatMiseEnRelation,
 } from './miseEnRelation';
@@ -22,10 +22,9 @@ export class MiseEnRelationDirecteAidant implements MiseEnRelation {
   async execute(
     donneesMiseEnRelation: DonneesMiseEnRelation
   ): Promise<ResultatMiseEnRelation<DirecteAidant>> {
-    await envoieRecapitulatifDemandeAide(
+    await envoieAuCotRecapitulatifDemandeAideDirecteAidant(
       this.adaptateurEnvoiMail,
-      donneesMiseEnRelation.demandeAide,
-      [],
+      donneesMiseEnRelation,
       this.aidant.email,
       this.annuaireCOT
     );

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationParCriteres.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationParCriteres.ts
@@ -40,7 +40,6 @@ export class MiseEnRelationParCriteres implements MiseEnRelation {
         this.adaptateurEnvoiMail,
         donneesMiseEnRelation.demandeAide,
         aidants,
-        undefined,
         this.annuaireCOT
       );
     }

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/miseEnRelation.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/miseEnRelation.ts
@@ -55,11 +55,34 @@ export const envoieAuCOTAucunAidantPourLaDemandeAide = async (
   });
 };
 
+export const envoieAuCotRecapitulatifDemandeAideDirecteAidant = async (
+  adaptateurEnvoiMail: AdaptateurEnvoiMail,
+  donneesMiseEnRelation: DonneesMiseEnRelation,
+  relationUtilisateur: string,
+  annuaireCOT: {
+    rechercheEmailParDepartement: (departement: Departement) => string;
+  }
+) => {
+  await adaptateurEnvoiMail.envoie({
+    objet:
+      "Demande d'aide pour MonAideCyber en relation directe avec un Aidant",
+    destinataire: {
+      email: annuaireCOT.rechercheEmailParDepartement(
+        donneesMiseEnRelation.demandeAide.departement
+      ),
+    },
+    copie: adaptateurEnvironnement.messagerie().copieMAC(),
+    corps: adaptateursCorpsMessage
+      .demande()
+      .recapitulatifDemandeAideDirecteAidant()
+      .genereCorpsMessage(donneesMiseEnRelation, relationUtilisateur),
+  });
+};
+
 export const envoieRecapitulatifDemandeAide = async (
   adaptateurEnvoiMail: AdaptateurEnvoiMail,
   aide: DemandeAide,
   aidants: Aidant[],
-  relationUtilisateur: string | undefined,
   annuaireCOT: {
     rechercheEmailParDepartement: (departement: Departement) => string;
   }
@@ -73,7 +96,7 @@ export const envoieRecapitulatifDemandeAide = async (
     corps: adaptateursCorpsMessage
       .demande()
       .recapitulatifDemandeAide()
-      .genereCorpsMessage(aide, aidants, relationUtilisateur),
+      .genereCorpsMessage(aide, aidants),
   });
 };
 

--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/fabriqueAnnuaireCOT.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/fabriqueAnnuaireCOT.ts
@@ -24,8 +24,8 @@ export const fabriqueAnnuaireCOT = (): AnnuaireCOT => {
     return {
       annuaireCOT: () => ({
         rechercheEmailParDepartement: (__departement: Departement): string =>
-          'cot@email.com',
-        tous: (): string[] => ['cot@email.com'],
+          'cot-mac@yopmail.com',
+        tous: (): string[] => ['cot-mac@yopmail.com'],
       }),
     };
   }

--- a/mon-aide-cyber-api/test/espace-aidant/ServiceAidantMAC.spec.ts
+++ b/mon-aide-cyber-api/test/espace-aidant/ServiceAidantMAC.spec.ts
@@ -135,7 +135,7 @@ describe('Service Aidant', () => {
 
       expect(
         adaptateurEnvoiMail.aEteEnvoyeEnCopieA(
-          'cot@email.com',
+          'cot-mac@yopmail.com',
           'Bonjour le monde!'
         )
       ).toBe(true);

--- a/mon-aide-cyber-api/test/gestion-demandes/aide/ConstructeurAdaptateurDeCorpsDeMessage.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/aide/ConstructeurAdaptateurDeCorpsDeMessage.ts
@@ -12,25 +12,24 @@ class ConstructeurAdaptateurDeCorpsDeMessage
 {
   private _recapitulatifDemandeAide: (
     _aide: DemandeAide,
-    _aidants: Aidant[],
-    _relationUtilisateur: string | undefined
-  ) => string = (
-    _aide: DemandeAide,
-    _aidants: Aidant[],
-    _relationUtilisateur: string | undefined
-  ) => 'Bonjour une entité a fait une demande d’aide';
+    _aidants: Aidant[]
+  ) => string = (_aide: DemandeAide, _aidants: Aidant[]) =>
+    'Bonjour une entité a fait une demande d’aide';
 
   private _aucunAidantPourLaDemandeAide: (
     _donneesMiseEnRelation: DonneesMiseEnRelation
   ) => string = (_donneesMiseEnRelation: DonneesMiseEnRelation) =>
     'Bonjour une entité a fait une demande d’aide';
 
+  private _recapitulatifDemandeAideDirecteAidant(
+    _donneesMiseEnRelation: DonneesMiseEnRelation,
+    _relationUtilisateur: string
+  ) {
+    return 'Bonjour une entité a fait une demande d’Aide directe Aidant.';
+  }
+
   recapitulatifDemandeAide(
-    recapitulatif: (
-      _aide: DemandeAide,
-      aidants: Aidant[],
-      relationUtilisateur: string | undefined
-    ) => string
+    recapitulatif: (_aide: DemandeAide, aidants: Aidant[]) => string
   ): ConstructeurAdaptateurDeCorpsDeMessage {
     this._recapitulatifDemandeAide = recapitulatif;
     return this;
@@ -43,16 +42,33 @@ class ConstructeurAdaptateurDeCorpsDeMessage
     return this;
   }
 
+  recapitulatifDemandeAideDirecteAidant(
+    recapitulatif: (
+      _donneesMiseEnRelation: DonneesMiseEnRelation,
+      relationUtilisateur: string
+    ) => string
+  ): ConstructeurAdaptateurDeCorpsDeMessage {
+    this._recapitulatifDemandeAideDirecteAidant = recapitulatif;
+    return this;
+  }
+
   construis(): AdaptateurCorpsDeMessageAide {
     return {
       demande: (): MessagesDemande => ({
         recapitulatifDemandeAide: () => ({
-          genereCorpsMessage: (aide, aidants, relationUtilisateur) =>
-            this._recapitulatifDemandeAide(aide, aidants, relationUtilisateur),
+          genereCorpsMessage: (aide, aidants) =>
+            this._recapitulatifDemandeAide(aide, aidants),
         }),
         aucunAidantPourLaDemandeAide: () => ({
           genereCorpsMessage: (aide) =>
             this._aucunAidantPourLaDemandeAide(aide),
+        }),
+        recapitulatifDemandeAideDirecteAidant: () => ({
+          genereCorpsMessage: (donneesMiseEnRelation, relationUtilisateur) =>
+            this._recapitulatifDemandeAideDirecteAidant(
+              donneesMiseEnRelation,
+              relationUtilisateur
+            ),
         }),
       }),
     };

--- a/mon-aide-cyber-api/test/gestion-demandes/aide/MiseEnRelationDirecteAidant.spec.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/aide/MiseEnRelationDirecteAidant.spec.ts
@@ -14,8 +14,8 @@ import { unAidant } from '../../constructeurs/constructeursAidantUtilisateurInsc
 import { unUtilisateurMAC } from '../../constructeurs/constructeurUtilisateurMac';
 import { FournisseurHorloge } from '../../../src/infrastructure/horloge/FournisseurHorloge';
 import { EntrepotsMemoire } from '../../../src/infrastructure/entrepots/memoire/EntrepotsMemoire';
-import { DemandeAide } from '../../../src/gestion-demandes/aide/DemandeAide';
-import { Aidant, entitesPubliques } from '../../../src/espace-aidant/Aidant';
+import { entitesPubliques } from '../../../src/espace-aidant/Aidant';
+import { DonneesMiseEnRelation } from '../../../src/gestion-demandes/aide/miseEnRelation';
 
 const cotParDefaut = {
   rechercheEmailParDepartement: (__departement: Departement) => 'cot@email.com',
@@ -108,11 +108,10 @@ describe('Mise en relation directe avec un Aidant', () => {
 
   it('Envoie un email de demande d’aide au COT en prenant en compte la relation existante avec un Aidant', async () => {
     adaptateursCorpsMessage.demande = unAdaptateurDeCorpsDeMessage()
-      .recapitulatifDemandeAide(
+      .recapitulatifDemandeAideDirecteAidant(
         (
-          _aide: DemandeAide,
-          _aidants: Aidant[],
-          relationUtilisateur: string | undefined
+          _donneesMiseEnRelation: DonneesMiseEnRelation,
+          relationUtilisateur: string
         ) =>
           `Bonjour une entité a fait une demande d’aide, relation Aidant : ${relationUtilisateur}`
       )

--- a/mon-aide-cyber-api/test/gestion-demandes/aide/MiseEnRelationParCriteres.spec.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/aide/MiseEnRelationParCriteres.spec.ts
@@ -115,7 +115,7 @@ describe('Mise en relation par critères', () => {
         .persiste(unAidantDansAllierEtAdministrationPublique);
       const adaptateurEnvoiMail = new AdaptateurEnvoiMailMemoire();
       adaptateursCorpsMessage.demande = unAdaptateurDeCorpsDeMessage()
-        .recapitulatifDemandeAide((_aide, aidants, _relationUtilisateur) => {
+        .recapitulatifDemandeAide((_aide, aidants) => {
           if (aidants.length === 0) {
             throw new Error('Ce test devrait trouver 1 Aidant.');
           }


### PR DESCRIPTION
Il existe une méthode d’envoi récapitulatif de demande d’Aide aux COTs. Cette méthode est utilisée dans la mise en relation directe Aidant et la mise en relation par critères. 
Elle prend donc des paramètres conditionnels ce qui n’ont pas lieu d’être, autant faire une fonction spécifique pour chaque cas.