### PR TITLE
[POSTULER] Affichage réel des informations relatives au token de mise en relation utilisé

### DIFF
--- a/mon-aide-cyber-api/src/api/aidant/miseEnRelation.ts
+++ b/mon-aide-cyber-api/src/api/aidant/miseEnRelation.ts
@@ -1,0 +1,8 @@
+import { Departement } from '../../gestion-demandes/departements';
+
+export type DemandePourPostuler = {
+  dateCreation: string;
+  departement: Departement;
+  typeEntite: string;
+  secteurActivite: string;
+};

--- a/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
+++ b/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
@@ -8,6 +8,8 @@ import * as core from 'express-serve-static-core';
 
 import { tokenAttributionDemandeAide } from '../../gestion-demandes/aide/MiseEnRelationParCriteres';
 
+import { DemandePourPostuler } from './miseEnRelation';
+
 type CorpsRequeteRepondreAUneDemande = core.ParamsDictionary & {
   token: string;
 };
@@ -44,6 +46,22 @@ export const routesAPIAidantRepondreAUneDemande = (
           .status(400)
           .json({ message: (erreur as DemandeAideDejaPourvue).message });
       }
+    }
+  );
+
+  routes.get(
+    '/informations-de-demande',
+    async (_requete, reponse: Response<DemandePourPostuler>) => {
+      reponse.json({
+        dateCreation: new Date('2025-05-15T15:30').toISOString(),
+        departement: {
+          nom: 'Gironde',
+          code: '33',
+          codeRegion: '75',
+        },
+        typeEntite: 'Entreprise privée',
+        secteurActivite: 'Tertiaire',
+      });
     }
   );
 

--- a/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
+++ b/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
@@ -97,7 +97,8 @@ export const routesAPIAidantRepondreAUneDemande = (
       const demandeAide = await entrepots
         .demandesAides()
         .rechercheParEmail(tokenEnClair.demande);
-      if (demandeAide.etat === 'INEXISTANT') {
+
+      if (demandeAide.etat !== 'COMPLET') {
         return suite(
           ErreurMAC.cree(
             "Postuler à une demande d'aide",
@@ -106,21 +107,22 @@ export const routesAPIAidantRepondreAUneDemande = (
         );
       }
 
-      if (demandeAide.demandeAide) {
-        const entreprises =
-          await adaptateurRechercheEntreprise.rechercheEntreprise(
-            demandeAide.demandeAide.siret,
-            ''
-          );
-        return reponse.json({
-          dateCreation: demandeAide.demandeAide.dateSignatureCGU.toISOString(),
-          departement: demandeAide.demandeAide.departement,
-          typeEntite: entreprises[0].typeEntite.nom,
-          secteurActivite: entreprises[0].secteursActivite
-            .map((s) => s.nom)
-            .join(', '),
-        });
-      }
+      const demande = demandeAide.demandeAide;
+
+      const [entreprise] =
+        await adaptateurRechercheEntreprise.rechercheEntreprise(
+          demande.siret,
+          ''
+        );
+
+      return reponse.json({
+        dateCreation: demande.dateSignatureCGU.toISOString(),
+        departement: demande.departement,
+        typeEntite: entreprise?.typeEntite.nom ?? 'Information indisponible',
+        secteurActivite:
+          entreprise?.secteursActivite.map((s) => s.nom).join(', ') ??
+          'Information indisponible',
+      });
     }
   );
 

--- a/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
+++ b/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
@@ -51,8 +51,14 @@ export const routesAPIAidantRepondreAUneDemande = (
 
   routes.get(
     '/informations-de-demande',
-    async (_requete, reponse: Response<DemandePourPostuler>) => {
-      reponse.json({
+    async (
+      requete: Request,
+      reponse: Response<DemandePourPostuler | { codeErreur: string }>
+    ) => {
+      if ((requete.query['token'] as string)?.startsWith('x')) {
+        return reponse.status(400).json({ codeErreur: 'TOKEN_INVALIDE' });
+      }
+      return reponse.json({
         dateCreation: new Date('2025-05-15T15:30').toISOString(),
         departement: {
           nom: 'Gironde',

--- a/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
+++ b/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
@@ -88,7 +88,7 @@ export const routesAPIAidantRepondreAUneDemande = (
       } catch (erreur: unknown | Error) {
         return suite(
           ErreurMAC.cree(
-            "Demande d'aide",
+            "Postuler à une demande d'aide",
             new ErreurPostulerTokenInvalide(token, erreur as Error)
           )
         );
@@ -100,11 +100,12 @@ export const routesAPIAidantRepondreAUneDemande = (
       if (demandeAide.etat === 'INEXISTANT') {
         return suite(
           ErreurMAC.cree(
-            "Demande d'aide",
+            "Postuler à une demande d'aide",
             new ErreurPostulerTokenSansDemande(token)
           )
         );
       }
+
       if (demandeAide.demandeAide) {
         const entreprises =
           await adaptateurRechercheEntreprise.rechercheEntreprise(

--- a/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
+++ b/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
@@ -25,6 +25,14 @@ export class ErreurPostulerTokenInvalide extends Error {
   }
 }
 
+export class ErreurPostulerTokenSansDemande extends Error {
+  constructor(token: string) {
+    super(
+      `Reçu token valide mais impossible de trouver la demande associée : ${token}`
+    );
+  }
+}
+
 export const routesAPIAidantRepondreAUneDemande = (
   configuration: ConfigurationServeur
 ) => {
@@ -89,6 +97,14 @@ export const routesAPIAidantRepondreAUneDemande = (
       const demandeAide = await entrepots
         .demandesAides()
         .rechercheParEmail(tokenEnClair.demande);
+      if (demandeAide.etat === 'INEXISTANT') {
+        return suite(
+          ErreurMAC.cree(
+            "Demande d'aide",
+            new ErreurPostulerTokenSansDemande(token)
+          )
+        );
+      }
       if (demandeAide.demandeAide) {
         const entreprises =
           await adaptateurRechercheEntreprise.rechercheEntreprise(
@@ -104,7 +120,6 @@ export const routesAPIAidantRepondreAUneDemande = (
             .join(', '),
         });
       }
-      return reponse.status(500).json({ codeErreur: 'NON_IMPLEMENTÉ' });
     }
   );
 

--- a/mon-aide-cyber-api/src/api/gestionnaires/erreurs.ts
+++ b/mon-aide-cyber-api/src/api/gestionnaires/erreurs.ts
@@ -23,7 +23,10 @@ import { ErreurAidantNonTrouve } from '../../espace-utilisateur-inscrit/ServiceU
 import { RequeteUtilisateur } from '../routesAPI';
 import { ErreurLectureReferentielAssociations } from '../associations/routesAssociations';
 import { IpDeniedError } from 'express-ipfilter';
-import { ErreurPostulerTokenInvalide } from '../aidant/routesAPIAidantRepondreAUneDemande';
+import {
+  ErreurPostulerTokenInvalide,
+  ErreurPostulerTokenSansDemande,
+} from '../aidant/routesAPIAidantRepondreAUneDemande';
 
 const HTTP_MAUVAISE_REQUETE = 400;
 const HTTP_NON_AUTORISE = 401;
@@ -295,6 +298,21 @@ const erreursGerees: Map<
     ) => {
       construisReponse(reponse, HTTP_MAUVAISE_REQUETE, {
         codeErreur: 'TOKEN_INVALIDE',
+        message: '',
+      });
+      consignateur.consigne(erreur);
+    },
+  ],
+  [
+    'ErreurPostulerTokenSansDemande',
+    (
+      erreur: ErreurMAC<ErreurPostulerTokenSansDemande>,
+      _requete: Request,
+      consignateur,
+      reponse
+    ) => {
+      construisReponse(reponse, HTTP_MAUVAISE_REQUETE, {
+        codeErreur: 'TOKEN_SANS_DEMANDE',
         message: '',
       });
       consignateur.consigne(erreur);

--- a/mon-aide-cyber-api/src/api/gestionnaires/erreurs.ts
+++ b/mon-aide-cyber-api/src/api/gestionnaires/erreurs.ts
@@ -23,6 +23,7 @@ import { ErreurAidantNonTrouve } from '../../espace-utilisateur-inscrit/ServiceU
 import { RequeteUtilisateur } from '../routesAPI';
 import { ErreurLectureReferentielAssociations } from '../associations/routesAssociations';
 import { IpDeniedError } from 'express-ipfilter';
+import { ErreurPostulerTokenInvalide } from '../aidant/routesAPIAidantRepondreAUneDemande';
 
 const HTTP_MAUVAISE_REQUETE = 400;
 const HTTP_NON_AUTORISE = 401;
@@ -282,6 +283,21 @@ const erreursGerees: Map<
       construisReponse(reponse, HTTP_NON_TROUVE, {
         message: erreur.message,
       });
+    },
+  ],
+  [
+    'ErreurPostulerTokenInvalide',
+    (
+      erreur: ErreurMAC<ErreurPostulerTokenInvalide>,
+      _requete: Request,
+      consignateur,
+      reponse
+    ) => {
+      construisReponse(reponse, HTTP_MAUVAISE_REQUETE, {
+        codeErreur: 'TOKEN_INVALIDE',
+        message: '',
+      });
+      consignateur.consigne(erreur);
     },
   ],
 ]);

--- a/mon-aide-cyber-api/src/domaine/erreurMAC.ts
+++ b/mon-aide-cyber-api/src/domaine/erreurMAC.ts
@@ -21,6 +21,7 @@ export type Contexte =
   | 'Modifie le mot de passe'
   | 'Modifie le profil Aidant'
   | 'Modifie les préférences de l’Aidant'
+  | "Postuler à une demande d'aide"
   | "Recherche d'un Aidé"
   | 'Réinitialisation mot de passe'
   | 'Valide les CGU'

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/DemandeAide.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/DemandeAide.ts
@@ -10,10 +10,17 @@ export type DemandeAide = Aggregat & {
   siret: string | 'NON_DISPONIBLE';
 };
 
-export type RechercheDemandeAide = {
-  demandeAide?: DemandeAide;
-  etat: 'COMPLET' | 'INCOMPLET' | 'INEXISTANT';
+export type RechercheDemandeAide =
+  | RechercheDemandeAideComplete
+  | RechercheDemandeAideNonTrouvee;
+export type RechercheDemandeAideComplete = {
+  demandeAide: DemandeAide;
+  etat: 'COMPLET';
 };
+export type RechercheDemandeAideNonTrouvee = {
+  etat: 'INEXISTANT' | 'INCOMPLET';
+};
+
 export interface EntrepotDemandeAide {
   rechercheParEmail(email: string): Promise<RechercheDemandeAide>;
   persiste(entite: DemandeAide): Promise<void>;

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationParCriteres.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationParCriteres.ts
@@ -23,7 +23,7 @@ export type AidantMisEnRelation = {
   lienPourPostuler: string;
 };
 
-type TonkenAttributionDemandeAide = {
+export type TonkenAttributionDemandeAide = {
   demande: crypto.UUID;
   aidant: crypto.UUID;
 };

--- a/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
+++ b/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
@@ -156,5 +156,23 @@ describe('Le serveur MAC, sur  les routes de réponse à une demande', () => {
         message: '',
       });
     });
+
+    it('Rejette la requête avec une erreur 400 (et non une 404) si la demande d’Aide est introuvable', async () => {
+      const tokenSansDemande = tokenAttributionDemandeAide(
+        testeurMAC.serviceDeChiffrement
+      ).chiffre('entite-aidee@email.com', crypto.randomUUID());
+
+      const reponse = await executeRequete(
+        donneesServeur.app,
+        'GET',
+        `/api/aidant/repondre-a-une-demande/informations-de-demande?token=${tokenSansDemande}`
+      );
+
+      expect(reponse.statusCode).toBe(400);
+      expect(await reponse.json()).toStrictEqual({
+        codeErreur: 'TOKEN_SANS_DEMANDE',
+        message: '',
+      });
+    });
   });
 });

--- a/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
+++ b/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
@@ -143,7 +143,7 @@ describe('Le serveur MAC, sur  les routes de réponse à une demande', () => {
       });
     });
 
-    it('Rejette la requête avec une erreur 400 si le token commence par ’x’, le temps de développer complètement la feature', async () => {
+    it('Rejette la requête avec une erreur 400 si le déchiffrement du token lève une exception', async () => {
       const reponse = await executeRequete(
         donneesServeur.app,
         'GET',

--- a/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
+++ b/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
@@ -20,66 +20,69 @@ describe('Le serveur MAC, sur  les routes de réponse à une demande', () => {
 
   afterEach(() => testeurMAC.arrete());
 
-  it("Envoie la confirmation de diagnostic à l'Aidant", async () => {
-    const aidant = unAidant()
-      .avecUnEmail('jean.dupont@email.com')
-      .avecUnNomPrenom('Jean DUPONT')
-      .construis();
-    const demandeAide: DemandeAide = uneDemandeAide()
-      .avecUnEmail('entite-aidee@email.com')
-      .dansLeDepartement(gironde)
-      .construis();
-    await testeurMAC.entrepots.aidants().persiste(aidant);
-    await testeurMAC.entrepots.demandesAides().persiste(demandeAide);
-    const token = tokenAttributionDemandeAide().chiffre(
-      demandeAide.email,
-      aidant.identifiant
-    );
+  describe("Concernant la réponse par l'aidant", () => {
+    it("Envoie la confirmation de diagnostic à l'Aidant", async () => {
+      const aidant = unAidant()
+        .avecUnEmail('jean.dupont@email.com')
+        .avecUnNomPrenom('Jean DUPONT')
+        .construis();
+      const demandeAide: DemandeAide = uneDemandeAide()
+          .avecUnEmail('entite-aidee@email.com')
+          .dansLeDepartement(gironde)
+          .construis();
+      await testeurMAC.entrepots.aidants().persiste(aidant);
+      await testeurMAC.entrepots.demandesAides().persiste(demandeAide);
+      const token = tokenAttributionDemandeAide().chiffre(
+        demandeAide.email,
+        aidant.identifiant
+      );
 
-    const reponse = await executeRequete(
-      donneesServeur.app,
-      'POST',
-      `/api/aidant/repondre-a-une-demande`,
-      {
-        token,
-      }
-    );
+      const reponse = await executeRequete(
+        donneesServeur.app,
+        'POST',
+        `/api/aidant/repondre-a-une-demande`,
+        { token }
+      );
 
-    expect(reponse.statusCode).toBe(202);
-    expect(
-      (
-        testeurMAC.adaptateurEnvoieMessage as AdaptateurEnvoiMailMemoire
-      ).demandeAideAttribueeEnvoyee({
-        emailAidant: 'user-xavier@yopmail.com',
-        nomPrenomAidant: 'User XAVIER',
-        emailEntite: 'entite-aidee@yopmail.com',
-        departement: gironde,
-      })
-    ).toBe(true);
-  });
+      expect(reponse.statusCode).toBe(202);
+      expect(
+        (
+          testeurMAC.adaptateurEnvoieMessage as AdaptateurEnvoiMailMemoire
+        ).demandeAideAttribueeEnvoyee({
+          emailAidant: 'user-xavier@yopmail.com',
+          nomPrenomAidant: 'User XAVIER',
+          emailEntite: 'entite-aidee@yopmail.com',
+          departement: gironde,
+        })
+      ).toBe(true);
+    });
 
-  it('Retourne une erreur 400 si la demande ne peut être pourvue (le mail de la demande commence par b)', async () => {
-    const aidant = unAidant().construis();
-    const demandeAide: DemandeAide = uneDemandeAide()
-      .avecUnEmail('banal@email.com')
-      .dansLeDepartement(gironde)
-      .construis();
-    await testeurMAC.entrepots.aidants().persiste(aidant);
-    await testeurMAC.entrepots.demandesAides().persiste(demandeAide);
-    const token = tokenAttributionDemandeAide().chiffre(
-      demandeAide.email,
-      aidant.identifiant
-    );
+    it('Retourne une erreur 400 si la demande ne peut être pourvue (le mail de la demande commence par b)', async () => {
+      const aidant = unAidant()
 
-    const reponse = await executeRequete(
-      donneesServeur.app,
-      'POST',
-      `/api/aidant/repondre-a-une-demande`,
-      {
-        token,
-      }
-    );
+        .construis();
+      const demandeAide: DemandeAide = uneDemandeAide()
+          .avecUnEmail('banal@email.com')
+          .dansLeDepartement(gironde)
+          .construis();
 
-    expect(reponse.statusCode).toBe(400);
+      await testeurMAC.entrepots.aidants().persiste(aidant);
+      await testeurMAC.entrepots.demandesAides().persiste(demandeAide);
+      const token = tokenAttributionDemandeAide().chiffre(
+        demandeAide.email,
+        aidant.identifiant
+      );
+
+      const reponse = await executeRequete(
+        donneesServeur.app,
+        'POST',
+        `/api/aidant/repondre-a-une-demande`,
+        {
+          token,
+        }
+      );
+
+      expect(reponse.statusCode).toBe(400);
+    });
   });
 });

--- a/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
+++ b/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
@@ -153,6 +153,7 @@ describe('Le serveur MAC, sur  les routes de réponse à une demande', () => {
       expect(reponse.statusCode).toBe(400);
       expect(await reponse.json()).toStrictEqual({
         codeErreur: 'TOKEN_INVALIDE',
+        message: '',
       });
     });
   });

--- a/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
+++ b/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
@@ -108,5 +108,18 @@ describe('Le serveur MAC, sur  les routes de réponse à une demande', () => {
         secteurActivite: 'Tertiaire',
       });
     });
+
+    it('Rejette la requête avec une erreur 400 si le token commence par ’x’, le temps de développer complètement la feature', async () => {
+      const reponse = await executeRequete(
+        donneesServeur.app,
+        'GET',
+        `/api/aidant/repondre-a-une-demande/informations-de-demande?token=xa`
+      );
+
+      expect(reponse.statusCode).toBe(400);
+      expect(await reponse.json()).toStrictEqual({
+        codeErreur: 'TOKEN_INVALIDE',
+      });
+    });
   });
 });

--- a/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
+++ b/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
@@ -9,6 +9,7 @@ import { gironde } from '../../../src/gestion-demandes/departements';
 import { DemandeAide } from '../../../src/gestion-demandes/aide/DemandeAide';
 
 import { tokenAttributionDemandeAide } from '../../../src/gestion-demandes/aide/MiseEnRelationParCriteres';
+import { DemandePourPostuler } from '../../../src/api/aidant/miseEnRelation';
 
 describe('Le serveur MAC, sur  les routes de réponse à une demande', () => {
   const testeurMAC = testeurIntegration();
@@ -83,6 +84,29 @@ describe('Le serveur MAC, sur  les routes de réponse à une demande', () => {
       );
 
       expect(reponse.statusCode).toBe(400);
+    });
+  });
+
+  describe("Concernant l'obtention des détails de la demande d'aide", () => {
+    it('Renvoie systématiquement des infos en dur, le temps de développer complètement la feature', async () => {
+      const reponse = await executeRequete(
+        donneesServeur.app,
+        'GET',
+        `/api/aidant/repondre-a-une-demande/informations-de-demande`
+      );
+
+      expect(reponse.statusCode).toBe(200);
+
+      expect(reponse.json()).toStrictEqual<DemandePourPostuler>({
+        dateCreation: '2025-05-15T13:30:00.000Z',
+        departement: {
+          nom: 'Gironde',
+          code: '33',
+          codeRegion: '75',
+        },
+        typeEntite: 'Entreprise privée',
+        secteurActivite: 'Tertiaire',
+      });
     });
   });
 });

--- a/mon-aide-cyber-api/test/gestion-demandes/aide/ConstructeurDemandeAide.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/aide/ConstructeurDemandeAide.ts
@@ -50,6 +50,11 @@ class ConstructeurDemandeAide implements Constructeur<DemandeAide> {
     this.email = email;
     return this;
   }
+
+  avecLeSiret(siret: string): ConstructeurDemandeAide {
+    this.siret = siret;
+    return this;
+  }
 }
 
 export const uneDemandeAide = () => new ConstructeurDemandeAide();

--- a/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotAideConcret.spec.ts
+++ b/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotAideConcret.spec.ts
@@ -18,6 +18,7 @@ import { FournisseurHorloge } from '../../../../src/infrastructure/horloge/Fourn
 import {
   DemandeAide,
   RechercheDemandeAide,
+  RechercheDemandeAideComplete,
 } from '../../../../src/gestion-demandes/aide/DemandeAide';
 import { uneDemandeAide } from '../../../gestion-demandes/aide/ConstructeurDemandeAide';
 import { AdaptateurRepertoireDeContactsMemoire } from '../../../../src/infrastructure/adaptateurs/AdaptateurRepertoireDeContactsMemoire';
@@ -264,7 +265,9 @@ describe('Entrepot Aidé Concret', () => {
         entrepotAideBrevoMemoire
       ).rechercheParEmail(demandeAide.email);
 
-      expect(aideRecherche.demandeAide?.siret).toBe('NON_DISPONIBLE');
+      const demandeTrouvee = (aideRecherche as RechercheDemandeAideComplete)
+        .demandeAide;
+      expect(demandeTrouvee.siret).toBe('NON_DISPONIBLE');
     });
   });
 });

--- a/mon-aide-cyber-ui/src/domaine/gestion-demandes/repondre-a-une-demande/composants/RepondreALaDemande.tsx
+++ b/mon-aide-cyber-ui/src/domaine/gestion-demandes/repondre-a-une-demande/composants/RepondreALaDemande.tsx
@@ -6,10 +6,10 @@ import { DemandePourPostuler } from '../EcranRepondreAUneDemande.tsx';
 
 export const RepondreALaDemande = ({
   demandeAide,
-  surReponsePositive,
+  surReponse,
 }: {
   demandeAide?: DemandePourPostuler;
-  surReponsePositive?: () => void;
+  surReponse?: () => void;
 }) => {
   return (
     <>
@@ -55,11 +55,7 @@ export const RepondreALaDemande = ({
               </div>
             </div>
             <div className="actions-demande-aide">
-              <Button
-                type="button"
-                variant="primary"
-                onClick={surReponsePositive}
-              >
+              <Button type="button" variant="primary" onClick={surReponse}>
                 Je souhaite réaliser ce diagnostic
               </Button>
             </div>

--- a/mon-aide-cyber-ui/src/domaine/gestion-demandes/repondre-a-une-demande/composants/RepondreALaDemande.tsx
+++ b/mon-aide-cyber-ui/src/domaine/gestion-demandes/repondre-a-une-demande/composants/RepondreALaDemande.tsx
@@ -2,13 +2,13 @@ import HeroBloc from '../../../../composants/communs/HeroBloc.tsx';
 import { TypographieH1 } from '../../../../composants/communs/typographie/TypographieH1/TypographieH1.tsx';
 import { TypographieH4 } from '../../../../composants/communs/typographie/TypographieH4/TypographieH4.tsx';
 import Button from '../../../../composants/atomes/Button/Button.tsx';
-import { DemandeAide } from '../EcranRepondreAUneDemande.tsx';
+import { DemandePourPostuler } from '../EcranRepondreAUneDemande.tsx';
 
 export const RepondreALaDemande = ({
   demandeAide,
   surReponsePositive,
 }: {
-  demandeAide: DemandeAide;
+  demandeAide?: DemandePourPostuler;
   surReponsePositive?: () => void;
 }) => {
   return (
@@ -24,41 +24,47 @@ export const RepondreALaDemande = ({
         </div>
       </HeroBloc>
       <section className="contenu-principal fond-clair-mac">
-        <div className="section-blanche">
-          <div className="description-demande-aide">
-            <TypographieH4>Informations sur la demande d‘Aide</TypographieH4>
-            <div className="informations">
-              <p>
-                Date :{'  '}
-                <b>{demandeAide?.dateCreation}</b>
-              </p>
-              <p>
-                Type d‘entité :{'  '}
-                <b>{demandeAide?.typeEntite}</b>
-              </p>
-              <p>
-                Territoire :{'  '}
-                <b>
-                  {demandeAide?.departement.nom} (
-                  {demandeAide?.departement.code})
-                </b>
-              </p>
-              <p>
-                Secteur d‘activité :{'  '}
-                <b>{demandeAide?.secteurActivite}</b>
-              </p>
+        {!demandeAide ? (
+          <div>Chargement...</div>
+        ) : (
+          <div className="section-blanche">
+            <div className="description-demande-aide">
+              <TypographieH4>Informations sur la demande d‘Aide</TypographieH4>
+              <div className="informations">
+                <p>
+                  Date :{'  '}
+                  <b>
+                    {new Date(demandeAide.dateCreation).toLocaleDateString()}
+                  </b>
+                </p>
+                <p>
+                  Type d‘entité :{'  '}
+                  <b>{demandeAide?.typeEntite}</b>
+                </p>
+                <p>
+                  Territoire :{'  '}
+                  <b>
+                    {demandeAide?.departement.nom} (
+                    {demandeAide?.departement.code})
+                  </b>
+                </p>
+                <p>
+                  Secteur d‘activité :{'  '}
+                  <b>{demandeAide?.secteurActivite}</b>
+                </p>
+              </div>
+            </div>
+            <div className="actions-demande-aide">
+              <Button
+                type="button"
+                variant="primary"
+                onClick={surReponsePositive}
+              >
+                Je souhaite réaliser ce diagnostic
+              </Button>
             </div>
           </div>
-          <div className="actions-demande-aide">
-            <Button
-              type="button"
-              variant="primary"
-              onClick={surReponsePositive}
-            >
-              Je souhaite réaliser ce diagnostic
-            </Button>
-          </div>
-        </div>
+        )}
       </section>
     </>
   );


### PR DESCRIPTION
Cette PR prend la valeur du `<token>` présent dans `http://localhost:8081/repondre-a-une-demande?token=<token>` comme la source de données permettant de recherche la demande sur laquelle l'Aidant va postuler.

On cesse donc d'hard-coder les bons et mauvais chemins, au profit d'appels réels vers nos services et dépôts.