### PR TITLE
[MISE EN RELATION] Corrige le cadencement qui ne faisait pas partir les mails aux Aidants

### DIFF
--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailBrevo.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailBrevo.ts
@@ -213,16 +213,12 @@ export class AdaptateurEnvoiMailBrevo implements AdaptateurEnvoiMail {
     matchingAidants: AidantMisEnRelation[],
     informations: InformationEntitePourMiseEnRelation
   ): Promise<void> {
-    const etaleLesEnvois = async (
-      i: InformationEntitePourMiseEnRelation,
-      a: AidantMisEnRelation
-    ) => {
-      await enCadence(100, () => this.envoieUneMiseEnRelation(i, a));
-    };
-
-    const tousLesEnvois = matchingAidants.map((a) =>
-      etaleLesEnvois(informations, a)
-    );
+    const tousLesEnvois = matchingAidants.map(async (a) => {
+      const envoiCadence = await enCadence(100, () =>
+        this.envoieUneMiseEnRelation(informations, a)
+      );
+      await envoiCadence();
+    });
     await Promise.all(tousLesEnvois);
   }
 


### PR DESCRIPTION
**Contexte**
Mise en relation entité Aidée - Aidants

**Reproduction**
- **Pré-requis**
   - Avoir un Aidant avec des préférences à jour (Type d’entité, Secteurs d’activité, Secteurs géographique)
- Effectuer une demande d’Aide avec une entité répondant aux critères de l’Aidant

**Résultat constaté**
Aucun Aidant n’est contacté pour la mise en relation, les mails ne partent pas
<img width="1462" alt="KO" src="https://github.com/user-attachments/assets/2b016c50-9990-418f-832b-d4c7f8d24851" />

**Résultat attendu**
Les Aidants répondants aux critères reçoivent un mail de mise en relation
<img width="1465" alt="OK" src="https://github.com/user-attachments/assets/f2171557-89c0-47ed-82e5-beb9fa99a96d" />

