### PR TITLE
[MISE EN RELATION] Cadence l’envoi de mail aux Aidants lors de la mise en relation

### DIFF
--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailBrevo.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailBrevo.ts
@@ -10,6 +10,7 @@ import {
 import { ErreurEnvoiEmail } from '../../api/messagerie/Messagerie';
 import {
   adaptateursRequeteBrevo,
+  enCadence,
   EnvoiMailBrevoAvecTemplate,
   ErreurRequeBrevo,
   RequeteBrevo,
@@ -140,7 +141,11 @@ export class AdaptateurEnvoiMailBrevo implements AdaptateurEnvoiMail {
     requeteBrevo: RequeteBrevo<T>
   ) {
     try {
-      await adaptateursRequeteBrevo().envoiMail().execute(requeteBrevo);
+      const envoiEnCadence = await enCadence<EnvoiMailBrevoAvecTemplate>(
+        300,
+        adaptateursRequeteBrevo().envoiMail().execute
+      );
+      await envoiEnCadence(requeteBrevo);
     } catch (reponse: unknown | ErreurRequeBrevo) {
       throw new ErreurEnvoiEmail(
         JSON.stringify((reponse as ErreurRequeBrevo).corps),

--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/adaptateurPThrottle.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/adaptateurPThrottle.ts
@@ -1,0 +1,133 @@
+const registry = new FinalizationRegistry(
+  ({ signal, aborted }: { signal: any; aborted: any }) => {
+    signal?.removeEventListener('abort', aborted);
+  }
+);
+
+export function pThrottle({
+  limit,
+  interval,
+  strict,
+  signal,
+  onDelay,
+}: {
+  limit: number;
+  interval: number;
+  strict?: boolean;
+  signal?: any;
+  onDelay?: any;
+}) {
+  if (!Number.isFinite(limit)) {
+    throw new TypeError('Expected `limit` to be a finite number');
+  }
+
+  if (!Number.isFinite(interval)) {
+    throw new TypeError('Expected `interval` to be a finite number');
+  }
+
+  const queue = new Map();
+
+  let currentTick = 0;
+  let activeCount = 0;
+
+  function windowedDelay() {
+    const now = Date.now();
+
+    if (now - currentTick > interval) {
+      activeCount = 1;
+      currentTick = now;
+      return 0;
+    }
+
+    if (activeCount < limit) {
+      activeCount++;
+    } else {
+      currentTick += interval;
+      activeCount = 1;
+    }
+
+    return currentTick - now;
+  }
+
+  const strictTicks: number[] = [];
+
+  function strictDelay() {
+    const now = Date.now();
+
+    // Clear the queue if there's a significant delay since the last execution
+    const lastTick = strictTicks.at(-1);
+    if (strictTicks.length > 0 && lastTick && now - lastTick > interval) {
+      strictTicks.length = 0;
+    }
+
+    // If the queue is not full, add the current time and execute immediately
+    if (strictTicks.length < limit) {
+      strictTicks.push(now);
+      return 0;
+    }
+
+    // Calculate the next execution time based on the first item in the queue
+    const nextExecutionTime = strictTicks[0] + interval;
+
+    // Shift the queue and add the new execution time
+    strictTicks.shift();
+    strictTicks.push(nextExecutionTime);
+
+    // Calculate the delay for the current execution
+    return Math.max(0, nextExecutionTime - now);
+  }
+
+  const getDelay = strict ? strictDelay : windowedDelay;
+
+  return (function_: any) => {
+    const throttled = function (this: any, ...arguments_: any[]) {
+      if (!throttled.isEnabled) {
+        return (async () => function_.apply(this, arguments_))();
+      }
+
+      let timeoutId: NodeJS.Timeout;
+      return new Promise((resolve, reject) => {
+        const execute = () => {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          resolve(function_.apply(this, arguments_));
+          queue.delete(timeoutId);
+        };
+
+        const delay = getDelay();
+        if (delay > 0) {
+          timeoutId = setTimeout(execute, delay);
+          queue.set(timeoutId, reject);
+          onDelay?.(...arguments_);
+        } else {
+          execute();
+        }
+      });
+    };
+
+    const aborted = () => {
+      for (const timeout of queue.keys()) {
+        clearTimeout(timeout);
+        queue.get(timeout)(signal.reason);
+      }
+
+      queue.clear();
+      strictTicks.splice(0, strictTicks.length);
+    };
+
+    registry.register(throttled, { signal, aborted });
+
+    signal?.throwIfAborted();
+    signal?.addEventListener('abort', aborted, { once: true });
+
+    throttled.isEnabled = true;
+
+    Object.defineProperty(throttled, 'queueSize', {
+      get() {
+        return queue.size;
+      },
+    });
+
+    return throttled;
+  };
+}

--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/adaptateursRequeteBrevo.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/adaptateursRequeteBrevo.ts
@@ -1,3 +1,5 @@
+import { pThrottle } from './adaptateurPThrottle';
+
 type ReponseBrevo = Response;
 
 type CorpsReponseEnErreur = {
@@ -170,4 +172,16 @@ const estReponseEnErreur = (
   reponse: ReponseBrevo | ReponseBrevoEnErreur
 ): reponse is ReponseBrevoEnErreur => {
   return !reponse.ok;
+};
+
+export const enCadence = async <T>(
+  intervalleEnMs: number,
+  fonctionEncapsulee: (
+    requete: RequeteBrevo<T>
+  ) => Promise<ReponseEnvoiMail | ReponseBrevoEnErreur>
+) => {
+  return (async () => {
+    const cadence = pThrottle({ limit: 1, interval: intervalleEnMs });
+    return cadence(fonctionEncapsulee);
+  })();
 };


### PR DESCRIPTION
**Attention :**
Le fait de rajouter un cadencement risque de rajouter encore plus de frustration dans la communauté car il pourrait y avoir un décalage de plusieurs secondes entre le premier mail et le dernier. 


On a dû récupérer le code de [p-throttle](https://github.com/sindresorhus/p-throttle) car impossible de l’utiliser au runtime du fait de la configuration CommonJS de MAC quand `p-throttle` est un module `ES`