### PR TITLE
[CRISP] Corrige les reprises de compte des listes

### DIFF
--- a/mon-aide-cyber-ui/src/domaine/crisp/article-crisp.scss
+++ b/mon-aide-cyber-ui/src/domaine/crisp/article-crisp.scss
@@ -1,10 +1,16 @@
 @import '../../assets/styles/points-de-rupture';
 
+:root {
+  // Fais fonctionner les numéros des listes qui se suivent
+  --ol-content:  unset;
+}
+
 body:has(details[open]) {
   overflow: hidden;
 }
 
 .page-crisp {
+
   .chapeau {
     background: var(--couleurs-mac-violet-fonce);
     padding: 24px var(--gouttiere) 40px;


### PR DESCRIPTION
On veut que <ol start="3">, par exemple, soit pris en compte. Le DSFR fait un `counters()` personnalisé, qu'on ne veut pas : https://github.com/GouvernementFR/dsfr/blob/main/src/dsfr/core/style/typography/tool/_list.scss#L21

Ce qui donne un rendu correct 👇 

![image](https://github.com/user-attachments/assets/fa4e2d8d-9552-42c1-8437-45ff6d0346f3)
