### PR TITLE
[BRIQUES REUTILISABLES UI-KIT] Intègre la brique Hero et le carrousel dans la page d'accueil de MAC

### DIFF
--- a/mon-aide-cyber-ui/index.html
+++ b/mon-aide-cyber-ui/index.html
@@ -33,7 +33,7 @@
 
     <script
       type="text/javascript"
-      src="https://lab-anssi-ui-kit-prod-s3-assets.cellar-c2.services.clever-cloud.com/1.8.4/lab-anssi-ui-kit.iife.js"
+      src="https://lab-anssi-ui-kit-prod-s3-assets.cellar-c2.services.clever-cloud.com/1.9.0/lab-anssi-ui-kit.iife.js"
       nonce="%%NONCE%%"
     >
     </script>

--- a/mon-aide-cyber-ui/index.html
+++ b/mon-aide-cyber-ui/index.html
@@ -33,7 +33,7 @@
 
     <script
       type="text/javascript"
-      src="https://lab-anssi-ui-kit-prod-s3-assets.cellar-c2.services.clever-cloud.com/1.6.3/lab-anssi-ui-kit.iife.js"
+      src="https://lab-anssi-ui-kit-prod-s3-assets.cellar-c2.services.clever-cloud.com/1.8.4/lab-anssi-ui-kit.iife.js"
       nonce="%%NONCE%%"
     >
     </script>

--- a/mon-aide-cyber-ui/package.json
+++ b/mon-aide-cyber-ui/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@babel/runtime": ">=7.26.10",
     "@gouvfr/dsfr": "^1.11.0",
-    "@lab-anssi/ui-kit": "1.6.3",
+    "@lab-anssi/ui-kit": "1.8.4",
     "@tanstack/react-query": "^5.59.15",
     "@vitejs/plugin-react-swc": "^3.6.0",
     "react": "^18.2.0",

--- a/mon-aide-cyber-ui/package.json
+++ b/mon-aide-cyber-ui/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@babel/runtime": ">=7.26.10",
     "@gouvfr/dsfr": "^1.11.0",
-    "@lab-anssi/ui-kit": "1.8.4",
+    "@lab-anssi/ui-kit": "1.9.0",
     "@tanstack/react-query": "^5.59.15",
     "@vitejs/plugin-react-swc": "^3.6.0",
     "react": "^18.2.0",

--- a/mon-aide-cyber-ui/src/Accueil.tsx
+++ b/mon-aide-cyber-ui/src/Accueil.tsx
@@ -21,7 +21,37 @@ export const Accueil = () => {
     setMotDGClique(false);
     setMotGeneralClique(true);
   }, []);
-  
+
+  const tuiles = [
+    {
+      titre: 'Un dispositif étatique',
+      contenu:
+        'MonAideCyber est proposé par l’Agence nationale de la sécurité des systèmes d’information.',
+      illustration: {
+        lien: '/images/icones/accompagnement-personnalise.svg',
+        alt: 'Un diagnostic cyber',
+      },
+    },
+    {
+      titre: 'Une communauté de confiance',
+      contenu:
+        'Les Aidants cyber sont issus de la sphère publique ou sont membres d’associations œuvrant pour un numérique de confiance.',
+      illustration: {
+        lien: '/images/icones/diagnostic-cyber.svg',
+        alt: 'Un accompagnement personnalisé',
+      },
+    },
+    {
+      titre: 'Au service de l’intérêt général',
+      contenu:
+        'Le diagnostic cyber aide les entités qui souhaitent se protéger contre les cyberattaques et passer à l’action.',
+      illustration: {
+        lien: '/images/icones/communaute-aidants.svg',
+        alt: 'Communauté d‘Aidants cyber',
+      },
+    },
+  ];
+
   return (
     <main role="main">
       <lab-anssi-brique-hero
@@ -42,6 +72,9 @@ export const Accueil = () => {
           lien: liensMesServicesCyber().cyberDepartBrut,
         })}
       ></lab-anssi-brique-hero>
+      <lab-anssi-carrousel-tuiles
+        tuiles={JSON.stringify(tuiles)}
+      ></lab-anssi-carrousel-tuiles>
       <div className="conteneur-accueil">
         <div className="fr-container">
           <div id="ce-que-cest" className="fr-grid-row fr-grid-row--gutters">

--- a/mon-aide-cyber-ui/src/Accueil.tsx
+++ b/mon-aide-cyber-ui/src/Accueil.tsx
@@ -1,6 +1,7 @@
 import { ActionsPiedDePage } from './composants/communs/ActionsPiedDePage.tsx';
 import { useCallback, useState } from 'react';
 import { useTitreDePage } from './hooks/useTitreDePage.ts';
+import { liensMesServicesCyber } from './infrastructure/mes-services-cyber/liens.ts';
 
 export const Accueil = () => {
   const [motDGClique, setMotDGClique] = useState<boolean>(true);
@@ -20,102 +21,28 @@ export const Accueil = () => {
     setMotDGClique(false);
     setMotGeneralClique(true);
   }, []);
-
+  
   return (
     <main role="main">
-      <div className="mode-fonce accueil">
-        <div id="presentation" className="fr-container">
-          <div className="fr-grid-row fr-grid-row--middle fr-py-20v">
-            <div id="corps" className="fr-col-md-6 fr-col-sm-12">
-              <h1 className="fr-mb-5w">MonAideCyber</h1>
-              <p>
-                Passez à l’action et menons ensemble votre première démarche de
-                cybersécurité grâce à notre communauté d’Aidants cyber présente
-                sur tout le territoire !
-              </p>
-            </div>
-            <div id="illustration" className="fr-col-md-6 fr-col-sm-12">
-              <img
-                src="/images/illustration-dialogue-mac.svg"
-                alt="scène d'un aidant cyber et d'un aidé faisant un diagnostic"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
+      <lab-anssi-brique-hero
+        titre="MonAideCyber"
+        soustitre="Passez à l’action et menons ensemble votre première démarche de
+                cybersécurité grâce à notre communauté d’Aidants présente sur
+                tout le territoire !"
+        illustration={JSON.stringify({
+          lien: '/images/illustration-dialogue-mac.svg',
+          alt: '',
+        })}
+        actiongauche={JSON.stringify({
+          titre: 'Devenir Aidant cyber',
+          lien: '/realiser-des-diagnostics-anssi',
+        })}
+        actiondroite={JSON.stringify({
+          titre: 'Bénéficier d‘un diagnostic cyber',
+          lien: liensMesServicesCyber().cyberDepartBrut,
+        })}
+      ></lab-anssi-brique-hero>
       <div className="conteneur-accueil">
-        <div className="fr-container tuiles">
-          <div className="fr-grid-row fr-grid-row--gutters">
-            <div className="fr-col-md-4 fr-col-sm-12">
-              <div className="tuile tuile-centree tuile-petite">
-                <div className="illustration">
-                  <img
-                    src="/images/icones/diagnostic-cyber.svg"
-                    alt="Un diagnostic cyber"
-                  />
-                </div>
-                <div className="corps">
-                  <div>
-                    <h4>
-                      <span>
-                        1 Diagnostic <br />
-                        cyber
-                      </span>
-                    </h4>
-                  </div>
-                  <div>
-                    <p>
-                      MonAideCyber propose un diagnostic de sécurité cyber
-                      gratuit
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className="fr-col-md-4 fr-col-sm-12">
-              <div className="tuile tuile-centree tuile-petite">
-                <div className="illustration">
-                  <img
-                    src="/images/icones/communaute-aidants.svg"
-                    alt="Un diagnostic cyber"
-                  />
-                </div>
-                <div className="corps">
-                  <div>
-                    <h4>1 Communauté d&apos;Aidants cyber</h4>
-                  </div>
-                  <div>
-                    <p>
-                      MonAideCyber s’appuie sur une communauté d’Aidants cyber
-                      de confiance
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className="fr-col-md-4 fr-col-sm-12">
-              <div className="tuile tuile-centree tuile-petite">
-                <div className="illustration">
-                  <img
-                    src="/images/icones/accompagnement-personnalise.svg"
-                    alt="Un diagnostic cyber"
-                  />
-                </div>
-                <div className="corps">
-                  <div>
-                    <h4>1 Accompagnement personnalisé</h4>
-                  </div>
-                  <div>
-                    <p>
-                      MonAideCyber aiguille les entités vers des dispositifs et
-                      des tiers de confiance
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
         <div className="fr-container">
           <div id="ce-que-cest" className="fr-grid-row fr-grid-row--gutters">
             <div className="fr-col-8 fr-col-sm-12">

--- a/mon-aide-cyber-ui/src/assets/styles/_centre-aide.scss
+++ b/mon-aide-cyber-ui/src/assets/styles/_centre-aide.scss
@@ -6,4 +6,14 @@
   --centre-aide-font-color-lien-secondaire: var(--centre-aide-background-entete);
   --centre-aide-background-hover-lien: var(--couleurs-mac-securiteacces);
   --centre-aide-background-hover-declencheur: var(--centre-aide-background-hover-lien);
+  --brique-background-primaire: var(--centre-aide-background-entete);
+  --brique-hero-bouton-gauche-background: white;
+  --brique-hero-bouton-gauche-background-hover: #F6F6F6;
+  --brique-hero-bouton-gauche-background-active: #F6F6F6;
+  --brique-hero-bouton-gauche-texte: #5D2A9D;
+  --brique-hero-bouton-droite-background: transparent;
+  --brique-hero-bouton-droite-background-hover: rgba(255, 255, 255, 0.08);
+  --brique-hero-bouton-droite-background-active: rgba(255, 255, 255, 0.16);
+  --brique-hero-bouton-droite-texte: white;
+  --titre-couleur-primaire: #5D2A9D;
 }

--- a/mon-aide-cyber-ui/src/assets/styles/_centre-aide.scss
+++ b/mon-aide-cyber-ui/src/assets/styles/_centre-aide.scss
@@ -1,12 +1,13 @@
 :root {
-  --centre-aide-background-entete: var(--couleurs-mac-violet-fonce);
+  --centre-aide-background-entete: #5D2A9D;
   --centre-aide-background-bouton: var(--centre-aide-background-entete);
   --centre-aide-font-color-bouton: white;
   --centre-aide-border-lien-secondaire: var(--centre-aide-background-entete);
   --centre-aide-font-color-lien-secondaire: var(--centre-aide-background-entete);
-  --centre-aide-background-hover-lien: var(--couleurs-mac-securiteacces);
+  --centre-aide-background-hover-lien: #9C51D0;
   --centre-aide-background-hover-declencheur: var(--centre-aide-background-hover-lien);
   --brique-background-primaire: var(--centre-aide-background-entete);
+  --brique-background-secondaire: #F5F1F9;
   --brique-hero-bouton-gauche-background: white;
   --brique-hero-bouton-gauche-background-hover: #F6F6F6;
   --brique-hero-bouton-gauche-background-active: #F6F6F6;
@@ -16,4 +17,11 @@
   --brique-hero-bouton-droite-background-active: rgba(255, 255, 255, 0.16);
   --brique-hero-bouton-droite-texte: white;
   --titre-couleur-primaire: #5D2A9D;
+  --brique-marelle-titre-couleur: #5D2A9D;
+  --brique-marelle-etapes-numero-etape-couleur: #9C51D0;
+  --brique-marelle-etapes-lien-couleur: #5D2A9D;
+  --brique-marelle-bouton-background: #5D2A9D;
+  --brique-marelle-bouton-background-hover: #9C51D0;
+  --brique-marelle-bouton-background-active: #9C51D0;
+  --brique-marelle-bouton-texte: #FFFFFF;
 }

--- a/mon-aide-cyber-ui/src/composants/layout/header/NavigationPublique.tsx
+++ b/mon-aide-cyber-ui/src/composants/layout/header/NavigationPublique.tsx
@@ -94,7 +94,7 @@ export const NavigationPublique = ({
         <li className="diagnostic-mes-services-cyber fr-nav__item lien">
           <lab-anssi-mes-services-cyber-lien-diagnostic-cyber
             lien={liensMesServicesCyber().cyberDepartAvecTracking}
-            versExterne={true}
+            versExterne="true"
           ></lab-anssi-mes-services-cyber-lien-diagnostic-cyber>
         </li>
       </ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -417,7 +417,7 @@
       "dependencies": {
         "@babel/runtime": ">=7.26.10",
         "@gouvfr/dsfr": "^1.11.0",
-        "@lab-anssi/ui-kit": "1.8.4",
+        "@lab-anssi/ui-kit": "1.9.0",
         "@tanstack/react-query": "^5.59.15",
         "@vitejs/plugin-react-swc": "^3.6.0",
         "react": "^18.2.0",
@@ -3997,9 +3997,9 @@
       }
     },
     "node_modules/@lab-anssi/ui-kit": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@lab-anssi/ui-kit/-/ui-kit-1.8.4.tgz",
-      "integrity": "sha512-FKErEqZb74/Wqcc1WJ5MqVTZf8nEDcWwyISMc8SMJpOvvgLMUGT3IXyLNgHSlDK9DugYLrly+YCuJbGL+MgFkw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@lab-anssi/ui-kit/-/ui-kit-1.9.0.tgz",
+      "integrity": "sha512-e3jr+a+S5LOxrtBsND/Kz/5c58ahEoc7FjSwS8Z0m0BkuZaB3+8GXpbtQgGZl9+plrdSptk5fNHFrXpryfxtrA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "svelte": "^4.2.19"

--- a/package-lock.json
+++ b/package-lock.json
@@ -417,7 +417,7 @@
       "dependencies": {
         "@babel/runtime": ">=7.26.10",
         "@gouvfr/dsfr": "^1.11.0",
-        "@lab-anssi/ui-kit": "1.6.3",
+        "@lab-anssi/ui-kit": "1.8.4",
         "@tanstack/react-query": "^5.59.15",
         "@vitejs/plugin-react-swc": "^3.6.0",
         "react": "^18.2.0",
@@ -3997,9 +3997,9 @@
       }
     },
     "node_modules/@lab-anssi/ui-kit": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lab-anssi/ui-kit/-/ui-kit-1.6.3.tgz",
-      "integrity": "sha512-oO/badVTIUuzhJ4C/U3wCiNvSTWeQhnBav3uhv6aeCht+HVDOY04RjjAUYUYJaHvqGKsISyMnBJXPs3U13Lilg==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@lab-anssi/ui-kit/-/ui-kit-1.8.4.tgz",
+      "integrity": "sha512-FKErEqZb74/Wqcc1WJ5MqVTZf8nEDcWwyISMc8SMJpOvvgLMUGT3IXyLNgHSlDK9DugYLrly+YCuJbGL+MgFkw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "svelte": "^4.2.19"


### PR DESCRIPTION
Cette PR a pour objectif de remplacer dans la landing page principale les deux éléments d'origine (Hero et carrousel) par les webcomponents de l'UI-KIT

![image](https://github.com/user-attachments/assets/d7ee821a-0eed-453e-a152-c6885391be96)
