### PR TITLE
[DEMANDE AIDE] Améliore la remontée des exceptions lors de la demande d’Aide afin d’avoir la cause racine

### DIFF
--- a/mon-aide-cyber-api/src/api/demandes/routesAPIDemandeEtreAide.ts
+++ b/mon-aide-cyber-api/src/api/demandes/routesAPIDemandeEtreAide.ts
@@ -10,6 +10,7 @@ import { constructeurActionsHATEOAS } from '../hateoas/hateoas';
 import { NextFunction } from 'express-serve-static-core';
 import { ErreurMAC } from '../../domaine/erreurMAC';
 import {
+  ErreurDemandeAide,
   ErreurDemandeAideEntrepriseInconnue,
   ErreurUtilisateurMACInconnu,
   SagaDemandeAide,
@@ -31,12 +32,6 @@ type CorpsRequeteDemandeAide = {
   identifiantAidant?: crypto.UUID;
   siret: string;
 };
-
-class ErreurDemandeAide extends Error {
-  constructor(public readonly message: string) {
-    super(message);
-  }
-}
 
 export const routesAPIDemandeEtreAide = (
   configuration: ConfigurationServeur
@@ -124,20 +119,25 @@ export const routesAPIDemandeEtreAide = (
           .catch(
             (
               erreur:
-                | string
+                | Error
                 | ErreurUtilisateurMACInconnu
                 | ErreurDemandeAideEntrepriseInconnue
+                | ErreurDemandeAide
             ) => {
               if (
                 erreur instanceof ErreurUtilisateurMACInconnu ||
-                erreur instanceof ErreurDemandeAideEntrepriseInconnue
+                erreur instanceof ErreurDemandeAideEntrepriseInconnue ||
+                erreur instanceof ErreurDemandeAide
               ) {
-                suite(ErreurMAC.cree("Demande d'aide", erreur));
+                return suite(ErreurMAC.cree("Demande d'aide", erreur));
               }
-              suite(
+              return suite(
                 ErreurMAC.cree(
                   "Demande d'aide",
-                  new ErreurDemandeAide(erreur as string)
+                  new ErreurDemandeAide(
+                    'Votre demande d’aide n’a pu aboutir',
+                    erreur as Error
+                  )
                 )
               );
             }

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurSagaDemandeAide.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/CapteurSagaDemandeAide.ts
@@ -33,6 +33,12 @@ export class ErreurDemandeAideEntrepriseInconnue extends Error {
   }
 }
 
+export class ErreurDemandeAide extends Error {
+  constructor(message: string, erreur: Error) {
+    super(message, { cause: erreur });
+  }
+}
+
 export type SagaDemandeAide = Saga & {
   cguValidees: boolean;
   email: string;
@@ -166,8 +172,11 @@ export class CapteurSagaDemandeAide
             },
           });
         });
-    } catch (erreur) {
-      return Promise.reject("Votre demande d'aide n'a pu aboutir");
+    } catch (erreur: unknown | Error) {
+      throw new ErreurDemandeAide(
+        "Votre demande d'aide n'a pu aboutir",
+        erreur as Error
+      );
     }
   }
 }


### PR DESCRIPTION
Lorsqu’une erreur lors d’une demande d’Aide nous parvient sur MT 
<img width="539" alt="Capture d’écran 2025-06-13 à 09 18 55" src="https://github.com/user-attachments/assets/a8d8dee5-19ea-4610-991d-f6c15897c020" />

Les causes racines de l’erreur ne sont pas visibles dans Sentry, nous n’avons pas de détails ou d’éléments qui nous permette d’investiguer l’erreur :
<img width="488" alt="Capture d’écran 2025-06-13 à 09 19 09" src="https://github.com/user-attachments/assets/7cdad532-f06e-41fd-957f-4a2274de6416" />


Ajouter la cause nous retourne ces détails dans Sentry (cet exemple est issu d’un environnement de dev avec une exception levée volontairement)
<img width="425" alt="Capture d’écran 2025-06-13 à 09 20 00" src="https://github.com/user-attachments/assets/a82fec78-64c7-461d-a4fd-629392254c31" />
