### PR TITLE
[REMANIEMENT][DEMANDE DEVENIR AIDANT] S’assure que les nouvelles demandes pour devenir Aidant contiennent tous les champs de l’entité pour laquelle un Aidant fait une demande

### DIFF
--- a/mon-aide-cyber-api/src/api/demandes/routeAPIDemandeDevenirAidant.ts
+++ b/mon-aide-cyber-api/src/api/demandes/routeAPIDemandeDevenirAidant.ts
@@ -121,11 +121,9 @@ const validateurNouveauParcoursDemandeDevenirAidant = () => {
           .custom((value: boolean) => value)
           .withMessage('Veuillez signer la Charte Aidant.'),
         body('entite.nom')
-          .optional()
           .notEmpty()
           .withMessage('Veuillez renseigner un nom pour votre entité'),
         body('entite.siret')
-          .optional()
           .notEmpty()
           .withMessage('Veuillez renseigner un SIRET pour votre entité'),
         body('entite.type').optional().typeEntite(),
@@ -244,16 +242,6 @@ export const routesAPIDemandesDevenirAidant = (
       reponse: Response<ReponseHATEOAS | ReponseHATEOASEnErreur>,
       suite: NextFunction
     ) => {
-      const genereEntite = () => ({
-        entite: {
-          type: requete.body.entite.type,
-          ...(requete.body.entite.nom && { nom: requete.body.entite.nom }),
-          ...(requete.body.entite.siret && {
-            siret: requete.body.entite.siret,
-          }),
-        },
-      });
-
       const valideLesCGUDeLUtilisateurConnecte = async () => {
         await unServiceUtilisateurInscrit(
           entrepots.utilisateursInscrits(),
@@ -287,7 +275,11 @@ export const routesAPIDemandesDevenirAidant = (
           mail: requete.body.mail.toLowerCase(),
           nom: requete.body.nom,
           prenom: requete.body.prenom,
-          ...(requete.body.entite && genereEntite()),
+          entite: {
+            type: requete.body.entite.type,
+            nom: requete.body.entite.nom,
+            siret: requete.body.entite.siret,
+          },
         };
 
         await configuration.busCommande.publie(commande);

--- a/mon-aide-cyber-api/src/gestion-demandes/devenir-aidant/CapteurCommandeDevenirAidant.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/devenir-aidant/CapteurCommandeDevenirAidant.ts
@@ -25,7 +25,7 @@ export type CommandeDevenirAidant = Omit<Commande, 'type'> & {
   mail: string;
   prenom: string;
   nom: string;
-  entite?: EntiteDemande;
+  entite: EntiteDemande;
 };
 
 class ErreurDemandeDevenirAidant extends Error {

--- a/mon-aide-cyber-api/src/gestion-demandes/devenir-aidant/DemandeDevenirAidant.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/devenir-aidant/DemandeDevenirAidant.ts
@@ -14,7 +14,7 @@ export type DemandeDevenirAidant = Aggregat & {
   mail: string;
   departement: Departement;
   statut: StatutDemande;
-  entite?: EntiteDemande;
+  entite: EntiteDemande;
 };
 export interface EntrepotDemandeDevenirAidant
   extends EntrepotEcriture<DemandeDevenirAidant> {
@@ -29,12 +29,15 @@ export type TypeEntite = 'ServicePublic' | 'ServiceEtat' | 'Association';
 
 export type EntiteDemande = {
   type: TypeEntite;
-  nom?: string;
-  siret?: string;
+  nom: string;
+  siret: string;
 };
 export const futurAidantEnAttenteAdhesionAssociation = (
   demandeDevenirAidant: DemandeDevenirAidant
 ) =>
-  demandeDevenirAidant.entite?.type === 'Association' &&
-  !demandeDevenirAidant.entite.nom &&
-  !demandeDevenirAidant.entite.siret;
+  demandeDevenirAidant.entite &&
+  demandeDevenirAidant.entite.type === 'Association' &&
+  (!demandeDevenirAidant.entite.nom ||
+    demandeDevenirAidant.entite.nom.trim() === '') &&
+  (!demandeDevenirAidant.entite.siret ||
+    demandeDevenirAidant.entite.siret.trim() === '');

--- a/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotDemandeDevenirAidantPostgres.ts
+++ b/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotDemandeDevenirAidantPostgres.ts
@@ -77,17 +77,11 @@ export class EntrepotDemandeDevenirAidantPostgres
         prenom: this.chiffrement.chiffre(entite.prenom),
         mail: this.chiffrement.chiffre(entite.mail),
         nomDepartement: this.chiffrement.chiffre(entite.departement.nom),
-        ...(entite.entite && {
-          entite: {
-            type: this.chiffrement.chiffre(entite.entite.type),
-            ...(entite.entite.nom && {
-              nom: this.chiffrement.chiffre(entite.entite.nom),
-            }),
-            ...(entite.entite.siret && {
-              siret: this.chiffrement.chiffre(entite.entite.siret),
-            }),
-          },
-        }),
+        entite: {
+          type: this.chiffrement.chiffre(entite.entite.type),
+          nom: this.chiffrement.chiffre(entite.entite.nom),
+          siret: this.chiffrement.chiffre(entite.entite.siret),
+        },
       },
       statut: entite.statut,
     };
@@ -112,19 +106,19 @@ export class EntrepotDemandeDevenirAidantPostgres
       mail: this.chiffrement.dechiffre(dto.donnees.mail),
       departement: departementDechiffre,
       statut: dto.statut,
-      ...(dto.donnees.entite && {
+      ...((dto.donnees.entite && {
         entite: {
           type: this.chiffrement.dechiffre(
             dto.donnees.entite.type
           ) as TypeEntite,
-          ...(dto.donnees.entite.nom && {
+          ...((dto.donnees.entite.nom && {
             nom: this.chiffrement.dechiffre(dto.donnees.entite.nom),
-          }),
-          ...(dto.donnees.entite.siret && {
+          }) || { nom: '' }),
+          ...((dto.donnees.entite.siret && {
             siret: this.chiffrement.dechiffre(dto.donnees.entite.siret),
-          }),
+          }) || { siret: '' }),
         },
-      }),
+      }) || { entite: { type: 'Association', nom: '', siret: '' } }),
     };
   }
 }

--- a/mon-aide-cyber-api/test/administration/aidants/espace-aidant/validationCompteAidant.spec.ts
+++ b/mon-aide-cyber-api/test/administration/aidants/espace-aidant/validationCompteAidant.spec.ts
@@ -70,12 +70,13 @@ describe('Validation des comptes Aidants', () => {
   });
 
   it('N’envoie pas le mail de création de l’espace Aidant si la demande est incomplète', async () => {
-    const demande = uneDemandeDevenirAidant()
-      .avantArbitrage()
+    const { entite, ...demandeAvantArbitrage } = uneDemandeDevenirAidant()
       .pour('Jean', 'Dupont')
       .ayantPourMail('jean.dupont@email.com')
       .construis();
-    await entrepots.demandesDevenirAidant().persiste(demande);
+    await entrepots
+      .demandesDevenirAidant()
+      .persiste(demandeAvantArbitrage as DemandeDevenirAidant);
     const csv = unConstructeurFichierAidantCSV()
       .avecLesAidants([
         unConstructeurAidantCSV()
@@ -93,7 +94,7 @@ describe('Validation des comptes Aidants', () => {
         {
           nom: 'Jean Dupont',
           email: 'jean.dupont@email.com',
-          identificationDemande: demande.identifiant,
+          identificationDemande: demandeAvantArbitrage.identifiant,
         },
       ],
       demandesEnErreur: [],

--- a/mon-aide-cyber-api/test/api/demandes/constructeurRequeteDemandeDevenirAidant.ts
+++ b/mon-aide-cyber-api/test/api/demandes/constructeurRequeteDemandeDevenirAidant.ts
@@ -2,6 +2,7 @@ import { Constructeur } from '../../constructeurs/constructeur';
 import { fakerFR } from '@faker-js/faker';
 import { departements } from '../../../src/gestion-demandes/departements';
 import { UtilisateurInscrit } from '../../../src/espace-utilisateur-inscrit/UtilisateurInscrit';
+import { TypeEntite } from '../../../src/gestion-demandes/devenir-aidant/DemandeDevenirAidant';
 
 type RequeteDemandeDevenirAidant = {
   nom: string;
@@ -10,7 +11,7 @@ type RequeteDemandeDevenirAidant = {
   departement: string;
   cguValidees: boolean;
   signatureCharte?: boolean;
-  entite?: { type: string; nom?: string; siret?: string };
+  entite: { type: TypeEntite; nom: string; siret: string };
 };
 
 class ConstructeurRequeteDemandeDevenirAidant
@@ -24,8 +25,11 @@ class ConstructeurRequeteDemandeDevenirAidant
     departements[fakerFR.number.int({ min: 0, max: departements.length - 1 })]
       .nom;
   private signatureCharte: boolean | undefined = undefined;
-  private entite: { type: string; nom?: string; siret?: string } | undefined =
-    undefined;
+  private entite: { type: TypeEntite; nom: string; siret: string } = {
+    type: 'Association',
+    nom: fakerFR.company.name(),
+    siret: fakerFR.number.int(10).toString(),
+  };
 
   dansLeDepartement(
     departement: string
@@ -52,7 +56,7 @@ class ConstructeurRequeteDemandeDevenirAidant
   dansUneEntite = (
     nom: string,
     siret: string,
-    type: string
+    type: TypeEntite
   ): ConstructeurRequeteDemandeDevenirAidant => {
     this.entite = {
       nom,
@@ -64,12 +68,6 @@ class ConstructeurRequeteDemandeDevenirAidant
 
   ayantSigneLaCharte(): ConstructeurRequeteDemandeDevenirAidant {
     this.signatureCharte = true;
-    return this;
-  }
-
-  enAttenteAdhesionAssociation(): ConstructeurRequeteDemandeDevenirAidant {
-    this.signatureCharte = true;
-    this.entite = { type: 'Association' };
     return this;
   }
 
@@ -95,7 +93,7 @@ class ConstructeurRequeteDemandeDevenirAidant
       ...(this.signatureCharte !== undefined && {
         signatureCharte: this.signatureCharte,
       }),
-      ...(this.entite !== undefined && { entite: this.entite }),
+      entite: this.entite,
     };
   }
 }

--- a/mon-aide-cyber-api/test/api/demandes/routeAPIDemandeDevenirAidant.spec.ts
+++ b/mon-aide-cyber-api/test/api/demandes/routeAPIDemandeDevenirAidant.spec.ts
@@ -764,10 +764,10 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
 
       it('Retourne le code 422 si les informations de l’entité fournie sont incorrectes', async () => {
         await creeEtConnecteUnUtilisateurInscrit(unUtilisateurInscrit());
-        const corpsDeRequete = uneRequeteDemandeDevenirAidant()
-          .dansUneEntite('', '', '')
-          .ayantSigneLaCharte()
-          .construis();
+        const corpsDeRequete = {
+          ...uneRequeteDemandeDevenirAidant().ayantSigneLaCharte().construis(),
+          entite: { type: '', nom: '', siret: '' },
+        };
 
         const reponse = await executeRequete(
           donneesServeur.app,
@@ -780,28 +780,6 @@ describe('Le serveur MAC, sur  les routes de demande pour devenir Aidant', () =>
           'Veuillez renseigner un nom pour votre entité, Veuillez renseigner un SIRET pour votre entité, Veuillez fournir l’une des valeurs suivantes pour le type d’entité ’ServicePublic’, ’ServiceEtat’, ’Association’'
         );
         expect(reponse.statusCode).toStrictEqual(422);
-      });
-
-      it("Retourne OK si le futur Aidant est en attente d'adhésion à une association", async () => {
-        await creeEtConnecteUnUtilisateurInscrit(unUtilisateurInscrit());
-        const corpsDeRequete = uneRequeteDemandeDevenirAidant()
-          .enAttenteAdhesionAssociation()
-          .construis();
-
-        const reponse = await executeRequete(
-          donneesServeur.app,
-          'POST',
-          '/api/demandes/devenir-aidant',
-          corpsDeRequete
-        );
-
-        expect(reponse.statusCode).toStrictEqual(200);
-        const demandes = await testeurMAC.entrepots
-          .demandesDevenirAidant()
-          .tous();
-        expect(demandes[0].entite).toStrictEqual({
-          type: corpsDeRequete.entite?.type,
-        });
       });
     });
 

--- a/mon-aide-cyber-api/test/constructeurs/constructeurDemandesDevenirAidant.ts
+++ b/mon-aide-cyber-api/test/constructeurs/constructeurDemandesDevenirAidant.ts
@@ -20,7 +20,11 @@ class ConstructeurDemandeDevenirAidant
   private nom: string = fakerFR.person.lastName();
   private prenom: string = fakerFR.person.firstName();
   private statut: StatutDemande = StatutDemande.EN_COURS;
-  private entite?: EntiteDemande | undefined = undefined;
+  private entite: EntiteDemande = {
+    type: 'Association',
+    nom: fakerFR.company.name(),
+    siret: fakerFR.string.numeric(10),
+  };
 
   traitee(): ConstructeurDemandeDevenirAidant {
     this.statut = StatutDemande.TRAITEE;
@@ -36,15 +40,14 @@ class ConstructeurDemandeDevenirAidant
     return this;
   }
 
-  enAttenteAdhesion(): ConstructeurDemandeDevenirAidant {
-    this.entite = {
-      type: 'Association',
-    };
+  pour(nom: string, prenom: string): ConstructeurDemandeDevenirAidant {
+    this.nom = nom;
+    this.prenom = prenom;
     return this;
   }
 
-  avantArbitrage(): ConstructeurDemandeDevenirAidant {
-    this.entite = undefined;
+  ayantPourMail(email: string): ConstructeurDemandeDevenirAidant {
+    this.mail = email;
     return this;
   }
 
@@ -59,17 +62,6 @@ class ConstructeurDemandeDevenirAidant
       statut: this.statut,
       ...(this.entite && { entite: this.entite }),
     };
-  }
-
-  pour(nom: string, prenom: string): ConstructeurDemandeDevenirAidant {
-    this.nom = nom;
-    this.prenom = prenom;
-    return this;
-  }
-
-  ayantPourMail(email: string): ConstructeurDemandeDevenirAidant {
-    this.mail = email;
-    return this;
   }
 }
 

--- a/mon-aide-cyber-api/test/espace-admin/extraction/Extraction.spec.ts
+++ b/mon-aide-cyber-api/test/espace-admin/extraction/Extraction.spec.ts
@@ -25,6 +25,7 @@ import {
   DemandeDevenirAidant,
   DemandesDevenirAidant,
 } from '../../../src/gestion-demandes/devenir-aidant/ServiceDemandeDevenirAidant';
+import { DemandeDevenirAidant as DomaineDemandeDevenirAidant } from '../../../src/gestion-demandes/devenir-aidant/DemandeDevenirAidant';
 import { uneDemandeAide } from '../../gestion-demandes/aide/ConstructeurDemandeAide';
 import { EntrepotRelationMemoire } from '../../../src/relation/infrastructure/EntrepotRelationMemoire';
 import { uneStatistiqueAidant } from '../../constructeurs/constructeurStatistiqueAidant';
@@ -149,12 +150,13 @@ describe('Extraction', () => {
       const demande = uneDemandeDevenirAidant()
         .avecEntiteMorale('ServicePublic')
         .construis();
-      const demandeAvantArbitrage = uneDemandeDevenirAidant()
-        .avantArbitrage()
-        .construis();
+      const { entite, ...demandeAvantArbitrage } =
+        uneDemandeDevenirAidant().construis();
       const entrepotDemande = new EntrepotDemandeDevenirAidantMemoire();
       await entrepotDemande.persiste(demande);
-      await entrepotDemande.persiste(demandeAvantArbitrage);
+      await entrepotDemande.persiste(
+        demandeAvantArbitrage as DomaineDemandeDevenirAidant
+      );
 
       const rapport = await uneExtraction({
         entrepotDemandes: entrepotDemande,
@@ -247,9 +249,13 @@ describe('Extraction', () => {
     });
 
     it('Fournit l’information si le futur Aidant est en attente d’adhésion à une association', async () => {
-      const demande = uneDemandeDevenirAidant().enAttenteAdhesion().construis();
+      const { entite, ...demandeEnAttenteAdhesion } =
+        uneDemandeDevenirAidant().construis();
       const entrepotDemande = new EntrepotDemandeDevenirAidantMemoire();
-      await entrepotDemande.persiste(demande);
+      await entrepotDemande.persiste({
+        ...demandeEnAttenteAdhesion,
+        entite: { type: 'Association' },
+      } as DomaineDemandeDevenirAidant);
 
       const rapport = await uneExtraction({
         entrepotDemandes: entrepotDemande,
@@ -275,12 +281,13 @@ describe('Extraction', () => {
       const demande = uneDemandeDevenirAidant()
         .avecEntiteMorale('ServiceEtat')
         .construis();
-      const demandeAvantArbitrage = uneDemandeDevenirAidant()
-        .avantArbitrage()
-        .construis();
+      const { entite, ...demandeAvantArbitrage } =
+        uneDemandeDevenirAidant().construis();
       const entrepotDemande = new EntrepotDemandeDevenirAidantMemoire();
       await entrepotDemande.persiste(demande);
-      await entrepotDemande.persiste(demandeAvantArbitrage);
+      await entrepotDemande.persiste(
+        demandeAvantArbitrage as DomaineDemandeDevenirAidant
+      );
 
       const rapport = await uneExtraction({
         entrepotDemandes: entrepotDemande,
@@ -319,9 +326,12 @@ describe('Extraction', () => {
     });
 
     it('Le rapport contient entête et intitulé', async () => {
-      const demande = uneDemandeDevenirAidant().avantArbitrage().construis();
+      const { entite, ...demandeAvantArbitrage } =
+        uneDemandeDevenirAidant().construis();
       const entrepotDemande = new EntrepotDemandeDevenirAidantMemoire();
-      await entrepotDemande.persiste(demande);
+      await entrepotDemande.persiste(
+        demandeAvantArbitrage as DomaineDemandeDevenirAidant
+      );
 
       const rapportJSON = new RapportJSON();
       await uneExtraction({

--- a/mon-aide-cyber-api/test/gestion-demandes/devenir-aidant/ServiceDemandeDevenirAidant.spec.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/devenir-aidant/ServiceDemandeDevenirAidant.spec.ts
@@ -6,12 +6,14 @@ import {
 import { EntrepotDemandeDevenirAidantMemoire } from '../../../src/infrastructure/entrepots/memoire/EntrepotMemoire';
 import { uneDemandeDevenirAidant } from '../../constructeurs/constructeurDemandesDevenirAidant';
 import { FournisseurHorloge } from '../../../src/infrastructure/horloge/FournisseurHorloge';
+import { DemandeDevenirAidant } from '../../../src/gestion-demandes/devenir-aidant/DemandeDevenirAidant';
 
 describe('Service demande devenir Aidant', () => {
   it('Retourne les demandes en attente', async () => {
-    const premiereDemande = uneDemandeDevenirAidant().construis();
+    const { entite, ...premiereDemande } =
+      uneDemandeDevenirAidant().construis();
     const entrepot = new EntrepotDemandeDevenirAidantMemoire();
-    await entrepot.persiste(premiereDemande);
+    await entrepot.persiste(premiereDemande as DemandeDevenirAidant);
     await entrepot.persiste(uneDemandeDevenirAidant().traitee().construis());
 
     const demandes =

--- a/mon-aide-cyber-api/test/gestion-demandes/devenir-aidant/constructeurDeDemandeDevenirAidant.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/devenir-aidant/constructeurDeDemandeDevenirAidant.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../src/gestion-demandes/devenir-aidant/DemandeDevenirAidant';
 import { fakerFR } from '@faker-js/faker';
 import { FournisseurHorloge } from '../../../src/infrastructure/horloge/FournisseurHorloge';
-import { UUID } from 'crypto';
+import crypto from 'crypto';
 import { departements } from '../../../src/gestion-demandes/departements';
 
 class ConstructeurDemandeDevenirAidant
@@ -14,7 +14,16 @@ class ConstructeurDemandeDevenirAidant
 {
   private email: string = fakerFR.internet.email();
   private statut: StatutDemande = StatutDemande.EN_COURS;
-  private entite: EntiteDemande | undefined = undefined;
+  private entite: EntiteDemande = {
+    nom: fakerFR.company.name(),
+    type: 'Association',
+    siret: fakerFR.string.numeric(10),
+  };
+  private identifiant: crypto.UUID = fakerFR.string.uuid() as crypto.UUID;
+  private date: Date = fakerFR.date.recent({
+    days: 7,
+    refDate: FournisseurHorloge.maintenant(),
+  });
 
   avecUnMail(email: string): ConstructeurDemandeDevenirAidant {
     this.email = email;
@@ -37,29 +46,31 @@ class ConstructeurDemandeDevenirAidant
     return this;
   }
 
-  pourUneDemandeEnAttenteAdhesion(): ConstructeurDemandeDevenirAidant {
-    this.entite = {
-      type: 'Association',
-    };
+  avecPourIdentifiant(
+    identifiantDemande: crypto.UUID
+  ): ConstructeurDemandeDevenirAidant {
+    this.identifiant = identifiantDemande;
+    return this;
+  }
+
+  enDate(date: Date): ConstructeurDemandeDevenirAidant {
+    this.date = date;
     return this;
   }
 
   construis(): DemandeDevenirAidant {
     return {
-      date: fakerFR.date.recent({
-        days: 7,
-        refDate: FournisseurHorloge.maintenant(),
-      }),
+      date: this.date,
       departement:
         departements[
           fakerFR.number.int({ min: 0, max: departements.length - 1 })
         ],
-      identifiant: fakerFR.string.uuid() as UUID,
+      identifiant: this.identifiant,
       mail: this.email,
       nom: fakerFR.person.lastName(),
       prenom: fakerFR.person.firstName(),
       statut: this.statut,
-      ...(this.entite && { entite: this.entite }),
+      entite: this.entite,
     };
   }
 }


### PR DESCRIPTION
Avec le nouvel aiguillage qui est fait post inscription via ProConnect, et le fait que l’on ne puisse plus stipuler être en attente d’une adhésion, on vérifie la présence de tous les champs de l’entité.

Les anciennes demandes incomplètes (i.e : en attente d’adhésion) continuent de fonctionner => Pour les utilisateurs inscrits ayant fait une demande, ils peuvent mettre à jour leur demande (en vue d’un futur support).

Il reste à prendre en compte les envois de mails qui ne sont plus faits.