### PR TITLE
[MISE EN RELATION] S’assure que le cadencement s’effectue sur la même instance de cadencement

### DIFF
--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailBrevo.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailBrevo.ts
@@ -213,11 +213,11 @@ export class AdaptateurEnvoiMailBrevo implements AdaptateurEnvoiMail {
     matchingAidants: AidantMisEnRelation[],
     informations: InformationEntitePourMiseEnRelation
   ): Promise<void> {
+    const etaleLesEnvois = await enCadence(100, (a: AidantMisEnRelation) =>
+      this.envoieUneMiseEnRelation(informations, a)
+    );
     const tousLesEnvois = matchingAidants.map(async (a) => {
-      const envoiCadence = await enCadence(100, () =>
-        this.envoieUneMiseEnRelation(informations, a)
-      );
-      await envoiCadence();
+      await etaleLesEnvois(a);
     });
     await Promise.all(tousLesEnvois);
   }


### PR DESCRIPTION


Auparavant on faisait une instance de cadencement puis l’appel immédiatement, ainsi, au sein d’une boucle on avait n instances, on perdait l’utiliter de la fonction