### PR TITLE
[CORRECTION] Scope la règle CSS aux pages Crisp seulement

### DIFF
--- a/mon-aide-cyber-ui/src/domaine/crisp/article-crisp.scss
+++ b/mon-aide-cyber-ui/src/domaine/crisp/article-crisp.scss
@@ -5,7 +5,7 @@
   --ol-content:  unset;
 }
 
-body:has(details[open]) {
+body:has(.page-crisp details[open]) {
   overflow: hidden;
 }
 


### PR DESCRIPTION
… car sinon la restitution de diag est impacté par le `body { overflow: hidden; }` lorsqu'une mesure prioritaire est dépliée.

Le bug se produisait sur la page de restitution : lorsqu'une mesure est dépliée le scroll devient inutilisable 👇 
![image](https://github.com/user-attachments/assets/b4bd1f8f-6172-43d5-b771-68e7cc9bffa6)


Le but est de conserver un scroll désactivé sur les pages Crisp, lorsque le sommaire mobile est ouvert 👇 

![image](https://github.com/user-attachments/assets/820eeae1-0879-44c5-bff1-94622b3b03e3)

![image](https://github.com/user-attachments/assets/92408bb3-4c87-4164-8b3a-4ff700c036d4)
