### PR TITLE
[REMANIEMENT] Ajoute du contexte lors de la vérification des CGU pour faciliter la compréhension des erreurs remontées

### DIFF
--- a/mon-aide-cyber-api/src/adaptateurs/AdaptateurDeVerificationDeCGU.ts
+++ b/mon-aide-cyber-api/src/adaptateurs/AdaptateurDeVerificationDeCGU.ts
@@ -1,11 +1,14 @@
+import { Contexte } from '../domaine/erreurMAC';
 import { RequestHandler } from 'express';
 
 export class UtilisateurNonTrouve extends Error {
-  constructor() {
-    super("L'utilisateur voulant accédé à cette ressource n'est pas connu.");
+  constructor(contexte: Contexte) {
+    super(
+      `[${contexte}] L'utilisateur voulant accéder à cette ressource n'est pas connu.`
+    );
   }
 }
 
 export interface AdaptateurDeVerificationDeCGU {
-  verifie(): RequestHandler;
+  verifie(contexte: Contexte): RequestHandler;
 }

--- a/mon-aide-cyber-api/src/adaptateurs/AdaptateurDeVerificationDeCGUMAC.ts
+++ b/mon-aide-cyber-api/src/adaptateurs/AdaptateurDeVerificationDeCGUMAC.ts
@@ -8,13 +8,14 @@ import { RequeteUtilisateur } from '../api/routesAPI';
 import { NextFunction } from 'express-serve-static-core';
 import { constructeurActionsHATEOAS } from '../api/hateoas/hateoas';
 import { uneRechercheUtilisateursMAC } from '../recherche-utilisateurs-mac/rechercheUtilisateursMAC';
+import { Contexte } from '../domaine/erreurMAC';
 
 export class AdaptateurDeVerificationDeCGUMAC
   implements AdaptateurDeVerificationDeCGU
 {
   constructor(private readonly entrepots: Entrepots) {}
 
-  verifie<T>(): RequestHandler {
+  verifie<T>(contexte: Contexte): RequestHandler {
     return async (
       requete: RequeteUtilisateur<T>,
       reponse: Response,
@@ -24,7 +25,7 @@ export class AdaptateurDeVerificationDeCGUMAC
         this.entrepots.utilisateursMAC()
       ).rechercheParIdentifiant(requete.identifiantUtilisateurCourant!);
       if (!aidant) {
-        throw new UtilisateurNonTrouve();
+        throw new UtilisateurNonTrouve(contexte);
       }
       if (aidant.doitValiderLesCGU) {
         reponse

--- a/mon-aide-cyber-api/src/api/aidant/routesAPIAidantPreferences.ts
+++ b/mon-aide-cyber-api/src/api/aidant/routesAPIAidantPreferences.ts
@@ -96,7 +96,7 @@ export const routesAPIAidantPreferences = (
   routes.get(
     '/',
     session.verifie('Accède aux préférences de l’Aidant'),
-    cgu.verifie(),
+    cgu.verifie('Accède aux préférences de l’Aidant'),
     async (
       requete: RequeteUtilisateur,
       reponse: Response<ReponsePreferencesAidantAPI>,
@@ -141,7 +141,7 @@ export const routesAPIAidantPreferences = (
   routes.patch(
     '/',
     session.verifie('Modifie les préférences de l’Aidant'),
-    cgu.verifie(),
+    cgu.verifie('Modifie les préférences de l’Aidant'),
     express.json(),
     valideLesPreferences(),
     async (

--- a/mon-aide-cyber-api/src/api/aidant/routesAPIProfil.ts
+++ b/mon-aide-cyber-api/src/api/aidant/routesAPIProfil.ts
@@ -50,7 +50,7 @@ export const routesAPIProfil = (configuration: ConfigurationServeur) => {
   routes.get(
     '/',
     session.verifie('Accède au profil'),
-    cgu.verifie(),
+    cgu.verifie('Accède au profil'),
     async (
       requete: RequeteUtilisateur,
       reponse: Response,
@@ -132,7 +132,7 @@ export const routesAPIProfil = (configuration: ConfigurationServeur) => {
     '/',
     express.json(),
     session.verifie('Modifie le profil Aidant'),
-    cgu.verifie(),
+    cgu.verifie('Modifie le profil Aidant'),
     body('consentementAnnuaire')
       .isBoolean()
       .withMessage(
@@ -175,7 +175,7 @@ export const routesAPIProfil = (configuration: ConfigurationServeur) => {
     '/modifier-mot-de-passe',
     express.json(),
     session.verifie('Modifie le mot de passe'),
-    cgu.verifie(),
+    cgu.verifie('Modifie le mot de passe'),
     validateurDeNouveauMotDePasse(
       entrepots,
       'ancienMotDePasse',

--- a/mon-aide-cyber-api/src/api/routesAPIDiagnostic.ts
+++ b/mon-aide-cyber-api/src/api/routesAPIDiagnostic.ts
@@ -84,7 +84,7 @@ export const routesAPIDiagnostic = (configuration: ConfigurationServeur) => {
     body('emailEntiteAidee')
       .isEmail()
       .withMessage('Veuillez renseigner une adresse email valide.'),
-    cgu.verifie(),
+    cgu.verifie('Lance le diagnostic'),
     demandeAide.verifie(),
     (
       requete: RequeteUtilisateur<CorpsRequeteLanceDiagnostic>,
@@ -113,7 +113,7 @@ export const routesAPIDiagnostic = (configuration: ConfigurationServeur) => {
   routes.get(
     '/:id',
     session.verifie('Accès diagnostic'),
-    cgu.verifie(),
+    cgu.verifie('Accès diagnostic'),
     verifieRelations(relations, entrepots),
     (requete: RequeteUtilisateur, reponse: Response, suite: NextFunction) => {
       const { id } = requete.params;
@@ -137,7 +137,7 @@ export const routesAPIDiagnostic = (configuration: ConfigurationServeur) => {
   routes.patch(
     '/:id',
     session.verifie('Ajout réponse au diagnostic'),
-    cgu.verifie(),
+    cgu.verifie('Ajout réponse au diagnostic'),
     verifieRelations(relations, entrepots),
     bodyParser.json(),
     (
@@ -172,7 +172,7 @@ export const routesAPIDiagnostic = (configuration: ConfigurationServeur) => {
   routes.get(
     '/:id/restitution',
     session.verifie('Demande la restitution'),
-    cgu.verifie(),
+    cgu.verifie('Demande la restitution'),
     verifieRelations(relations, entrepots),
     (requete: RequeteUtilisateur, reponse: Response, suite: NextFunction) => {
       const { id } = requete.params;

--- a/mon-aide-cyber-api/src/api/tableau-de-bord/routesAPITableauDeBord.ts
+++ b/mon-aide-cyber-api/src/api/tableau-de-bord/routesAPITableauDeBord.ts
@@ -25,7 +25,7 @@ export const routesAPITableauDeBord = (configuration: ConfigurationServeur) => {
   routes.get(
     '/',
     session.verifie('Accède au Tableau de Bord'),
-    cgu.verifie(),
+    cgu.verifie('Accède au Tableau de Bord'),
     async (
       requete: RequeteUtilisateur,
       reponse: Response,

--- a/mon-aide-cyber-api/test/adaptateurs/AdaptateurDeVerificationDeCGUDeTest.ts
+++ b/mon-aide-cyber-api/test/adaptateurs/AdaptateurDeVerificationDeCGUDeTest.ts
@@ -2,13 +2,14 @@ import { AdaptateurDeVerificationDeCGU } from '../../src/adaptateurs/AdaptateurD
 import { RequestHandler, Response } from 'express';
 import { RequeteUtilisateur } from '../../src/api/routesAPI';
 import { NextFunction } from 'express-serve-static-core';
+import { Contexte } from '../../src/domaine/erreurMAC';
 
 export class AdapatateurDeVerificationDeCGUDeTest
   implements AdaptateurDeVerificationDeCGU
 {
   private verificationFaite = false;
 
-  verifie(): RequestHandler {
+  verifie(__contexte: Contexte): RequestHandler {
     return (
       _requete: RequeteUtilisateur,
       _reponse: Response,

--- a/mon-aide-cyber-api/test/adaptateurs/AdaptateurDeVerificationDeCGUMAC.spec.ts
+++ b/mon-aide-cyber-api/test/adaptateurs/AdaptateurDeVerificationDeCGUMAC.spec.ts
@@ -36,7 +36,7 @@ describe('Adaptateur de Vérification de CGU', () => {
       },
     } as Response;
 
-    await adaptateurDeVerificationDeCGU.verifie()(
+    await adaptateurDeVerificationDeCGU.verifie('Accède au profil')(
       {
         identifiantUtilisateurCourant: aidant.identifiant,
       } as RequeteUtilisateur,
@@ -73,7 +73,7 @@ describe('Adaptateur de Vérification de CGU', () => {
       },
     } as Response;
 
-    await adaptateurDeVerificationDeCGU.verifie()(
+    await adaptateurDeVerificationDeCGU.verifie('Accède au profil')(
       {
         identifiantUtilisateurCourant: utilisateurInscrit.identifiant,
       } as RequeteUtilisateur,
@@ -100,7 +100,7 @@ describe('Adaptateur de Vérification de CGU', () => {
     await entrepots.aidants().persiste(utilisateur);
     let suiteAppelee = false;
 
-    await adaptateurDeVerificationDeCGU.verifie()(
+    await adaptateurDeVerificationDeCGU.verifie('Accède au profil')(
       {
         identifiantUtilisateurCourant: utilisateur.identifiant,
       } as RequeteUtilisateur,
@@ -115,7 +115,7 @@ describe('Adaptateur de Vérification de CGU', () => {
 
   it("Retourne une erreur si l'utilisateur n'est pas trouvé", async () => {
     try {
-      await adaptateurDeVerificationDeCGU.verifie()(
+      await adaptateurDeVerificationDeCGU.verifie('Accède au profil')(
         {
           identifiantUtilisateurCourant: crypto.randomUUID(),
         } as RequeteUtilisateur,
@@ -125,7 +125,7 @@ describe('Adaptateur de Vérification de CGU', () => {
       assert.fail('');
     } catch (e: unknown | Error) {
       expect((e as Error).message).toStrictEqual(
-        "L'utilisateur voulant accédé à cette ressource n'est pas connu."
+        "[Accède au profil] L'utilisateur voulant accéder à cette ressource n'est pas connu."
       );
     }
   });


### PR DESCRIPTION
**L’alerte remontée lors de la vérification des CGU est obscure et ne facilite pas son identification :**
<img width="715" alt="Capture d’écran 2025-07-01 à 08 58 19" src="https://github.com/user-attachments/assets/d3f01077-9159-4d84-891b-fff39124b2d2" />

**L’origine n’est pas plus simple à trouver dans Sentry car noyée dans la page d’erreur**
<img width="905" alt="Capture d’écran 2025-07-01 à 08 59 33" src="https://github.com/user-attachments/assets/6d6a578f-0908-420b-b6e2-72b223b93b63" />

L’idée est de préfixer l’erreur remontée avec le contexte dans lequel la requête a été faite, e.g `[Accède au profil] L'utilisateur voulant accéder à cette ressource n'est pas connu.`
