### PR TITLE
[CORRECTION][MISE EN RELATION] Cadence correctement les appels à Brevo

### DIFF
--- a/mon-aide-cyber-api/src/adaptateurs/AdaptateurEnvoiMail.ts
+++ b/mon-aide-cyber-api/src/adaptateurs/AdaptateurEnvoiMail.ts
@@ -44,9 +44,9 @@ export interface AdaptateurEnvoiMail {
     confirmation: ConfirmationDemandeAideAttribuee
   ): Promise<void>;
 
-  envoieMiseEnRelation(
-    informations: InformationEntitePourMiseEnRelation,
-    aidant: AidantMisEnRelation
+  envoiToutesLesMisesEnRelation(
+    matchingAidants: AidantMisEnRelation[],
+    informations: InformationEntitePourMiseEnRelation
   ): Promise<void>;
 
   envoieRestitutionEntiteAidee(

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationParCriteres.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationParCriteres.ts
@@ -153,20 +153,17 @@ export class MiseEnRelationParCriteres implements MiseEnRelation {
       )) as Entreprise;
     const epci = await this.adaptateurGeo.epciAvecCode(entreprise.codeEpci);
 
-    const envoisEmails = matchingAidants.map((a) =>
-      this.adaptateurEnvoiMail.envoieMiseEnRelation(
-        {
-          departement: donneesMiseEnRelation.demandeAide.departement.nom,
-          epci: epci.nom,
-          typeEntite: donneesMiseEnRelation.typeEntite.nom,
-          secteursActivite: donneesMiseEnRelation.secteursActivite
-            .map((s) => s.nom)
-            .join(','),
-        },
-        a
-      )
+    await this.adaptateurEnvoiMail.envoiToutesLesMisesEnRelation(
+      matchingAidants,
+      {
+        departement: donneesMiseEnRelation.demandeAide.departement.nom,
+        epci: epci.nom,
+        typeEntite: donneesMiseEnRelation.typeEntite.nom,
+        secteursActivite: donneesMiseEnRelation.secteursActivite
+          .map((s) => s.nom)
+          .join(','),
+      }
     );
-    await Promise.all(envoisEmails);
   }
 
   private aidantsPourPostuler = (

--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailMemoire.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailMemoire.ts
@@ -20,7 +20,6 @@ export class AdaptateurEnvoiMailMemoire implements AdaptateurEnvoiMail {
   private _envoiRestitutionEntiteAideeEffectue:
     | { pdf: Buffer; emailEntiteAidee: string }
     | undefined = undefined;
-
   envoie(
     message: Email,
     expediteur: Expediteur = 'MONAIDECYBER'
@@ -61,6 +60,13 @@ export class AdaptateurEnvoiMailMemoire implements AdaptateurEnvoiMail {
     this.confirmation = confirmation;
     this.destinataires.push(confirmation.emailAidant);
     return Promise.resolve();
+  }
+
+  async envoiToutesLesMisesEnRelation(
+    matchingAidants: AidantMisEnRelation[],
+    __informations: InformationEntitePourMiseEnRelation
+  ): Promise<void> {
+    this.destinataires.push(...matchingAidants.map((a) => a.email));
   }
 
   envoieMiseEnRelation(

--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/adaptateursRequeteBrevo.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/adaptateursRequeteBrevo.ts
@@ -1,5 +1,3 @@
-import { pThrottle } from './adaptateurPThrottle';
-
 type ReponseBrevo = Response;
 
 type CorpsReponseEnErreur = {
@@ -172,16 +170,4 @@ const estReponseEnErreur = (
   reponse: ReponseBrevo | ReponseBrevoEnErreur
 ): reponse is ReponseBrevoEnErreur => {
   return !reponse.ok;
-};
-
-export const enCadence = async <T>(
-  intervalleEnMs: number,
-  fonctionEncapsulee: (
-    requete: RequeteBrevo<T>
-  ) => Promise<ReponseEnvoiMail | ReponseBrevoEnErreur>
-) => {
-  return (async () => {
-    const cadence = pThrottle({ limit: 1, interval: intervalleEnMs });
-    return cadence(fonctionEncapsulee);
-  })();
 };

--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/enCadence.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/enCadence.ts
@@ -1,0 +1,9 @@
+import { pThrottle } from './adaptateurPThrottle';
+
+export const enCadence = async <T = void>(
+  intervalleEnMs: number,
+  fonctionEncapsulee: (param: T) => Promise<void>
+) => {
+  const cadence = pThrottle({ limit: 1, interval: intervalleEnMs });
+  return cadence(fonctionEncapsulee);
+};

--- a/mon-aide-cyber-api/test/gestion-demandes/aide/MiseEnRelationParCriteres.spec.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/aide/MiseEnRelationParCriteres.spec.ts
@@ -189,11 +189,11 @@ describe('Mise en relation par critères', () => {
       await entrepots.aidants().persiste(deuxiemeAidant);
 
       const aidantsContactes: AidantMisEnRelation[] = [];
-      envoieMail.envoieMiseEnRelation = async (
-        _donneesMiseEnRelation,
-        aidant
+      envoieMail.envoiToutesLesMisesEnRelation = async (
+        aidants: AidantMisEnRelation[],
+        __donneesMiseEnRelation
       ) => {
-        aidantsContactes.push(aidant);
+        aidantsContactes.push(...aidants);
       };
 
       const miseEnRelation = laMiseEnRelation();
@@ -247,9 +247,9 @@ describe('Mise en relation par critères', () => {
       await entrepots.aidants().persiste(premierAidant);
 
       let informationsDuMail: InformationEntitePourMiseEnRelation;
-      envoieMail.envoieMiseEnRelation = async (
-        informations: InformationEntitePourMiseEnRelation,
-        __aidant
+      envoieMail.envoiToutesLesMisesEnRelation = async (
+        __aidants: AidantMisEnRelation[],
+        informations: InformationEntitePourMiseEnRelation
       ) => {
         informationsDuMail = informations;
       };
@@ -286,11 +286,11 @@ describe('Mise en relation par critères', () => {
         .ayantPourTypesEntite([entitesPubliques])
         .construis();
       const aidantsContactes: AidantMisEnRelation[] = [];
-      envoieMail.envoieMiseEnRelation = async (
-        _donneesMiseEnRelation,
-        aidant
+      envoieMail.envoiToutesLesMisesEnRelation = async (
+        aidants: AidantMisEnRelation[],
+        __donneesMiseEnRelation
       ) => {
-        aidantsContactes.push(aidant);
+        aidantsContactes.push(...aidants);
       };
       await entrepots.aidants().persiste(premierAidant);
       const miseEnRelation = laMiseEnRelation();
@@ -370,9 +370,9 @@ describe('Mise en relation par critères', () => {
         .ayantPourSecteursActivite([{ nom: 'Transports' }])
         .ayantPourTypesEntite([entitesPubliques])
         .construis();
-      envoieMail.envoieMiseEnRelation = async (
-        _donneesMiseEnRelation,
-        __aidant
+      envoieMail.envoiToutesLesMisesEnRelation = async (
+        __aidants,
+        __donneesMiseEnRelation
       ) => {
         throw new Error('Erreur pour test lors de l’envoi du mail');
       };

--- a/mon-aide-cyber-api/test/infrastructure/adaptateurs/enCadence.spec.ts
+++ b/mon-aide-cyber-api/test/infrastructure/adaptateurs/enCadence.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { enCadence } from '../../../src/infrastructure/adaptateurs/enCadence';
+
+const assertDuree = (fin: number, debut: number) => {
+  expect(Math.round(Number(fin - debut))).toBeGreaterThanOrEqual(10 * 4);
+};
+
+describe('En cadence', () => {
+  it('Exécute la fonction', async () => {
+    let compteur = 0;
+
+    const cadencee = await enCadence(1, async () => {
+      compteur += 1;
+    });
+    await cadencee();
+
+    expect(compteur).toBe(1);
+  });
+
+  it('respecte l’intervale en millisecondes', async () => {
+    let compteur = 0;
+    const debut = performance.now();
+
+    const cadencee = await enCadence(10, async () => {
+      compteur += 1;
+    });
+    await cadencee();
+    await cadencee();
+    await cadencee();
+    await cadencee();
+    await cadencee();
+
+    const fin = performance.now();
+    assertDuree(fin, debut);
+  });
+
+  it('Peut fonctionner avec un Promise.all()', async () => {
+    let compteur = 0;
+    const debut = performance.now();
+
+    const cadencee = await enCadence(10, async () => {
+      compteur += 1;
+    });
+    await Promise.all([
+      cadencee(),
+      cadencee(),
+      cadencee(),
+      cadencee(),
+      cadencee(),
+    ]);
+
+    const fin = performance.now();
+    assertDuree(fin, debut);
+  });
+
+  it('Peut encapsuler une fonction asynchrone', async () => {
+    let compteur = 0;
+    const debut = performance.now();
+
+    const cadencee = await enCadence(10, (nombre: number) => {
+      return new Promise((resolve) => {
+        compteur += nombre;
+        resolve();
+      });
+    });
+    await Promise.all([
+      cadencee(2),
+      cadencee(2),
+      cadencee(2),
+      cadencee(2),
+      cadencee(2),
+    ]);
+
+    const fin = performance.now();
+    assertDuree(fin, debut);
+    expect(compteur).toBe(10);
+  });
+});


### PR DESCRIPTION
On reflète dans l’API de l’adaptateur l’envoi en masse, c’est un détail d’implémentation, chaque implémentation pouvant choisir de cadencer ou non