### PR TITLE
[CORRECTION] Corrige la redirection vers / quand la route n’est pas trouvée

### DIFF
--- a/mon-aide-cyber-api/src/serveur.ts
+++ b/mon-aide-cyber-api/src/serveur.ts
@@ -137,7 +137,9 @@ const creeApp = (config: ConfigurationServeur) => {
   app.use('/contact', routeContact(config));
   app.use('/statistiques', routesStatistiques(config));
 
-  app.get('*', (_: Request, reponse: Response) => reponse.redirect('/'));
+  app.get('*', (_: Request, reponse: Response) =>
+    envoieIndexAvecNonce(reponse)
+  );
 
   app.use(
     gestionnaireErreurGeneralisee(config.gestionnaireErreurs.consignateur())


### PR DESCRIPTION
**Contexte**
Navigation sur le site

**Reproduction**
- Se rendre sur MAC
- Cliquer sur un lien / bouton (comme `Se connecter`

**Résultat constaté**
Je suis redirigé vers la page d’accueil

**Résulta attendu**
Je peux me rendre sur la page de connexion
