### PR TITLE
[CORRECTION][MISE EN RELATION] Affiche correctement la liste des Aidants qui matchent dans le mail récapitulatif aux COTs

### DIFF
--- a/mon-aide-cyber-api/src/gestion-demandes/aide/adaptateursCorpsMessage.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/adaptateursCorpsMessage.ts
@@ -34,7 +34,7 @@ const genereCorpsRecapitulatifDemandeAide = (
   const raisonSociale = aide.raisonSociale
     ? `- Raison sociale: ${aide.raisonSociale}\n`
     : '';
-  const aidantsQuiMatchent = aidants.map((a) => `- ${a.email}\n`);
+  const aidantsQuiMatchent = aidants.map((a) => `- ${a.email}`);
   return (
     'Bonjour,\n' +
     '\n' +
@@ -46,7 +46,7 @@ const genereCorpsRecapitulatifDemandeAide = (
     raisonSociale +
     '\n' +
     `Les Aidants disponibles : \n` +
-    (aidantsQuiMatchent.length > 0 ? aidantsQuiMatchent : 'Aucun')
+    (aidantsQuiMatchent.length > 0 ? aidantsQuiMatchent.join('\n') : 'Aucun')
   );
 };
 


### PR DESCRIPTION
**Contexte**
Mise en relation par critères

**Reproduction**
- Effectuer une demande d’Aide avec des critères remontant plusieurs Aidants
- Vérifier le mail envoyé aux COTs

**Résultat constaté**
Les Aidants apparaissent avec une `,` avant chaque `-`
![Capture d’écran 2025-05-15 à 14 57 24](https://github.com/user-attachments/assets/9712026d-2b28-4a2d-a6e9-321ef83df0cf)

**Résultat attendu**
Il n’y a pas de `,` avant chaque Aidant