### PR TITLE
Rajout de l'identifiant de la demande dans le token de mise en relation

### DIFF
--- a/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
+++ b/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
@@ -53,13 +53,14 @@ export const routesAPIAidantRepondreAUneDemande = (
       reponse: Response
     ) => {
       try {
-        const { identifiantDemande, demande, aidant } =
+        const { identifiantDemande, emailDemande, aidant } =
           tokenAttributionDemandeAide().dechiffre(requete.body.token);
+
         const commandeAttribueDemandeAide: CommandeAttribueDemandeAide = {
           type: 'CommandeAttribueDemandeAide',
           identifiantDemande,
+          emailDemande,
           identifiantAidant: aidant,
-          emailDemande: demande,
         };
 
         await busCommande.publie(commandeAttribueDemandeAide);
@@ -96,7 +97,7 @@ export const routesAPIAidantRepondreAUneDemande = (
 
       const demandeAide = await entrepots
         .demandesAides()
-        .rechercheParEmail(tokenEnClair.demande);
+        .rechercheParEmail(tokenEnClair.emailDemande);
 
       if (demandeAide.etat !== 'COMPLET') {
         return suite(

--- a/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
+++ b/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
@@ -53,14 +53,14 @@ export const routesAPIAidantRepondreAUneDemande = (
       reponse: Response
     ) => {
       try {
-        const { identifiantDemande, emailDemande, aidant } =
+        const { identifiantDemande, emailDemande, identifiantAidant } =
           tokenAttributionDemandeAide().dechiffre(requete.body.token);
 
         const commandeAttribueDemandeAide: CommandeAttribueDemandeAide = {
           type: 'CommandeAttribueDemandeAide',
           identifiantDemande,
           emailDemande,
-          identifiantAidant: aidant,
+          identifiantAidant: identifiantAidant,
         };
 
         await busCommande.publie(commandeAttribueDemandeAide);

--- a/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
+++ b/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
@@ -53,13 +53,13 @@ export const routesAPIAidantRepondreAUneDemande = (
       reponse: Response
     ) => {
       try {
-        const { demande, aidant } = tokenAttributionDemandeAide().dechiffre(
-          requete.body.token
-        );
+        const { identifiantDemande, demande, aidant } =
+          tokenAttributionDemandeAide().dechiffre(requete.body.token);
         const commandeAttribueDemandeAide: CommandeAttribueDemandeAide = {
           type: 'CommandeAttribueDemandeAide',
-          identifiantDemande: demande,
+          identifiantDemande,
           identifiantAidant: aidant,
+          emailDemande: demande,
         };
 
         await busCommande.publie(commandeAttribueDemandeAide);

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurCommandeAttribueDemandeAide.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurCommandeAttribueDemandeAide.ts
@@ -10,6 +10,7 @@ export type CommandeAttribueDemandeAide = Omit<Commande, 'type'> & {
   type: 'CommandeAttribueDemandeAide';
   identifiantDemande: crypto.UUID;
   identifiantAidant: crypto.UUID;
+  emailDemande: string;
 };
 
 export class DemandeAideDejaPourvue extends Error {
@@ -24,7 +25,7 @@ export class CapteurCommandeAttribueDemandeAide
   constructor(private readonly adaptateurEnvoiMail: AdaptateurEnvoiMail) {}
 
   async execute(commande: CommandeAttribueDemandeAide): Promise<void> {
-    if (commande.identifiantDemande.startsWith('b')) {
+    if (commande.emailDemande.startsWith('b')) {
       throw new DemandeAideDejaPourvue();
     }
     const demandeAide: DemandeAide = {

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationParCriteres.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationParCriteres.ts
@@ -24,14 +24,14 @@ export type AidantMisEnRelation = {
 };
 
 export type TonkenAttributionDemandeAide = {
-  demande: string;
+  emailDemande: string;
   identifiantDemande: crypto.UUID;
   aidant: crypto.UUID;
 };
 
 type GestionTokenAttributionDemandeAide = {
   chiffre: (
-    emailEntiteAidee: string,
+    emailDemande: string,
     identifiantDemande: crypto.UUID,
     identifiantAidant: crypto.UUID
   ) => string;
@@ -43,14 +43,14 @@ export const tokenAttributionDemandeAide = (
 ): GestionTokenAttributionDemandeAide => {
   return {
     chiffre(
-      emailEntiteAidee: string,
+      emailDemande: string,
       identifiantDemande: crypto.UUID,
       identifiantAidant: crypto.UUID
     ): string {
       return btoa(
         serviceDeChiffrement.chiffre(
           JSON.stringify({
-            demande: emailEntiteAidee,
+            emailDemande,
             identifiantDemande,
             aidant: identifiantAidant,
           })

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationParCriteres.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationParCriteres.ts
@@ -24,21 +24,34 @@ export type AidantMisEnRelation = {
 };
 
 export type TonkenAttributionDemandeAide = {
-  demande: crypto.UUID;
+  demande: string;
+  identifiantDemande: crypto.UUID;
   aidant: crypto.UUID;
 };
+
+type GestionTokenAttributionDemandeAide = {
+  chiffre: (
+    emailEntiteAidee: string,
+    identifiantDemande: crypto.UUID,
+    identifiantAidant: crypto.UUID
+  ) => string;
+  dechiffre: (token: string) => TonkenAttributionDemandeAide;
+};
+
 export const tokenAttributionDemandeAide = (
   serviceDeChiffrement: ServiceDeChiffrement = adaptateurServiceChiffrement()
-): {
-  dechiffre: (token: string) => TonkenAttributionDemandeAide;
-  chiffre: (emailEntiteAidee: string, identifiantAidant: crypto.UUID) => string;
-} => {
+): GestionTokenAttributionDemandeAide => {
   return {
-    chiffre(emailEntiteAidee: string, identifiantAidant: crypto.UUID): string {
+    chiffre(
+      emailEntiteAidee: string,
+      identifiantDemande: crypto.UUID,
+      identifiantAidant: crypto.UUID
+    ): string {
       return btoa(
         serviceDeChiffrement.chiffre(
           JSON.stringify({
             demande: emailEntiteAidee,
+            identifiantDemande,
             aidant: identifiantAidant,
           })
         )
@@ -126,7 +139,7 @@ export class MiseEnRelationParCriteres implements MiseEnRelation {
     return emailsDesAidants.map((email) => ({
       email,
       nomPrenom: 'Un prénom',
-      lienPourPostuler: `${urlMAC}/repondre-a-une-demande?token=${chiffre(demandeAide.email, crypto.randomUUID())}`,
+      lienPourPostuler: `${urlMAC}/repondre-a-une-demande?token=${chiffre(demandeAide.email, demandeAide.identifiant, crypto.randomUUID())}`,
     }));
   };
 }

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationParCriteres.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationParCriteres.ts
@@ -26,7 +26,7 @@ export type AidantMisEnRelation = {
 export type TonkenAttributionDemandeAide = {
   emailDemande: string;
   identifiantDemande: crypto.UUID;
-  aidant: crypto.UUID;
+  identifiantAidant: crypto.UUID;
 };
 
 type GestionTokenAttributionDemandeAide = {
@@ -52,7 +52,7 @@ export const tokenAttributionDemandeAide = (
           JSON.stringify({
             emailDemande,
             identifiantDemande,
-            aidant: identifiantAidant,
+            identifiantAidant,
           })
         )
       );

--- a/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
+++ b/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
@@ -61,6 +61,7 @@ describe('Le serveur MAC, sur  les routes de réponse à une demande', () => {
       await testeurMAC.entrepots.demandesAides().persiste(demandeAide);
       const token = tokenAttributionDemandeAide().chiffre(
         demandeAide.email,
+        demandeAide.identifiant,
         aidant.identifiant
       );
 
@@ -95,6 +96,7 @@ describe('Le serveur MAC, sur  les routes de réponse à une demande', () => {
       await testeurMAC.entrepots.demandesAides().persiste(demandeAide);
       const token = tokenAttributionDemandeAide().chiffre(
         demandeAide.email,
+        demandeAide.identifiant,
         aidant.identifiant
       );
 
@@ -102,9 +104,7 @@ describe('Le serveur MAC, sur  les routes de réponse à une demande', () => {
         donneesServeur.app,
         'POST',
         `/api/aidant/repondre-a-une-demande`,
-        {
-          token,
-        }
+        { token }
       );
 
       expect(reponse.statusCode).toBe(400);
@@ -115,10 +115,15 @@ describe('Le serveur MAC, sur  les routes de réponse à une demande', () => {
     it('Renvoie les infos de la demande dont l’email est dans le token', async () => {
       const token = tokenAttributionDemandeAide(
         testeurMAC.serviceDeChiffrement
-      ).chiffre('entite-aidee@email.com', crypto.randomUUID());
+      ).chiffre(
+        'entite-aidee@email.com',
+        '11111111-1111-1111-1111-111111111111',
+        crypto.randomUUID()
+      );
       const demandeAide: DemandeAide = uneDemandeAide()
         .avecUneDateDeSignatureDesCGU(new Date('2025-04-02T12:37:00.000Z'))
         .avecUnEmail('entite-aidee@email.com')
+        .avecIdentifiant('11111111-1111-1111-1111-111111111111')
         .dansLeDepartement(finistere)
         .avecLeSiret('0987654321')
         .construis();
@@ -160,7 +165,11 @@ describe('Le serveur MAC, sur  les routes de réponse à une demande', () => {
     it('Rejette la requête avec une erreur 400 (et non une 404) si la demande d’Aide est introuvable', async () => {
       const tokenSansDemande = tokenAttributionDemandeAide(
         testeurMAC.serviceDeChiffrement
-      ).chiffre('entite-aidee@email.com', crypto.randomUUID());
+      ).chiffre(
+        'entite-aidee@email.com',
+        crypto.randomUUID(),
+        crypto.randomUUID()
+      );
 
       const reponse = await executeRequete(
         donneesServeur.app,

--- a/mon-aide-cyber-api/test/gestion-demandes/aide/ConstructeurDemandeAide.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/aide/ConstructeurDemandeAide.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../src/gestion-demandes/departements';
 
 class ConstructeurDemandeAide implements Constructeur<DemandeAide> {
+  private identifiant: crypto.UUID = crypto.randomUUID();
   private dateSignatureCGU: Date = FournisseurHorloge.maintenant();
   private demandeIncomplete = false;
   private email: string = fakerFR.internet.email();
@@ -20,7 +21,7 @@ class ConstructeurDemandeAide implements Constructeur<DemandeAide> {
     return this.demandeIncomplete
       ? ({ email: fakerFR.internet.email() } as DemandeAide)
       : {
-          identifiant: crypto.randomUUID(),
+          identifiant: this.identifiant,
           dateSignatureCGU: this.dateSignatureCGU,
           email: this.email,
           raisonSociale: fakerFR.company.name(),
@@ -48,6 +49,11 @@ class ConstructeurDemandeAide implements Constructeur<DemandeAide> {
 
   avecUnEmail(email: string): ConstructeurDemandeAide {
     this.email = email;
+    return this;
+  }
+
+  avecIdentifiant(id: crypto.UUID): ConstructeurDemandeAide {
+    this.identifiant = id;
     return this;
   }
 

--- a/mon-aide-cyber-api/test/gestion-demandes/aide/MiseEnRelationParCriteres.spec.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/aide/MiseEnRelationParCriteres.spec.ts
@@ -185,7 +185,10 @@ describe('Mise en relation par critères', () => {
       );
 
       await miseEnRelation.execute({
-        demandeAide: uneDemandeAide().dansLeDepartement(finistere).construis(),
+        demandeAide: uneDemandeAide()
+          .avecUnEmail('demandeur@societe.fr')
+          .dansLeDepartement(finistere)
+          .construis(),
         secteursActivite: [{ nom: 'Transports' }],
         typeEntite: entitesPubliques,
         siret: '12345',
@@ -199,8 +202,8 @@ describe('Mise en relation par critères', () => {
             premierAidantMisEnRelation.lienPourPostuler.indexOf('=') + 1
           )
         )
-      ).toStrictEqual<{ demande: crypto.UUID; aidant: crypto.UUID }>({
-        demande: expect.any(String),
+      ).toStrictEqual<{ demande: string; aidant: crypto.UUID }>({
+        demande: 'demandeur@societe.fr',
         aidant: expect.any(String),
       });
       const deuxiemeAidantMisEnRelation = aidantsContactes[0];
@@ -210,8 +213,8 @@ describe('Mise en relation par critères', () => {
             deuxiemeAidantMisEnRelation.lienPourPostuler.indexOf('=') + 1
           )
         )
-      ).toStrictEqual<{ demande: crypto.UUID; aidant: crypto.UUID }>({
-        demande: expect.any(String),
+      ).toStrictEqual<{ demande: string; aidant: crypto.UUID }>({
+        demande: 'demandeur@societe.fr',
         aidant: expect.any(String),
       });
     });

--- a/mon-aide-cyber-api/test/gestion-demandes/aide/MiseEnRelationParCriteres.spec.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/aide/MiseEnRelationParCriteres.spec.ts
@@ -25,7 +25,6 @@ import {
 } from '../../../src/espace-aidant/Aidant';
 import { uneDemandeAide } from './ConstructeurDemandeAide';
 import { DonneesMiseEnRelation } from '../../../src/gestion-demandes/aide/miseEnRelation';
-import crypto from 'crypto';
 import { ServiceDeChiffrementChacha20 } from '../../../src/infrastructure/securite/ServiceDeChiffrementChacha20';
 import { DemandeAide } from '../../../src/gestion-demandes/aide/DemandeAide';
 
@@ -206,12 +205,8 @@ describe('Mise en relation par critères', () => {
             premierAidantMisEnRelation.lienPourPostuler.indexOf('=') + 1
           )
         )
-      ).toStrictEqual<{
-        demande: string;
-        identifiantDemande: crypto.UUID;
-        aidant: crypto.UUID;
-      }>({
-        demande: 'demandeur@societe.fr',
+      ).toStrictEqual<TonkenAttributionDemandeAide>({
+        emailDemande: 'demandeur@societe.fr',
         identifiantDemande: '11111111-1111-1111-1111-111111111111',
         aidant: expect.any(String),
       });
@@ -222,12 +217,8 @@ describe('Mise en relation par critères', () => {
             deuxiemeAidantMisEnRelation.lienPourPostuler.indexOf('=') + 1
           )
         )
-      ).toStrictEqual<{
-        demande: string;
-        identifiantDemande: crypto.UUID;
-        aidant: crypto.UUID;
-      }>({
-        demande: 'demandeur@societe.fr',
+      ).toStrictEqual<TonkenAttributionDemandeAide>({
+        emailDemande: 'demandeur@societe.fr',
         identifiantDemande: '11111111-1111-1111-1111-111111111111',
         aidant: expect.any(String),
       });
@@ -322,14 +313,14 @@ describe('Mise en relation par critères', () => {
       ).chiffre(demandeAide.email, demandeAide.identifiant, identifiantAidant);
 
       expect(valeurChiffree).toBe(
-        'Njk3NjZjNmY2ZTY3NzU2NTc1NzIzMTMyNjE3MzczNmY2MzJkNmM2ZjZlNjc3NTY1NzU3MjMxMzZmNWY0ZDBhZTc4YzNhOTEwMGMxN2E0Njc4MGI4Zjk5NmFmOTg4NWU2NWQ1MDc2MmQ1OGY1MTMzODc3YTAwYjUyOWNjYTIwODA0N2ViNDRjMTM2MjQ5NWM0NzhhOTcwMDg3YmZlZWNmZWI5YjBmZjRmYjU0YTVlMWI5ZjU3MWZmN2E3NjY2MWE1NTI5OGMxOWNmNzlhNzY1OWVhZDJkNTliOWI5NjBhMDU0ZTViYzQ1ZmFmYTAyMjUxMmYwZjMyMzZlMzk5ZTU5NjRiZGRjODg4MDVlNTY0ODA1NjgxMzgxZWFmODYzZjQ0YjAwYTc1YmZiYzFiOWRhZDhhZTYzNDRlODIwNzZkYjNhYWVlMTQ4YTkyMGZiNGE0MDE2MzQyOWI2ZTYyYTFmMDY3MmEyODJjZjRhM2VkZWU5MWUxMzE='
+        'Njk3NjZjNmY2ZTY3NzU2NTc1NzIzMTMyNjE3MzczNmY2MzJkNmM2ZjZlNjc3NTY1NzU3MjMxMzZmNWY0ZDFhNjc0Y2JhYjMwMGM1OGZmMmI4ZWI4YmFjMmEzOTY5NWY3NWMxMDY2MTg0ZGY3MWMyNTViZWIwNTVjOTg4NDIyYzE0OWVmMDI4YzdhMzlkMzliMzRlYTJjNTkyM2ZiZTRlZmM0ZjhhMTFmYmUxOTE2MGRjMDQzNDhlYmFlNjczNGYxNGVjZjhkY2JhNzk4MjE0N2U5ZDA4NjliZDI4NTE3MTYxNjEyOTAwMGVhZjg3NTA5N2Y1MDc3NDNiN2M1YTZkNDBkZDk4M2Q2NDZiYTIxOTM1ZDkyM2UxYWE5OWE2YTEzZTQwMjc1YmRiYzRmOWJhZDhmYjIzMzE5ODIwZTZjZTZmZWYyNDNkYWM1NWZiNmYzMDM3MzBjMDQwNTA3YTI1MzliMDZkMTE4YzZiZjRhOWIxZWQ4YzAyMzY5ZWJkZmI4'
       );
       expect(
         tokenAttributionDemandeAide(serviceDeChiffrement).dechiffre(
           valeurChiffree
         )
       ).toStrictEqual<TonkenAttributionDemandeAide>({
-        demande: 'jean.dupont@email.com',
+        emailDemande: 'jean.dupont@email.com',
         identifiantDemande: '11111111-1111-1111-1111-111111111111',
         aidant: '7571dfe9-31e7-4e6f-80de-fafa3f323b1d',
       });

--- a/mon-aide-cyber-api/test/gestion-demandes/aide/MiseEnRelationParCriteres.spec.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/aide/MiseEnRelationParCriteres.spec.ts
@@ -4,6 +4,7 @@ import {
   AidantMisEnRelation,
   MiseEnRelationParCriteres,
   tokenAttributionDemandeAide,
+  TonkenAttributionDemandeAide,
 } from '../../../src/gestion-demandes/aide/MiseEnRelationParCriteres';
 import {
   allier,
@@ -184,11 +185,14 @@ describe('Mise en relation par critères', () => {
         entrepots
       );
 
+      const demandeAide = uneDemandeAide()
+        .avecIdentifiant('11111111-1111-1111-1111-111111111111')
+        .avecUnEmail('demandeur@societe.fr')
+        .dansLeDepartement(finistere)
+        .construis();
+
       await miseEnRelation.execute({
-        demandeAide: uneDemandeAide()
-          .avecUnEmail('demandeur@societe.fr')
-          .dansLeDepartement(finistere)
-          .construis(),
+        demandeAide,
         secteursActivite: [{ nom: 'Transports' }],
         typeEntite: entitesPubliques,
         siret: '12345',
@@ -202,8 +206,13 @@ describe('Mise en relation par critères', () => {
             premierAidantMisEnRelation.lienPourPostuler.indexOf('=') + 1
           )
         )
-      ).toStrictEqual<{ demande: string; aidant: crypto.UUID }>({
+      ).toStrictEqual<{
+        demande: string;
+        identifiantDemande: crypto.UUID;
+        aidant: crypto.UUID;
+      }>({
         demande: 'demandeur@societe.fr',
+        identifiantDemande: '11111111-1111-1111-1111-111111111111',
         aidant: expect.any(String),
       });
       const deuxiemeAidantMisEnRelation = aidantsContactes[0];
@@ -213,8 +222,13 @@ describe('Mise en relation par critères', () => {
             deuxiemeAidantMisEnRelation.lienPourPostuler.indexOf('=') + 1
           )
         )
-      ).toStrictEqual<{ demande: string; aidant: crypto.UUID }>({
+      ).toStrictEqual<{
+        demande: string;
+        identifiantDemande: crypto.UUID;
+        aidant: crypto.UUID;
+      }>({
         demande: 'demandeur@societe.fr',
+        identifiantDemande: '11111111-1111-1111-1111-111111111111',
         aidant: expect.any(String),
       });
     });
@@ -298,23 +312,25 @@ describe('Mise en relation par critères', () => {
         'ma-clef-secrete-de-longueur-0032'
       );
       const demandeAide: DemandeAide = uneDemandeAide()
+        .avecIdentifiant('11111111-1111-1111-1111-111111111111')
         .avecUnEmail('jean.dupont@email.com')
         .construis();
       const identifiantAidant = '7571dfe9-31e7-4e6f-80de-fafa3f323b1d';
 
       const valeurChiffree = tokenAttributionDemandeAide(
         serviceDeChiffrement
-      ).chiffre(demandeAide.email, identifiantAidant);
+      ).chiffre(demandeAide.email, demandeAide.identifiant, identifiantAidant);
 
       expect(valeurChiffree).toBe(
-        'Njk3NjZjNmY2ZTY3NzU2NTc1NzIzMTMyNjE3MzczNmY2MzJkNmM2ZjZlNjc3NTY1NzU3MjMxMzZmNWY0ZDBhZTc4YzNhOTEwMGMxN2E0Njc4MGI4Zjk5NmFmOTg4NWU2NWQ1MDc2MmQ1OGY1MTMzODc3YTAwYjUyOWNjYTIwODA0N2ViNDRjMTM2MjQ5NWM0NzhhOTcwMDg3YmZlZWNmZWI5YjBmZjRmYjU0YTVlMWI5ZjU3MWZmN2E3NjY2MWE1NTI5OGMxOWNmNzlhNzY1OWVhZDJkNTliOWI5NjViMDFhOWM4YmU3MmZiOGNkOTU2NjkyMTExNTIwNDVlYWM='
+        'Njk3NjZjNmY2ZTY3NzU2NTc1NzIzMTMyNjE3MzczNmY2MzJkNmM2ZjZlNjc3NTY1NzU3MjMxMzZmNWY0ZDBhZTc4YzNhOTEwMGMxN2E0Njc4MGI4Zjk5NmFmOTg4NWU2NWQ1MDc2MmQ1OGY1MTMzODc3YTAwYjUyOWNjYTIwODA0N2ViNDRjMTM2MjQ5NWM0NzhhOTcwMDg3YmZlZWNmZWI5YjBmZjRmYjU0YTVlMWI5ZjU3MWZmN2E3NjY2MWE1NTI5OGMxOWNmNzlhNzY1OWVhZDJkNTliOWI5NjBhMDU0ZTViYzQ1ZmFmYTAyMjUxMmYwZjMyMzZlMzk5ZTU5NjRiZGRjODg4MDVlNTY0ODA1NjgxMzgxZWFmODYzZjQ0YjAwYTc1YmZiYzFiOWRhZDhhZTYzNDRlODIwNzZkYjNhYWVlMTQ4YTkyMGZiNGE0MDE2MzQyOWI2ZTYyYTFmMDY3MmEyODJjZjRhM2VkZWU5MWUxMzE='
       );
       expect(
         tokenAttributionDemandeAide(serviceDeChiffrement).dechiffre(
           valeurChiffree
         )
-      ).toStrictEqual({
+      ).toStrictEqual<TonkenAttributionDemandeAide>({
         demande: 'jean.dupont@email.com',
+        identifiantDemande: '11111111-1111-1111-1111-111111111111',
         aidant: '7571dfe9-31e7-4e6f-80de-fafa3f323b1d',
       });
     });

--- a/mon-aide-cyber-api/test/gestion-demandes/aide/MiseEnRelationParCriteres.spec.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/aide/MiseEnRelationParCriteres.spec.ts
@@ -208,7 +208,7 @@ describe('Mise en relation par critères', () => {
       ).toStrictEqual<TonkenAttributionDemandeAide>({
         emailDemande: 'demandeur@societe.fr',
         identifiantDemande: '11111111-1111-1111-1111-111111111111',
-        aidant: expect.any(String),
+        identifiantAidant: expect.any(String),
       });
       const deuxiemeAidantMisEnRelation = aidantsContactes[0];
       expect(
@@ -220,7 +220,7 @@ describe('Mise en relation par critères', () => {
       ).toStrictEqual<TonkenAttributionDemandeAide>({
         emailDemande: 'demandeur@societe.fr',
         identifiantDemande: '11111111-1111-1111-1111-111111111111',
-        aidant: expect.any(String),
+        identifiantAidant: expect.any(String),
       });
     });
 
@@ -313,7 +313,7 @@ describe('Mise en relation par critères', () => {
       ).chiffre(demandeAide.email, demandeAide.identifiant, identifiantAidant);
 
       expect(valeurChiffree).toBe(
-        'Njk3NjZjNmY2ZTY3NzU2NTc1NzIzMTMyNjE3MzczNmY2MzJkNmM2ZjZlNjc3NTY1NzU3MjMxMzZmNWY0ZDFhNjc0Y2JhYjMwMGM1OGZmMmI4ZWI4YmFjMmEzOTY5NWY3NWMxMDY2MTg0ZGY3MWMyNTViZWIwNTVjOTg4NDIyYzE0OWVmMDI4YzdhMzlkMzliMzRlYTJjNTkyM2ZiZTRlZmM0ZjhhMTFmYmUxOTE2MGRjMDQzNDhlYmFlNjczNGYxNGVjZjhkY2JhNzk4MjE0N2U5ZDA4NjliZDI4NTE3MTYxNjEyOTAwMGVhZjg3NTA5N2Y1MDc3NDNiN2M1YTZkNDBkZDk4M2Q2NDZiYTIxOTM1ZDkyM2UxYWE5OWE2YTEzZTQwMjc1YmRiYzRmOWJhZDhmYjIzMzE5ODIwZTZjZTZmZWYyNDNkYWM1NWZiNmYzMDM3MzBjMDQwNTA3YTI1MzliMDZkMTE4YzZiZjRhOWIxZWQ4YzAyMzY5ZWJkZmI4'
+        'Njk3NjZjNmY2ZTY3NzU2NTc1NzIzMTMyNjE3MzczNmY2MzJkNmM2ZjZlNjc3NTY1NzU3MjMxMzZmNWY0ZDFhNjc0Y2JhYjMwMGM1OGZmMmI4ZWI4YmFjMmEzOTY5NWY3NWMxMDY2MTg0ZGY3MWMyNTViZWIwNTVjOTg4NDIyYzE0OWVmMDI4YzdhMzlkMzliMzRlYTJjNTkyM2ZiZTRlZmM0ZjhhMTFmYmUxOTE2MGRjMDQzNDhlYmFlNjczNGYxNGVjZjhkY2JhNzk4MjE0N2U5ZDA4NjliZDI4NTE3MTYxNjEyOTAwMGVhZjg3NTA5N2Y1MDc3NDNiN2M1YTZkNDBkZDE4ZWQ3NDlhMDNjZDcwZWQxNjc1YmRmYzI2YTE0ZWY0ZjdhYjRhZjFkOTliNzhhYjM2MzFhOTYxYjZmYjNmZWU4MDg4ZmM2MDhlM2I4MDg3MTViMDMxOTA1ZTE0OGMxMjg1MDE3MTc2NGY5ZjY4MTcxYzMxMjMzM2FjOWQwNmVmZmViMTA3MWIyMzU0YmJmMDQ1YQ=='
       );
       expect(
         tokenAttributionDemandeAide(serviceDeChiffrement).dechiffre(
@@ -322,7 +322,7 @@ describe('Mise en relation par critères', () => {
       ).toStrictEqual<TonkenAttributionDemandeAide>({
         emailDemande: 'jean.dupont@email.com',
         identifiantDemande: '11111111-1111-1111-1111-111111111111',
-        aidant: '7571dfe9-31e7-4e6f-80de-fafa3f323b1d',
+        identifiantAidant: '7571dfe9-31e7-4e6f-80de-fafa3f323b1d',
       });
     });
   });


### PR DESCRIPTION
Cette PR rajoute l'identifiant de la demande dans le token de mise en relation car on va en avoir besoin au moment de postuler.

```diff
export type TonkenAttributionDemandeAide = {
  emailDemande: string;
+ identifiantDemande: crypto.UUID;
  identifiantAidant: crypto.UUID;
};
```