### PR TITLE
[INSCRIPTION] Retire le feature flag de l’inscription

### DIFF
--- a/mon-aide-cyber-api/src/api/pro-connect/routeProConnect.ts
+++ b/mon-aide-cyber-api/src/api/pro-connect/routeProConnect.ts
@@ -164,20 +164,10 @@ export const routesProConnect = (configuration: ConfigurationServeur) => {
           ...(siret && { siret: siret }),
         });
 
-        const featureFlagAiguillage = process.env.AIGUILLAGE_INSCRIPTION;
-
-        if (featureFlagAiguillage === 'true') {
-          return redirige(
-            idToken,
-            espaceUtilisateurInscritCree.identifiant,
-            '/mon-espace/inscription'
-          );
-        }
-
         return redirige(
           idToken,
           espaceUtilisateurInscritCree.identifiant,
-          '/mon-espace/valide-signature-cgu'
+          '/mon-espace/inscription'
         );
       } catch (e: unknown | Error) {
         return suite(

--- a/mon-aide-cyber-api/test/api/pro-connect/routeProConnect.spec.ts
+++ b/mon-aide-cyber-api/test/api/pro-connect/routeProConnect.spec.ts
@@ -403,7 +403,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
           );
 
           expect(reponse.headers['location']).toStrictEqual(
-            '/mon-espace/valide-signature-cgu'
+            '/mon-espace/inscription'
           );
           expect(
             await testeurMAC.entrepots.utilisateursInscrits().tous()
@@ -424,7 +424,7 @@ describe('Le serveur MAC, sur les routes de connexion ProConnect', () => {
           );
 
           expect(reponse.headers['location']).toStrictEqual(
-            '/mon-espace/valide-signature-cgu'
+            '/mon-espace/inscription'
           );
           expect(
             (await testeurMAC.entrepots.utilisateursInscrits().tous())[0].email


### PR DESCRIPTION
L’aiguillage est maintenant opérationnel, il n’est plus nécessaire de vérifier la présence de la variable d’environnement AIGUILLAGE_INSCRIPTION car la redirection est maintenant la route par défaut