### PR TITLE
[POSTULER] Place les informations liées à la demande / l'Aidant dans le mail de confirmation

### DIFF
--- a/mon-aide-cyber-api/src/adaptateurs/AdaptateurEnvoiMail.ts
+++ b/mon-aide-cyber-api/src/adaptateurs/AdaptateurEnvoiMail.ts
@@ -21,6 +21,8 @@ export type ConfirmationDemandeAideAttribuee = {
   emailAidant: string;
   nomPrenomAidant: string;
   emailEntite: string;
+  secteursActivite: string;
+  typeEntite: string;
   departement: Departement;
 };
 

--- a/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
+++ b/mon-aide-cyber-api/src/api/aidant/routesAPIAidantRepondreAUneDemande.ts
@@ -110,16 +110,14 @@ export const routesAPIAidantRepondreAUneDemande = (
 
       const demande = demandeAide.demandeAide;
 
-      const [entreprise] =
-        await adaptateurRechercheEntreprise.rechercheEntreprise(
-          demande.siret,
-          ''
-        );
+      const entreprise = await adaptateurRechercheEntreprise.rechercheParSiret(
+        demande.siret
+      );
 
       return reponse.json({
         dateCreation: demande.dateSignatureCGU.toISOString(),
         departement: demande.departement,
-        typeEntite: entreprise?.typeEntite.nom ?? 'Information indisponible',
+        typeEntite: entreprise?.typeEntite?.nom ?? 'Information indisponible',
         secteurActivite:
           entreprise?.secteursActivite.map((s) => s.nom).join(', ') ??
           'Information indisponible',

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurCommandeAttribueDemandeAide.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurCommandeAttribueDemandeAide.ts
@@ -63,9 +63,8 @@ export class CapteurCommandeAttribueDemandeAide
       commande.identifiantAidant
     );
 
-    const entreprises = await this.rechercheEntreprise.rechercheEntreprise(
-      demandeAide.siret,
-      ''
+    const entreprise = await this.rechercheEntreprise.rechercheParSiret(
+      demandeAide.siret
     );
 
     await this.adaptateurEnvoiMail.envoieConfirmationDemandeAideAttribuee({
@@ -73,10 +72,10 @@ export class CapteurCommandeAttribueDemandeAide
       nomPrenomAidant: aidant.nomPrenom,
       departement: demandeAide.departement,
       emailEntite: demandeAide.email,
-      secteursActivite: entreprises[0].secteursActivite
+      secteursActivite: entreprise!.secteursActivite
         .map((s) => s.nom)
         .join(', '),
-      typeEntite: entreprises[0].typeEntite.nom,
+      typeEntite: entreprise!.typeEntite.nom,
     });
 
     await this.bus.publie<DemandeAidePourvue>(this.evenementSucces(commande));

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurSagaDemandeAide.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurSagaDemandeAide.ts
@@ -100,12 +100,9 @@ export class CapteurSagaDemandeAide
 
     const rechercheEntreprise = async () => {
       const entreprise =
-        await this.adaptateurRechercheEntreprise.rechercheEntreprise(
-          saga.siret,
-          ''
-        );
+        await this.adaptateurRechercheEntreprise.rechercheParSiret(saga.siret);
 
-      if (entreprise.length === 0) {
+      if (!entreprise) {
         throw new ErreurDemandeAideEntrepriseInconnue();
       }
       return entreprise;
@@ -153,9 +150,9 @@ export class CapteurSagaDemandeAide
             this.fabriqueMiseEnRelation.fabrique(utilisateurMAC);
           const resultat = await miseEnRelation.execute({
             demandeAide: aide,
-            siret: entreprise[0].siret,
-            secteursActivite: entreprise[0].secteursActivite,
-            typeEntite: entreprise[0].typeEntite,
+            siret: entreprise.siret,
+            secteursActivite: entreprise.secteursActivite,
+            typeEntite: entreprise.typeEntite,
           });
 
           await this.busEvenement.publie<DemandeAideCree<typeof resultat>>({

--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailBrevo.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailBrevo.ts
@@ -63,6 +63,8 @@ export class AdaptateurEnvoiMailBrevo implements AdaptateurEnvoiMail {
         nomPrenom: confirmation.nomPrenomAidant,
         mail: confirmation.emailEntite,
         departement: confirmation.departement.nom,
+        secteursActivite: confirmation.secteursActivite,
+        typeEntite: confirmation.typeEntite,
       });
     await this.envoieMailAvecTemplate(constructeurEmailBrevo.construis());
   }

--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailMemoire.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailMemoire.ts
@@ -126,7 +126,7 @@ export class AdaptateurEnvoiMailMemoire implements AdaptateurEnvoiMail {
   }): boolean {
     const confirmationCorrespond =
       this.confirmation !== undefined &&
-      this.confirmation.departement === confirmation.departement &&
+      this.confirmation.departement.code === confirmation.departement.code &&
       this.confirmation.emailEntite === confirmation.emailEntite &&
       this.confirmation.nomPrenomAidant === confirmation.nomPrenomAidant;
     return (

--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/adaptateurRechercheEntreprise.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/adaptateurRechercheEntreprise.ts
@@ -41,6 +41,8 @@ export interface AdaptateurRechercheEntreprise {
     nomOuSiretEntreprise: string,
     parametresRecherche: string
   ): Promise<Entreprise[]>;
+
+  rechercheParSiret(siret: string): Promise<Entreprise | undefined>;
 }
 
 class AdaptateurRechercheEntrepriseHTTP
@@ -113,6 +115,11 @@ class AdaptateurRechercheEntrepriseHTTP
           }))
       : [];
     return [...entreprises, ...associationsTrouvees];
+  }
+
+  async rechercheParSiret(siret: string): Promise<Entreprise | undefined> {
+    const entreprises = await this.rechercheEntreprise(siret, '');
+    return entreprises.length === 0 ? undefined : entreprises[0];
   }
 }
 

--- a/mon-aide-cyber-api/src/infrastructure/bus/BusCommandeMAC.ts
+++ b/mon-aide-cyber-api/src/infrastructure/bus/BusCommandeMAC.ts
@@ -235,7 +235,8 @@ const capteurs: Map<string, Capteur> = new Map([
         new CapteurCommandeAttribueDemandeAide(
           parametres.adaptateurEnvoiMail!,
           parametres.adaptateurRelations,
-          parametres.busEvenements!
+          parametres.busEvenements!,
+          parametres.entrepots!
         ),
     },
   ],

--- a/mon-aide-cyber-api/src/infrastructure/bus/BusCommandeMAC.ts
+++ b/mon-aide-cyber-api/src/infrastructure/bus/BusCommandeMAC.ts
@@ -236,7 +236,8 @@ const capteurs: Map<string, Capteur> = new Map([
           parametres.adaptateurEnvoiMail!,
           parametres.adaptateurRelations,
           parametres.busEvenements!,
-          parametres.entrepots!
+          parametres.entrepots!,
+          parametres.adaptateurRechercheEntreprise
         ),
     },
   ],

--- a/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
+++ b/mon-aide-cyber-api/test/api/aidant/routesAPIAidantRepondreAUneDemande.spec.ts
@@ -77,9 +77,9 @@ describe('Le serveur MAC, sur  les routes de réponse à une demande', () => {
         (
           testeurMAC.adaptateurEnvoieMessage as AdaptateurEnvoiMailMemoire
         ).demandeAideAttribueeEnvoyee({
-          emailAidant: 'user-xavier@yopmail.com',
-          nomPrenomAidant: 'User XAVIER',
-          emailEntite: 'entite-aidee@yopmail.com',
+          emailAidant: 'jean.dupont@email.com',
+          nomPrenomAidant: 'Jean DUPONT',
+          emailEntite: 'entite-aidee@email.com',
           departement: gironde,
         })
       ).toBe(true);

--- a/mon-aide-cyber-api/test/gestion-demandes/aide/CapteurCommandeAttribueDemandeAide.spec.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/aide/CapteurCommandeAttribueDemandeAide.spec.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it } from 'vitest';
+import { assert, describe, expect, it, beforeEach } from 'vitest';
 import { AdaptateurRelationsMAC } from '../../../src/relation/AdaptateurRelationsMAC';
 import { EntrepotRelationMemoire } from '../../../src/relation/infrastructure/EntrepotRelationMemoire';
 import {
@@ -9,16 +9,48 @@ import {
 import { AdaptateurEnvoiMailMemoire } from '../../../src/infrastructure/adaptateurs/AdaptateurEnvoiMailMemoire';
 import { BusEvenementDeTest } from '../../infrastructure/bus/BusEvenementDeTest';
 import { FournisseurHorlogeDeTest } from '../../infrastructure/horloge/FournisseurHorlogeDeTest';
+import { ConfirmationDemandeAideAttribuee } from '../../../src/adaptateurs/AdaptateurEnvoiMail';
+import { uneDemandeAide } from './ConstructeurDemandeAide';
+import { EntrepotsMemoire } from '../../../src/infrastructure/entrepots/memoire/EntrepotsMemoire';
+import { finistere } from '../../../src/gestion-demandes/departements';
+import { unAidant } from '../../constructeurs/constructeursAidantUtilisateurInscritUtilisateur';
+import { Aidant } from '../../../src/espace-aidant/Aidant';
+import { DemandeAide } from '../../../src/gestion-demandes/aide/DemandeAide';
 
 describe("Capteur de commande d'attribution de demande d'aide", () => {
-  it("Attribue la demande d'aide à l'aidant", async () => {
-    const relations = new AdaptateurRelationsMAC(new EntrepotRelationMemoire());
+  let entrepot: EntrepotsMemoire;
+  let relations: AdaptateurRelationsMAC;
+  let aidantJeanDujardin: Aidant;
+  let demandeFinistere: DemandeAide;
+  let bus: BusEvenementDeTest;
+  let envoiMail: AdaptateurEnvoiMailMemoire;
 
-    const capteur = new CapteurCommandeAttribueDemandeAide(
-      new AdaptateurEnvoiMailMemoire(),
-      relations,
-      new BusEvenementDeTest()
-    );
+  beforeEach(async () => {
+    aidantJeanDujardin = unAidant()
+      .avecUnIdentifiant('11111111-1111-1111-1111-111111111111')
+      .avecUnEmail('aidant@societe.fr')
+      .avecUnNomPrenom('Jean Dujardin')
+      .construis();
+    demandeFinistere = uneDemandeAide()
+      .avecUnEmail('22222222-2222-2222-2222-222222222222')
+      .avecUnEmail('demande@societe.fr')
+      .dansLeDepartement(finistere)
+      .construis();
+
+    entrepot = new EntrepotsMemoire();
+    await entrepot.aidants().persiste(aidantJeanDujardin);
+    await entrepot.demandesAides().persiste(demandeFinistere);
+
+    relations = new AdaptateurRelationsMAC(new EntrepotRelationMemoire());
+    bus = new BusEvenementDeTest();
+    envoiMail = new AdaptateurEnvoiMailMemoire();
+  });
+
+  const leCapteur = () =>
+    new CapteurCommandeAttribueDemandeAide(envoiMail, relations, bus, entrepot);
+
+  it("Attribue la demande d'aide à l'aidant", async () => {
+    const capteur = leCapteur();
 
     await capteur.execute({
       type: 'CommandeAttribueDemandeAide',
@@ -40,17 +72,10 @@ describe("Capteur de commande d'attribution de demande d'aide", () => {
   });
 
   it("Publie un événement de « DEMANDE_AIDE_POURVUE » avec un statut en Succès lorsque l'Aidant est le premier arrivé", async () => {
-    const bus = new BusEvenementDeTest();
     const maintenant = new Date();
     FournisseurHorlogeDeTest.initialise(maintenant);
 
-    const relations = new AdaptateurRelationsMAC(new EntrepotRelationMemoire());
-
-    const capteur = new CapteurCommandeAttribueDemandeAide(
-      new AdaptateurEnvoiMailMemoire(),
-      relations,
-      bus
-    );
+    const capteur = leCapteur();
 
     await capteur.execute({
       type: 'CommandeAttribueDemandeAide',
@@ -71,18 +96,41 @@ describe("Capteur de commande d'attribution de demande d'aide", () => {
     });
   });
 
+  describe("Pour l'envoie du mail de confirmation à l'Aidant", () => {
+    it("Fournit les détails de l'entité Aidée et de l'Aidant", async () => {
+      let confirmationEnvoyee: ConfirmationDemandeAideAttribuee;
+      envoiMail.envoieConfirmationDemandeAideAttribuee = async (
+        confirmation: ConfirmationDemandeAideAttribuee
+      ) => {
+        confirmationEnvoyee = confirmation;
+      };
+      const capteur = leCapteur();
+
+      await capteur.execute({
+        type: 'CommandeAttribueDemandeAide',
+        identifiantDemande: '22222222-2222-2222-2222-222222222222',
+        emailDemande: 'demande@societe.fr',
+        identifiantAidant: '11111111-1111-1111-1111-111111111111',
+      });
+
+      expect(
+        confirmationEnvoyee!
+      ).toStrictEqual<ConfirmationDemandeAideAttribuee>({
+        emailEntite: 'demande@societe.fr',
+        departement: finistere,
+        emailAidant: 'aidant@societe.fr',
+        nomPrenomAidant: 'Jean Dujardin',
+      });
+    });
+  });
+
   it('Jette une erreur de DemandeDejaPourvue si un aidant a déjà répondu à la demande', async () => {
-    const relations = new AdaptateurRelationsMAC(new EntrepotRelationMemoire());
     await relations.attribueDemandeAAidant(
       '22222222-2222-2222-2222-222222222222',
       'AAAAAAAA-1111-1111-1111-111111111111'
     );
 
-    const capteur = new CapteurCommandeAttribueDemandeAide(
-      new AdaptateurEnvoiMailMemoire(),
-      relations,
-      new BusEvenementDeTest()
-    );
+    const capteur = leCapteur();
 
     const deuxiemeAidant = 'BBBBBBBB-1111-1111-1111-111111111111';
     await expect(
@@ -96,21 +144,15 @@ describe("Capteur de commande d'attribution de demande d'aide", () => {
   });
 
   it('Publie un événement de « DEMANDE_AIDE_POURVUE » avec un statut à « DEJA_POURVUE » lorsque la demande est déjà attribuée', async () => {
-    const bus = new BusEvenementDeTest();
     const maintenant = new Date();
     FournisseurHorlogeDeTest.initialise(maintenant);
-    const relations = new AdaptateurRelationsMAC(new EntrepotRelationMemoire());
     await relations.attribueDemandeAAidant(
       '22222222-2222-2222-2222-222222222222',
       'AAAAAAAA-1111-1111-1111-111111111111'
     );
+    const capteur = leCapteur();
 
     const deuxiemeAidant = 'BBBBBBBB-1111-1111-1111-111111111111';
-    const capteur = new CapteurCommandeAttribueDemandeAide(
-      new AdaptateurEnvoiMailMemoire(),
-      relations,
-      bus
-    );
     try {
       await capteur.execute({
         type: 'CommandeAttribueDemandeAide',


### PR DESCRIPTION
Cette PR récupère réellement les informations de la demande et de l'Aidant pour l'envoi d'email de confirmation.
On cesse d'avoir des valeurs codées en dur.
On en profite pour refactorer les tests afin de réduire la duplication.