### PR TITLE
[MISE EN RELATION] Limite les Aidants pouvant postuler à 2 demandes sur 30 jours glissant

### DIFF
--- a/mon-aide-cyber-api/src/espace-aidant/Aidant.ts
+++ b/mon-aide-cyber-api/src/espace-aidant/Aidant.ts
@@ -83,7 +83,7 @@ export type Aidant = Aggregat & {
 export interface EntrepotAidant extends EntrepotEcriture<Aidant> {
   rechercheParEmail(email: string): Promise<Aidant>;
 
-  rechercheParPreferences(criteres: {
+  lesAidantsCorrespondantAuxCriteresDeEntiteAMoinsDe2DiagsSur30JoursGlissant(criteres: {
     departement: Departement;
     secteursActivite: SecteurActivite[];
     typeEntite:

--- a/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationParCriteres.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/aide/MiseEnRelationParCriteres.ts
@@ -84,11 +84,15 @@ export class MiseEnRelationParCriteres implements MiseEnRelation {
   async execute(
     donneesMiseEnRelation: DonneesMiseEnRelation
   ): Promise<ResultatMiseEnRelation<ParCriteres>> {
-    const aidants = await this.entrepots.aidants().rechercheParPreferences({
-      departement: donneesMiseEnRelation.demandeAide.departement,
-      secteursActivite: donneesMiseEnRelation.secteursActivite,
-      typeEntite: donneesMiseEnRelation.typeEntite,
-    });
+    const aidants = await this.entrepots
+      .aidants()
+      .lesAidantsCorrespondantAuxCriteresDeEntiteAMoinsDe2DiagsSur30JoursGlissant(
+        {
+          departement: donneesMiseEnRelation.demandeAide.departement,
+          secteursActivite: donneesMiseEnRelation.secteursActivite,
+          typeEntite: donneesMiseEnRelation.typeEntite,
+        }
+      );
     const aucunAidantMatche = aidants.length === 0;
     if (aucunAidantMatche) {
       await envoieAuCOTAucunAidantPourLaDemandeAide(

--- a/mon-aide-cyber-api/src/infrastructure/entrepots/memoire/EntrepotsMemoire.ts
+++ b/mon-aide-cyber-api/src/infrastructure/entrepots/memoire/EntrepotsMemoire.ts
@@ -36,12 +36,15 @@ import { EntrepotStatistiquesUtilisateurInscrit } from '../../../statistiques/ut
 export class EntrepotsMemoire implements Entrepots {
   private entrepotDiagnostic: EntrepotDiagnostic =
     new EntrepotDiagnosticMemoire();
-  private entrepotAidants: EntrepotAidant = new EntrepotAidantMemoire();
   private entrepotUtilisateursInscrits: EntrepotUtilisateurInscrit =
     new EntrepotUtilisateurInscritMemoire();
   private entrepotRestitution: EntrepotRestitution =
     new EntrepotRestitutionMemoire();
   private entrepotAides: EntrepotDemandeAide = new EntrepotAideMemoire();
+  private entrepotAidants: EntrepotAidant = new EntrepotAidantMemoire(
+    this.entrepotAides as EntrepotAideMemoire,
+    new EntrepotRelationMemoire()
+  );
   private entrepotDemandeDevenirAidant =
     new EntrepotDemandeDevenirAidantMemoire();
   private entrepotAnnuaireAidants: EntrepotAnnuaireAidants =

--- a/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotAidantPostgres.ts
+++ b/mon-aide-cyber-api/src/infrastructure/entrepots/postgres/EntrepotAidantPostgres.ts
@@ -59,7 +59,7 @@ export class EntrepotAidantPostgres
     super();
   }
 
-  async rechercheParPreferences(criteres: {
+  async lesAidantsCorrespondantAuxCriteresDeEntiteAMoinsDe2DiagsSur30JoursGlissant(criteres: {
     departement: Departement;
     secteursActivite: SecteurActivite[];
     typeEntite:

--- a/mon-aide-cyber-api/test/infrastructure/adaptateurs/enCadence.spec.ts
+++ b/mon-aide-cyber-api/test/infrastructure/adaptateurs/enCadence.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { enCadence } from '../../../src/infrastructure/adaptateurs/enCadence';
 
 const assertDuree = (fin: number, debut: number) => {
-  expect(Math.round(Number(fin - debut))).toBeGreaterThanOrEqual(10 * 4);
+  expect(Math.ceil(Number(fin - debut))).toBeGreaterThanOrEqual(10 * 4);
 };
 
 describe('En cadence', () => {

--- a/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotAideConcret.spec.ts
+++ b/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotAideConcret.spec.ts
@@ -272,7 +272,7 @@ describe('Entrepot Aidé Concret', () => {
   });
 });
 
-class EntrepotAideBrevoMemoire implements EntrepotAideDistant {
+export class EntrepotAideBrevoMemoire implements EntrepotAideDistant {
   protected entites: Map<string, AideDistantBrevoDTO> = new Map();
   private avecMetaDonnees = true;
 

--- a/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotsPostgres.spec.ts
+++ b/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotsPostgres.spec.ts
@@ -799,11 +799,13 @@ describe('Entrepot Aidant', () => {
       await entrepotAidant.persiste(unAidantEnAllierPourAdministrationPublique);
 
       const aidantsTrouvesEnGironde =
-        await entrepotAidant.rechercheParPreferences({
-          departement: gironde,
-          secteursActivite: [{ nom: 'Transports' }],
-          typeEntite: associations,
-        });
+        await entrepotAidant.lesAidantsCorrespondantAuxCriteresDeEntiteAMoinsDe2DiagsSur30JoursGlissant(
+          {
+            departement: gironde,
+            secteursActivite: [{ nom: 'Transports' }],
+            typeEntite: associations,
+          }
+        );
 
       expect(aidantsTrouvesEnGironde).toStrictEqual<Aidant[]>([
         unAidantEnGirondeDansLesTransportsAssociatifs,
@@ -833,11 +835,13 @@ describe('Entrepot Aidant', () => {
       await entrepotAidant.persiste(unAidantEnAllierPourAdministrationPublique);
 
       const aidantsTrouvesEnGironde =
-        await entrepotAidant.rechercheParPreferences({
-          departement: allier,
-          secteursActivite: [{ nom: 'Administration' }, { nom: 'Tertiaire' }],
-          typeEntite: entitesPubliques,
-        });
+        await entrepotAidant.lesAidantsCorrespondantAuxCriteresDeEntiteAMoinsDe2DiagsSur30JoursGlissant(
+          {
+            departement: allier,
+            secteursActivite: [{ nom: 'Administration' }, { nom: 'Tertiaire' }],
+            typeEntite: entitesPubliques,
+          }
+        );
 
       expect(aidantsTrouvesEnGironde).toStrictEqual<Aidant[]>([
         unAidantEnAllierPourAdministrationPublique,

--- a/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotsPostgres.spec.ts
+++ b/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/EntrepotsPostgres.spec.ts
@@ -88,9 +88,9 @@ import { EntrepotStatistiquesUtilisateursInscritsPostgres } from '../../../../sr
 import { uneDemandeAide } from '../../../gestion-demandes/aide/ConstructeurDemandeAide';
 import { EntrepotAideConcret } from '../../../../src/infrastructure/entrepots/postgres/EntrepotAideConcret';
 import { AdaptateurRepertoireDeContactsMemoire } from '../../../../src/infrastructure/adaptateurs/AdaptateurRepertoireDeContactsMemoire';
-import { EntrepotAideBrevoMemoire } from './EntrepotAideConcret.spec';
+import { EntrepotAideBrevoMemoire } from './aideAuxTests/EntrepotAideBrevoMemoire';
 
-describe('Entrepots Postgres', () => {
+describe('Tous les entreprôts Postgres', () => {
   describe('Entrepot Diagnostic Postgres', () => {
     const entrepotDiagnosticPostgres = new EntrepotDiagnosticPostgres();
 
@@ -495,906 +495,891 @@ describe('Entrepots Postgres', () => {
       });
     });
   });
-});
 
-describe('Entrepot Aidant', () => {
-  const serviceDeChiffrement: FauxServiceDeChiffrement =
-    new FauxServiceDeChiffrement(new Map());
-  let entrepot = new EntrepotAidantPostgres(serviceDeChiffrement);
+  describe('Entrepot Aidant', () => {
+    const serviceDeChiffrement: FauxServiceDeChiffrement =
+      new FauxServiceDeChiffrement(new Map());
+    let entrepot = new EntrepotAidantPostgres(serviceDeChiffrement);
 
-  beforeEach(async () => {
-    await nettoieLaBaseDeDonneesAidants();
-    serviceDeChiffrement.nettoie();
-  });
-
-  it('Persiste un Aidant', async () => {
-    const aidant = unAidant().construis();
-    serviceDeChiffrement.ajoute(aidant.email, 'aaa');
-    serviceDeChiffrement.ajoute(aidant.nomPrenom, 'ccc');
-    serviceDeChiffrement.ajoute(aidant.preferences.nomAffichageAnnuaire, 'ddd');
-
-    await entrepot.persiste(aidant);
-
-    const aidantRecu = await new EntrepotAidantPostgres(
-      serviceDeChiffrement
-    ).lis(aidant.identifiant);
-    expect(aidantRecu).toStrictEqual<Aidant>(aidant);
-  });
-
-  it('Persiste un aidant avec son Siret', async () => {
-    const aidant = unAidant().avecUnSiret('1234567890').construis();
-    serviceDeChiffrement.ajoute(aidant.email, 'aaa');
-    serviceDeChiffrement.ajoute(aidant.nomPrenom, 'ccc');
-
-    await entrepot.persiste(aidant);
-
-    const aidantRecu = await new EntrepotAidantPostgres(
-      serviceDeChiffrement
-    ).lis(aidant.identifiant);
-    expect(aidantRecu).toStrictEqual<Aidant>(aidant);
-  });
-
-  it('Persiste un aidant avec la date de la signature de la charte', async () => {
-    const dateSignatureCharte = new Date();
-    const aidant = unAidant()
-      .avecUneDateDeSignatureDeCharte(dateSignatureCharte)
-      .construis();
-    const serviceDeChiffrement = new FauxServiceDeChiffrement(new Map());
-
-    await entrepot.persiste(aidant);
-
-    const aidantRecu = await new EntrepotAidantPostgres(
-      serviceDeChiffrement
-    ).lis(aidant.identifiant);
-    expect(aidantRecu.dateSignatureCharte).toStrictEqual(dateSignatureCharte);
-  });
-
-  it("Persiste un Aidant avec l'entité", async () => {
-    const aidant = unAidant().faisantPartieDeEntite('Association').construis();
-    serviceDeChiffrement.ajoute(aidant.entite!.nom!, 'aaaa');
-    serviceDeChiffrement.ajoute(aidant.entite!.siret!, 'bbbb');
-    serviceDeChiffrement.ajoute(aidant.entite!.type!, 'cccc');
-
-    await entrepot.persiste(aidant);
-
-    const aidantRecu = await new EntrepotAidantPostgres(
-      serviceDeChiffrement
-    ).lis(aidant.identifiant);
-    expect(aidantRecu.entite).toStrictEqual<EntiteAidant>({
-      nom: aidant.entite!.nom!,
-      siret: aidant.entite!.siret!,
-      type: 'Association',
-    });
-  });
-
-  it("Persiste un Aidant sans entité mais en sachant qu'il souhaite être en association", async () => {
-    const aidant = unAidant().faisantPartieDeEntite('Association').construis();
-    serviceDeChiffrement.ajoute(aidant.entite!.type!, 'cccc');
-
-    await entrepot.persiste(aidant);
-
-    const aidantRecu = await new EntrepotAidantPostgres(
-      serviceDeChiffrement
-    ).lis(aidant.identifiant);
-    expect(aidantRecu.entite).toStrictEqual<EntiteAidant>({
-      type: 'Association',
-    });
-  });
-
-  it('Persiste un Aidant préalablement Utilisateur Inscrit', async () => {
-    const entrepot = new EntrepotAidantPostgres(
-      new ServiceDeChiffrementClair()
-    );
-    const utilisateurInscrit = unUtilisateurInscrit()
-      .avecUnEmail('jean.dujardin@mail.com')
-      .construis();
-    await new EntrepotUtilisateurInscritPostgres(
-      new ServiceDeChiffrementClair()
-    ).persiste(utilisateurInscrit);
-    const aidant = unAidant()
-      .avecUnEmail('jean.dujardin@mail.com')
-      .avecUnIdentifiant(utilisateurInscrit.identifiant)
-      .construis();
-
-    await entrepot.persiste(aidant);
-
-    expect(
-      await entrepot.lis(utilisateurInscrit.identifiant)
-    ).toStrictEqual<Aidant>(aidant);
-    await expect(() =>
-      new EntrepotUtilisateurInscritPostgres(
-        new ServiceDeChiffrementClair()
-      ).lis(utilisateurInscrit.identifiant)
-    ).rejects.toThrowError("Le utilisateur inscrit demandé n'existe pas.");
-  });
-
-  it('Met à jour le consentement pour apparaître dans l’annuaire', async () => {
-    const aidant = unAidant().construis();
-    const serviceDeChiffrement = new ServiceDeChiffrementClair();
-    await entrepot.persiste(aidant);
-
-    aidant.consentementAnnuaire = true;
-    await entrepot.persiste(aidant);
-
-    const aidantRecu = await new EntrepotAidantPostgres(
-      serviceDeChiffrement
-    ).lis(aidant.identifiant);
-    expect(aidantRecu.consentementAnnuaire).toBe(true);
-  });
-
-  describe('Met à jour les préférences', () => {
-    const serviceDeChiffrement: ServiceDeChiffrement =
-      new ServiceDeChiffrementClair();
-    const entrepot = new EntrepotAidantPostgres(serviceDeChiffrement);
-
-    it('Persiste les types d’entités de l’Aidant', async () => {
-      const organisationsPubliques: EntitesOrganisationsPubliques = {
-        nom: 'Organisations publiques',
-        libelle:
-          'Organisations publiques (ex. collectivité, administration, etc.)',
-      };
-      const associations: EntitesAssociations = {
-        nom: 'Associations',
-        libelle: 'Associations (ex. association loi 1901, GIP)',
-      };
-      const aidant = unAidant()
-        .ayantPourTypesEntite([organisationsPubliques, associations])
-        .construis();
-
-      await entrepot.persiste(aidant);
-
-      const aidantRecu = await entrepot.lis(aidant.identifiant);
-      expect(aidantRecu.preferences.typesEntites).toStrictEqual<TypesEntites>([
-        organisationsPubliques,
-        associations,
-      ]);
+    beforeEach(async () => {
+      await nettoieLaBaseDeDonneesAidants();
+      serviceDeChiffrement.nettoie();
     });
 
-    it('Persiste les départements où l’Aidant souhaite intervenir', async () => {
-      const finistere: Departement = {
-        nom: 'Finistère',
-        code: '29',
-        codeRegion: '53',
-      };
-      const gironde: Departement = {
-        nom: 'Gironde',
-        code: '33',
-        codeRegion: '75',
-      };
-      const gard: Departement = {
-        nom: 'Gard',
-        code: '30',
-        codeRegion: '76',
-      };
-      const aidant = unAidant()
-        .ayantPourDepartements([finistere, gironde, gard])
-        .construis();
-
-      await entrepot.persiste(aidant);
-
-      const aidantRecu = await entrepot.lis(aidant.identifiant);
-      expect(aidantRecu.preferences.departements).toStrictEqual<Departement[]>([
-        finistere,
-        gard,
-        gironde,
-      ]);
-    });
-
-    it('Persiste les secteurs d’activité pour lesquels l’Aidant peut intervenir', async () => {
-      const administration: SecteurActivite = {
-        nom: 'Administration',
-      };
-      const industrie: SecteurActivite = {
-        nom: 'Industrie',
-      };
-      const aidant = unAidant()
-        .ayantPourSecteursActivite([administration, industrie])
-        .construis();
-
-      await entrepot.persiste(aidant);
-
-      const aidantRecu = await entrepot.lis(aidant.identifiant);
-      expect(aidantRecu.preferences.secteursActivite).toStrictEqual<
-        SecteurActivite[]
-      >([administration, industrie]);
-    });
-  });
-
-  describe('Recherche par email', () => {
-    it("L'aidant est trouvé", async () => {
+    it('Persiste un Aidant', async () => {
       const aidant = unAidant().construis();
+      serviceDeChiffrement.ajoute(aidant.email, 'aaa');
+      serviceDeChiffrement.ajoute(aidant.nomPrenom, 'ccc');
+      serviceDeChiffrement.ajoute(
+        aidant.preferences.nomAffichageAnnuaire,
+        'ddd'
+      );
+
+      await entrepot.persiste(aidant);
+
+      const aidantRecu = await new EntrepotAidantPostgres(
+        serviceDeChiffrement
+      ).lis(aidant.identifiant);
+      expect(aidantRecu).toStrictEqual<Aidant>(aidant);
+    });
+
+    it('Persiste un aidant avec son Siret', async () => {
+      const aidant = unAidant().avecUnSiret('1234567890').construis();
       serviceDeChiffrement.ajoute(aidant.email, 'aaa');
       serviceDeChiffrement.ajoute(aidant.nomPrenom, 'ccc');
 
       await entrepot.persiste(aidant);
 
-      const aidantTrouve = await new EntrepotAidantPostgres(
+      const aidantRecu = await new EntrepotAidantPostgres(
         serviceDeChiffrement
-      ).rechercheParEmail(aidant.email);
-
-      expect(aidantTrouve).toStrictEqual<Aidant>(aidant);
+      ).lis(aidant.identifiant);
+      expect(aidantRecu).toStrictEqual<Aidant>(aidant);
     });
 
-    it("Retourne un erreur s'il ne s'agit pas d'un Aidant", async () => {
-      await knex(knexfile)
-        .insert({
-          id: crypto.randomUUID(),
-          type: 'UTILISATEUR_INSCRIT',
-          donnees: { email: 'jean.dupont@utilisateur-inscrit.com' },
-        })
-        .into('utilisateurs_mac');
-
-      const aidantTrouve = new EntrepotAidantPostgres(
-        new ServiceDeChiffrementClair()
-      ).rechercheParEmail('jean.dupont@utilisateur-inscrit.com');
-
-      expect(aidantTrouve).rejects.toStrictEqual(
-        new AggregatNonTrouve('aidant')
-      );
-    });
-
-    it("L'aidant n'est pas trouvé", () => {
-      expect(
-        new EntrepotAidantPostgres(
-          new FauxServiceDeChiffrement(new Map())
-        ).rechercheParEmail('identifiant-inconnu')
-      ).rejects.toThrow(new Error("Le aidant demandé n'existe pas."));
-    });
-  });
-
-  describe('Pour le type Aidant', () => {
-    it('Retourne une erreur s’il ne s’agit pas d’un Aidant', async () => {
-      const id = crypto.randomUUID();
-      await knex(knexfile)
-        .insert({
-          id,
-          type: 'UTILISATEUR_INSCRIT',
-          donnees: { email: 'jean.dupont@utilisateur-inscrit.com' },
-        })
-        .into('utilisateurs_mac');
-
-      const aidantTrouve = new EntrepotAidantPostgres(
-        new ServiceDeChiffrementClair()
-      ).lis(id);
-
-      expect(aidantTrouve).rejects.toStrictEqual(
-        new AggregatNonTrouve('aidant')
-      );
-    });
-
-    it('Retourne uniquement les Aidants', async () => {
-      const aidant = unAidant().construis();
-      const serviceDeChiffrement = new ServiceDeChiffrementClair();
-      entrepot = new EntrepotAidantPostgres(serviceDeChiffrement);
+    it('Persiste un aidant avec la date de la signature de la charte', async () => {
+      const dateSignatureCharte = new Date();
+      const aidant = unAidant()
+        .avecUneDateDeSignatureDeCharte(dateSignatureCharte)
+        .construis();
+      const serviceDeChiffrement = new FauxServiceDeChiffrement(new Map());
 
       await entrepot.persiste(aidant);
-      await knex(knexfile)
-        .insert({
-          id: crypto.randomUUID(),
-          type: 'UTILISATEUR_INSCRIT',
-          donnees: { email: 'jean.dupont@utilisateur-inscrit.com' },
-        })
-        .into('utilisateurs_mac');
 
-      const aidants = await new EntrepotAidantPostgres(
+      const aidantRecu = await new EntrepotAidantPostgres(
         serviceDeChiffrement
-      ).tous();
-
-      expect(aidants).toStrictEqual<Aidant[]>([aidant]);
+      ).lis(aidant.identifiant);
+      expect(aidantRecu.dateSignatureCharte).toStrictEqual(dateSignatureCharte);
     });
-  });
 
-  describe('Recherche les Aidants correspondant aux critères de l’entité à moins de 2 diagnostics sur 30 jours glissant', () => {
-    const creeDeuxDemandesAideEnDatePour = async (
-      aidantAyantPostuleADeuxDemandesAide: Aidant,
-      lesDates: Date[]
-    ) => {
+    it("Persiste un Aidant avec l'entité", async () => {
+      const aidant = unAidant()
+        .faisantPartieDeEntite('Association')
+        .construis();
+      serviceDeChiffrement.ajoute(aidant.entite!.nom!, 'aaaa');
+      serviceDeChiffrement.ajoute(aidant.entite!.siret!, 'bbbb');
+      serviceDeChiffrement.ajoute(aidant.entite!.type!, 'cccc');
+
+      await entrepot.persiste(aidant);
+
+      const aidantRecu = await new EntrepotAidantPostgres(
+        serviceDeChiffrement
+      ).lis(aidant.identifiant);
+      expect(aidantRecu.entite).toStrictEqual<EntiteAidant>({
+        nom: aidant.entite!.nom!,
+        siret: aidant.entite!.siret!,
+        type: 'Association',
+      });
+    });
+
+    it("Persiste un Aidant sans entité mais en sachant qu'il souhaite être en association", async () => {
+      const aidant = unAidant()
+        .faisantPartieDeEntite('Association')
+        .construis();
+      serviceDeChiffrement.ajoute(aidant.entite!.type!, 'cccc');
+
+      await entrepot.persiste(aidant);
+
+      const aidantRecu = await new EntrepotAidantPostgres(
+        serviceDeChiffrement
+      ).lis(aidant.identifiant);
+      expect(aidantRecu.entite).toStrictEqual<EntiteAidant>({
+        type: 'Association',
+      });
+    });
+
+    it('Persiste un Aidant préalablement Utilisateur Inscrit', async () => {
+      const entrepot = new EntrepotAidantPostgres(
+        new ServiceDeChiffrementClair()
+      );
+      const utilisateurInscrit = unUtilisateurInscrit()
+        .avecUnEmail('jean.dujardin@mail.com')
+        .construis();
+      await new EntrepotUtilisateurInscritPostgres(
+        new ServiceDeChiffrementClair()
+      ).persiste(utilisateurInscrit);
+      const aidant = unAidant()
+        .avecUnEmail('jean.dujardin@mail.com')
+        .avecUnIdentifiant(utilisateurInscrit.identifiant)
+        .construis();
+
+      await entrepot.persiste(aidant);
+
+      expect(
+        await entrepot.lis(utilisateurInscrit.identifiant)
+      ).toStrictEqual<Aidant>(aidant);
+      await expect(() =>
+        new EntrepotUtilisateurInscritPostgres(
+          new ServiceDeChiffrementClair()
+        ).lis(utilisateurInscrit.identifiant)
+      ).rejects.toThrowError("Le utilisateur inscrit demandé n'existe pas.");
+    });
+
+    it('Met à jour le consentement pour apparaître dans l’annuaire', async () => {
+      const aidant = unAidant().construis();
       const serviceDeChiffrement = new ServiceDeChiffrementClair();
-      const entrepotAideConcret = new EntrepotAideConcret(
-        serviceDeChiffrement,
-        new AdaptateurRepertoireDeContactsMemoire(),
-        new EntrepotAideBrevoMemoire()
-      );
-      const premiereDemande = uneDemandeAide()
-        .avecUneDateDeSignatureDesCGU(lesDates[0])
-        .construis();
-      const secondeDemande = uneDemandeAide()
-        .avecUneDateDeSignatureDesCGU(lesDates[1])
-        .construis();
-      await entrepotAideConcret.persiste(premiereDemande);
-      await entrepotAideConcret.persiste(secondeDemande);
-      const entrepotRelation = new EntrepotRelationPostgres();
-      await entrepotRelation.persiste(
-        unTupleAttributionDemandeAideAAidant(
-          premiereDemande.identifiant,
-          aidantAyantPostuleADeuxDemandesAide.identifiant
-        )
-      );
-      await entrepotRelation.persiste(
-        unTupleAttributionDemandeAideAAidant(
-          secondeDemande.identifiant,
-          aidantAyantPostuleADeuxDemandesAide.identifiant
-        )
-      );
-    };
+      await entrepot.persiste(aidant);
 
-    it('recherche les Aidants correspondants aux 3 critères', async () => {
-      const unAidantEnGirondeDansLesTransportsAssociatifs = unAidant()
-        .ayantPourDepartements([gironde])
-        .ayantPourSecteursActivite([{ nom: 'Transports' }])
-        .ayantPourTypesEntite([associations])
-        .construis();
-      const unAidantEnAllierPourAdministrationPublique = unAidant()
-        .ayantPourDepartements([allier])
-        .ayantPourTypesEntite([entitesPubliques])
-        .ayantPourSecteursActivite([{ nom: 'Administration' }])
-        .construis();
-      const entrepotAidant = new EntrepotAidantPostgres(
-        new ServiceDeChiffrementClair()
-      );
-      await entrepotAidant.persiste(
-        unAidantEnGirondeDansLesTransportsAssociatifs
-      );
-      await entrepotAidant.persiste(unAidantEnAllierPourAdministrationPublique);
+      aidant.consentementAnnuaire = true;
+      await entrepot.persiste(aidant);
 
-      const aidantsTrouvesEnGironde =
-        await entrepotAidant.lesAidantsCorrespondantAuxCriteresDeEntiteAMoinsDe2DiagsSur30JoursGlissant(
-          {
-            departement: gironde,
-            secteursActivite: [{ nom: 'Transports' }],
-            typeEntite: associations,
-          }
-        );
-
-      expect(aidantsTrouvesEnGironde).toStrictEqual<Aidant[]>([
-        unAidantEnGirondeDansLesTransportsAssociatifs,
-      ]);
+      const aidantRecu = await new EntrepotAidantPostgres(
+        serviceDeChiffrement
+      ).lis(aidant.identifiant);
+      expect(aidantRecu.consentementAnnuaire).toBe(true);
     });
 
-    it('recherche les Aidants de manière disctincte', async () => {
-      const unAidantEnGirondeDansLesTransportsAssociatifs = unAidant()
-        .ayantPourDepartements([gironde])
-        .ayantPourSecteursActivite([{ nom: 'Transports' }])
-        .ayantPourTypesEntite([associations])
-        .construis();
-      const unAidantEnAllierPourAdministrationPublique = unAidant()
-        .ayantPourDepartements([allier])
-        .ayantPourTypesEntite([entitesPubliques])
-        .ayantPourSecteursActivite([
-          { nom: 'Administration' },
-          { nom: 'Tertiaire' },
-        ])
-        .construis();
-      const entrepotAidant = new EntrepotAidantPostgres(
-        new ServiceDeChiffrementClair()
-      );
-      await entrepotAidant.persiste(
-        unAidantEnGirondeDansLesTransportsAssociatifs
-      );
-      await entrepotAidant.persiste(unAidantEnAllierPourAdministrationPublique);
+    describe('Met à jour les préférences', () => {
+      const serviceDeChiffrement: ServiceDeChiffrement =
+        new ServiceDeChiffrementClair();
+      const entrepot = new EntrepotAidantPostgres(serviceDeChiffrement);
 
-      const aidantsTrouvesEnGironde =
-        await entrepotAidant.lesAidantsCorrespondantAuxCriteresDeEntiteAMoinsDe2DiagsSur30JoursGlissant(
-          {
-            departement: allier,
-            secteursActivite: [{ nom: 'Administration' }, { nom: 'Tertiaire' }],
-            typeEntite: entitesPubliques,
-          }
-        );
-
-      expect(aidantsTrouvesEnGironde).toStrictEqual<Aidant[]>([
-        unAidantEnAllierPourAdministrationPublique,
-      ]);
-    });
-
-    it('Retourne un Aidant parmi 2', async () => {
-      const entrepotAidant = new EntrepotAidantPostgres(
-        new ServiceDeChiffrementClair()
-      );
-      FournisseurHorlogeDeTest.initialise(new Date('2025-03-19T13:50:00.000Z'));
-      const aidantAyantPostuleADeuxDemandesAide = unAidant()
-        .ayantPourDepartements([finistere])
-        .ayantPourSecteursActivite([{ nom: 'Transports' }])
-        .ayantPourTypesEntite([entitesPubliques])
-        .avecUnEmail('aidant-avec-deux-demandes@mail.con')
-        .avecUnNomPrenom('Jean DUPONT')
-        .construis();
-      const secondAidant = unAidant()
-        .ayantPourDepartements([finistere])
-        .ayantPourSecteursActivite([{ nom: 'Transports' }])
-        .ayantPourTypesEntite([entitesPubliques])
-        .avecUnEmail('aidant-qui-matche@mail.con')
-        .avecUnNomPrenom('Jean MARTIN')
-        .construis();
-      await entrepotAidant.persiste(aidantAyantPostuleADeuxDemandesAide);
-      await entrepotAidant.persiste(secondAidant);
-      await creeDeuxDemandesAideEnDatePour(
-        aidantAyantPostuleADeuxDemandesAide,
-        [
-          new Date('2025-02-21T14:50:00.000Z'),
-          new Date('2025-03-15T08:50:00.000Z'),
-        ]
-      );
-
-      const lesAidantsRetournes =
-        await entrepotAidant.lesAidantsCorrespondantAuxCriteresDeEntiteAMoinsDe2DiagsSur30JoursGlissant(
-          {
-            departement: finistere,
-            secteursActivite: [{ nom: 'Transports' }],
-            typeEntite: entitesPubliques,
-          }
-        );
-
-      expect(lesAidantsRetournes).toHaveLength(1);
-      expect(lesAidantsRetournes[0].email).toBe('aidant-qui-matche@mail.con');
-      expect(lesAidantsRetournes[0].nomPrenom).toBe('Jean MARTIN');
-    });
-
-    it('Retourne 2 aidants', async () => {
-      const entrepotAidant = new EntrepotAidantPostgres(
-        new ServiceDeChiffrementClair()
-      );
-      FournisseurHorlogeDeTest.initialise(new Date('2025-03-19T13:50:00.000Z'));
-      const aidantPouvantANouveauMatcher = unAidant()
-        .ayantPourDepartements([finistere])
-        .ayantPourSecteursActivite([{ nom: 'Transports' }])
-        .ayantPourTypesEntite([entitesPubliques])
-        .avecUnEmail('aidant-avec-deux-demandes@mail.con')
-        .avecUnNomPrenom('Jean DUPONT')
-        .construis();
-      const secondAidant = unAidant()
-        .ayantPourDepartements([finistere])
-        .ayantPourSecteursActivite([{ nom: 'Transports' }])
-        .ayantPourTypesEntite([entitesPubliques])
-        .avecUnEmail('aidant-qui-matche@mail.con')
-        .avecUnNomPrenom('Jean MARTIN')
-        .construis();
-      await entrepotAidant.persiste(aidantPouvantANouveauMatcher);
-      await entrepotAidant.persiste(secondAidant);
-      await creeDeuxDemandesAideEnDatePour(aidantPouvantANouveauMatcher, [
-        new Date('2025-02-17T13:49:00.000Z'),
-        new Date('2025-03-15T08:50:00.000Z'),
-      ]);
-
-      const lesAidantsRetournes =
-        await entrepotAidant.lesAidantsCorrespondantAuxCriteresDeEntiteAMoinsDe2DiagsSur30JoursGlissant(
-          {
-            departement: finistere,
-            secteursActivite: [{ nom: 'Transports' }],
-            typeEntite: entitesPubliques,
-          }
-        );
-
-      expect(lesAidantsRetournes).toHaveLength(2);
-      expect(lesAidantsRetournes.map((a) => a.email)).toEqual(
-        expect.arrayContaining([
-          'aidant-qui-matche@mail.con',
-          'aidant-avec-deux-demandes@mail.con',
-        ])
-      );
-    });
-  });
-});
-
-describe('EntrepotStatistiquesAidant', () => {
-  const entrepotAidant = new EntrepotAidantPostgres(
-    adaptateurServiceChiffrement()
-  );
-  const entrepotUtilisateurInscritPostgres =
-    new EntrepotUtilisateurInscritPostgres(adaptateurServiceChiffrement());
-
-  beforeEach(async () => {
-    await nettoieLaBaseDeDonneesAidants();
-    await nettoieLaBaseDeDonneesRelations();
-  });
-  const entrepotRelation = new EntrepotRelationPostgres();
-
-  it('Récupère un Aidant ayant plus de 2 diagnostics', async () => {
-    const aidant = unAidant().construis();
-    await entrepotAidant.persiste(aidant);
-    await entrepotRelation.persiste(
-      unTupleAidantInitieDiagnostic(aidant.identifiant, crypto.randomUUID())
-    );
-    await entrepotRelation.persiste(
-      unTupleAidantInitieDiagnostic(aidant.identifiant, crypto.randomUUID())
-    );
-
-    const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
-      adaptateurServiceChiffrement()
-    );
-
-    expect(
-      await entrepotAidantExtraction.rechercheAidantAyantAuMoinsNDiagnostics(2)
-    ).toStrictEqual<AidantExtraction[]>([
-      {
-        identifiant: aidant.identifiant,
-        nomPrenom: aidant.nomPrenom,
-        email: aidant.email,
-        compteCree: aidant.dateSignatureCGU!,
-        departements: aidant.preferences.departements,
-        entite: '',
-      },
-    ]);
-  });
-
-  it('Récupère un Aidant sans diagnostic', async () => {
-    const aidant = unAidant().construis();
-    await entrepotAidant.persiste(aidant);
-
-    const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
-      adaptateurServiceChiffrement()
-    );
-
-    expect(
-      await entrepotAidantExtraction.rechercheAidantSansDiagnostic()
-    ).toStrictEqual<AidantExtraction[]>([
-      {
-        identifiant: aidant.identifiant,
-        nomPrenom: aidant.nomPrenom,
-        email: aidant.email,
-        compteCree: aidant.dateSignatureCGU!,
-        departements: aidant.preferences.departements,
-        entite: '',
-      },
-    ]);
-  });
-
-  it('Récupère uniquement les Aidants sans diagnostic', async () => {
-    const utilisateurInscrit = unUtilisateurInscrit().construis();
-    await entrepotUtilisateurInscritPostgres.persiste(utilisateurInscrit);
-    const aidant = unAidant().construis();
-    await entrepotAidant.persiste(aidant);
-
-    const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
-      adaptateurServiceChiffrement()
-    );
-
-    expect(
-      await entrepotAidantExtraction.rechercheAidantSansDiagnostic()
-    ).toStrictEqual<AidantExtraction[]>([
-      {
-        identifiant: aidant.identifiant,
-        nomPrenom: aidant.nomPrenom,
-        email: aidant.email,
-        compteCree: aidant.dateSignatureCGU!,
-        departements: aidant.preferences.departements,
-        entite: '',
-      },
-    ]);
-  });
-
-  it('Récupère un Aidant sans diagnostic avec son entité et ses départements', async () => {
-    const aidant = unAidant()
-      .faisantPartieDeEntite('ServicePublic')
-      .ayantPourDepartements([gironde, allier])
-      .construis();
-    const serviceDeChiffrement = new FauxServiceDeChiffrement(
-      new Map([
-        [aidant.nomPrenom, 'abcd'],
-        [aidant.email, 'efgh'],
-        [aidant.entite!.nom!, 'ijkl'],
-      ])
-    );
-    const entrepotAidant = new EntrepotAidantPostgres(serviceDeChiffrement);
-    await entrepotAidant.persiste(aidant);
-
-    const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
-      serviceDeChiffrement
-    );
-
-    expect(
-      await entrepotAidantExtraction.rechercheAidantSansDiagnostic()
-    ).toStrictEqual<AidantExtraction[]>([
-      {
-        identifiant: aidant.identifiant,
-        nomPrenom: aidant.nomPrenom,
-        email: aidant.email,
-        compteCree: aidant.dateSignatureCGU!,
-        departements: aidant.preferences.departements,
-        entite: aidant.entite!.nom!,
-      },
-    ]);
-  });
-
-  it('Récupère un Aidant avec ses diagnostic, son entité et ses départements', async () => {
-    const aidant = unAidant()
-      .faisantPartieDeEntite('ServicePublic')
-      .ayantPourDepartements([gironde, allier])
-      .construis();
-    const serviceDeChiffrement = new FauxServiceDeChiffrement(
-      new Map([
-        [aidant.nomPrenom, 'mnop'],
-        [aidant.email, 'qrst'],
-        [aidant.entite!.nom!, 'uvwx'],
-      ])
-    );
-    const entrepotAidant = new EntrepotAidantPostgres(serviceDeChiffrement);
-    await entrepotAidant.persiste(aidant);
-
-    const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
-      serviceDeChiffrement
-    );
-
-    expect(
-      await entrepotAidantExtraction.rechercheAidantAvecNombreDeDiagnostics()
-    ).toStrictEqual<AidantExtraction[]>([
-      {
-        identifiant: aidant.identifiant,
-        nomPrenom: aidant.nomPrenom,
-        email: aidant.email,
-        compteCree: aidant.dateSignatureCGU!,
-        departements: aidant.preferences.departements,
-        entite: aidant.entite!.nom!,
-        nombreDiagnostics: 0,
-      },
-    ]);
-  });
-
-  it('Récupère les Aidants ayant fait exactement 1 diagnostic', async () => {
-    const premierAidant = unAidant().construis();
-    const secondAidant = unAidant().construis();
-    await entrepotAidant.persiste(premierAidant);
-    await entrepotAidant.persiste(secondAidant);
-    await entrepotRelation.persiste(
-      unTupleAidantInitieDiagnostic(
-        premierAidant.identifiant,
-        crypto.randomUUID()
-      )
-    );
-    await entrepotRelation.persiste(
-      unTupleAidantInitieDiagnostic(
-        secondAidant.identifiant,
-        crypto.randomUUID()
-      )
-    );
-
-    const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
-      adaptateurServiceChiffrement()
-    );
-
-    assert.sameDeepMembers(
-      await entrepotAidantExtraction.rechercheAidantAyantExactementNDiagnostics(
-        1
-      ),
-      [
-        {
-          identifiant: premierAidant.identifiant,
-          nomPrenom: premierAidant.nomPrenom,
-          email: premierAidant.email,
-          compteCree: premierAidant.dateSignatureCGU!,
-          departements: premierAidant.preferences.departements,
-          entite: '',
-        },
-        {
-          identifiant: secondAidant.identifiant,
-          nomPrenom: secondAidant.nomPrenom,
-          email: secondAidant.email,
-          compteCree: secondAidant.dateSignatureCGU!,
-          departements: premierAidant.preferences.departements,
-          entite: '',
-        },
-      ]
-    );
-  });
-
-  it('Récupère les Aidants avec leur nombre de diagnostics', async () => {
-    const premierAidant = unAidant().construis();
-    const secondAidant = unAidant().construis();
-    const troisiemeAidant = unAidant().construis();
-    await entrepotAidant.persiste(premierAidant);
-    await entrepotAidant.persiste(secondAidant);
-    await entrepotAidant.persiste(troisiemeAidant);
-    await entrepotRelation.persiste(
-      unTupleAidantInitieDiagnostic(
-        premierAidant.identifiant,
-        crypto.randomUUID()
-      )
-    );
-    await entrepotRelation.persiste(
-      unTupleAidantInitieDiagnostic(
-        premierAidant.identifiant,
-        crypto.randomUUID()
-      )
-    );
-    await entrepotRelation.persiste(
-      unTupleAidantInitieDiagnostic(
-        secondAidant.identifiant,
-        crypto.randomUUID()
-      )
-    );
-
-    const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
-      adaptateurServiceChiffrement()
-    );
-
-    assert.sameDeepMembers(
-      await entrepotAidantExtraction.rechercheAidantAvecNombreDeDiagnostics(),
-      [
-        {
-          identifiant: premierAidant.identifiant,
-          nomPrenom: premierAidant.nomPrenom,
-          email: premierAidant.email,
-          nombreDiagnostics: 2,
-          compteCree: premierAidant.dateSignatureCGU!,
-          departements: premierAidant.preferences.departements,
-          entite: '',
-        },
-        {
-          identifiant: secondAidant.identifiant,
-          nomPrenom: secondAidant.nomPrenom,
-          email: secondAidant.email,
-          nombreDiagnostics: 1,
-          compteCree: secondAidant.dateSignatureCGU!,
-          departements: premierAidant.preferences.departements,
-          entite: '',
-        },
-        {
-          identifiant: troisiemeAidant.identifiant,
-          nomPrenom: troisiemeAidant.nomPrenom,
-          email: troisiemeAidant.email,
-          nombreDiagnostics: 0,
-          compteCree: troisiemeAidant.dateSignatureCGU!,
-          departements: premierAidant.preferences.departements,
-          entite: '',
-        },
-      ]
-    );
-  });
-
-  it('Récupère uniquement les Aidants avec leur nombre de diagnostics', async () => {
-    const premierAidant = unAidant().construis();
-    const utilisateurInscrit = unUtilisateurInscrit().construis();
-    await entrepotUtilisateurInscritPostgres.persiste(utilisateurInscrit);
-    await entrepotAidant.persiste(premierAidant);
-    await entrepotRelation.persiste(
-      unTupleAidantInitieDiagnostic(
-        premierAidant.identifiant,
-        crypto.randomUUID()
-      )
-    );
-
-    const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
-      adaptateurServiceChiffrement()
-    );
-
-    assert.sameDeepMembers(
-      await entrepotAidantExtraction.rechercheAidantAvecNombreDeDiagnostics(),
-      [
-        {
-          identifiant: premierAidant.identifiant,
-          nomPrenom: premierAidant.nomPrenom,
-          email: premierAidant.email,
-          nombreDiagnostics: 1,
-          compteCree: premierAidant.dateSignatureCGU!,
-          departements: premierAidant.preferences.departements,
-          entite: '',
-        },
-      ]
-    );
-  });
-
-  it("Ne récupère pas d'Aidant", async () => {
-    const aidant = unAidant().construis();
-    await entrepotAidant.persiste(aidant);
-    await entrepotRelation.persiste(
-      unTupleAidantInitieDiagnostic(aidant.identifiant, crypto.randomUUID())
-    );
-
-    const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
-      adaptateurServiceChiffrement()
-    );
-
-    expect(
-      await entrepotAidantExtraction.rechercheAidantAyantAuMoinsNDiagnostics(2)
-    ).toStrictEqual<Aidant[]>([]);
-  });
-});
-
-describe('Entrepot Annuaire Aidants Postgres', () => {
-  beforeEach(async () => await nettoieLaBaseDeDonneesAidants());
-  it('Retourne les Aidants ayant consenti à apparaître dans l’Annuaire', async () => {
-    const premierAidantSansConsentement = unAidant().construis();
-    const secondAidantSansConsentement = unAidant().construis();
-    const premierAidantAvecConsentement = unAidant()
-      .ayantConsentiPourLAnnuaire()
-      .construis();
-    const secondAidantAvecConsentement = unAidant()
-      .ayantConsentiPourLAnnuaire(TypeAffichageAnnuaire.PRENOM_N)
-      .construis();
-    const entrepotAidant = new EntrepotAidantPostgres(
-      new ServiceDeChiffrementClair()
-    );
-    await entrepotAidant.persiste(premierAidantAvecConsentement);
-    await entrepotAidant.persiste(secondAidantAvecConsentement);
-    await entrepotAidant.persiste(premierAidantSansConsentement);
-    await entrepotAidant.persiste(secondAidantSansConsentement);
-
-    const tousLesAidants = await new EntrepotAnnuaireAidantsPostgres(
-      new ServiceDeChiffrementClair()
-    ).rechercheParCriteres();
-
-    expect(tousLesAidants).toStrictEqual<AnnuaireAidant[]>([
-      {
-        identifiant: premierAidantAvecConsentement.identifiant,
-        nomPrenom: premierAidantAvecConsentement.nomPrenom,
-        departements: premierAidantAvecConsentement.preferences.departements,
-      },
-      {
-        identifiant: secondAidantAvecConsentement.identifiant,
-        nomPrenom:
-          secondAidantAvecConsentement.preferences.nomAffichageAnnuaire,
-        departements: secondAidantAvecConsentement.preferences.departements,
-      },
-    ]);
-  });
-
-  it('Utilise le service de chiffrement pour déchiffrer le nom de l’Aidant', async () => {
-    const aidant = unAidant()
-      .avecUnNomPrenom('Jean Dupont')
-      .ayantConsentiPourLAnnuaire()
-      .construis();
-    const serviceDeChiffrement = new FauxServiceDeChiffrement(
-      new Map([[aidant.nomPrenom, 'ccc']])
-    );
-    const entrepotAidant = new EntrepotAidantPostgres(serviceDeChiffrement);
-    await entrepotAidant.persiste(aidant);
-
-    const tousLesAidants = await new EntrepotAnnuaireAidantsPostgres(
-      serviceDeChiffrement
-    ).rechercheParCriteres();
-
-    expect(tousLesAidants).toStrictEqual<AnnuaireAidant[]>([
-      {
-        identifiant: aidant.identifiant,
-        nomPrenom: 'Jean Dupont',
-        departements: aidant.preferences.departements,
-      },
-    ]);
-  });
-
-  describe('Lorsque l’on filtre', () => {
-    describe('Par territoire', () => {
-      it('Retourne les Aidants pouvant intervenir dans le département', async () => {
-        const premierAidantAvecConsentement = unAidant()
-          .ayantConsentiPourLAnnuaire()
-          .ayantPourDepartements([departements[0], departements[32]])
+      it('Persiste les types d’entités de l’Aidant', async () => {
+        const organisationsPubliques: EntitesOrganisationsPubliques = {
+          nom: 'Organisations publiques',
+          libelle:
+            'Organisations publiques (ex. collectivité, administration, etc.)',
+        };
+        const associations: EntitesAssociations = {
+          nom: 'Associations',
+          libelle: 'Associations (ex. association loi 1901, GIP)',
+        };
+        const aidant = unAidant()
+          .ayantPourTypesEntite([organisationsPubliques, associations])
           .construis();
-        const secondAidantAvecConsentement = unAidant()
-          .ayantConsentiPourLAnnuaire()
-          .ayantPourDepartements([departements[0]])
+
+        await entrepot.persiste(aidant);
+
+        const aidantRecu = await entrepot.lis(aidant.identifiant);
+        expect(aidantRecu.preferences.typesEntites).toStrictEqual<TypesEntites>(
+          [organisationsPubliques, associations]
+        );
+      });
+
+      it('Persiste les départements où l’Aidant souhaite intervenir', async () => {
+        const finistere: Departement = {
+          nom: 'Finistère',
+          code: '29',
+          codeRegion: '53',
+        };
+        const gironde: Departement = {
+          nom: 'Gironde',
+          code: '33',
+          codeRegion: '75',
+        };
+        const gard: Departement = {
+          nom: 'Gard',
+          code: '30',
+          codeRegion: '76',
+        };
+        const aidant = unAidant()
+          .ayantPourDepartements([finistere, gironde, gard])
+          .construis();
+
+        await entrepot.persiste(aidant);
+
+        const aidantRecu = await entrepot.lis(aidant.identifiant);
+        expect(aidantRecu.preferences.departements).toStrictEqual<
+          Departement[]
+        >([finistere, gard, gironde]);
+      });
+
+      it('Persiste les secteurs d’activité pour lesquels l’Aidant peut intervenir', async () => {
+        const administration: SecteurActivite = {
+          nom: 'Administration',
+        };
+        const industrie: SecteurActivite = {
+          nom: 'Industrie',
+        };
+        const aidant = unAidant()
+          .ayantPourSecteursActivite([administration, industrie])
+          .construis();
+
+        await entrepot.persiste(aidant);
+
+        const aidantRecu = await entrepot.lis(aidant.identifiant);
+        expect(aidantRecu.preferences.secteursActivite).toStrictEqual<
+          SecteurActivite[]
+        >([administration, industrie]);
+      });
+    });
+
+    describe('Recherche par email', () => {
+      it("L'aidant est trouvé", async () => {
+        const aidant = unAidant().construis();
+        serviceDeChiffrement.ajoute(aidant.email, 'aaa');
+        serviceDeChiffrement.ajoute(aidant.nomPrenom, 'ccc');
+
+        await entrepot.persiste(aidant);
+
+        const aidantTrouve = await new EntrepotAidantPostgres(
+          serviceDeChiffrement
+        ).rechercheParEmail(aidant.email);
+
+        expect(aidantTrouve).toStrictEqual<Aidant>(aidant);
+      });
+
+      it("Retourne un erreur s'il ne s'agit pas d'un Aidant", async () => {
+        await knex(knexfile)
+          .insert({
+            id: crypto.randomUUID(),
+            type: 'UTILISATEUR_INSCRIT',
+            donnees: { email: 'jean.dupont@utilisateur-inscrit.com' },
+          })
+          .into('utilisateurs_mac');
+
+        const aidantTrouve = new EntrepotAidantPostgres(
+          new ServiceDeChiffrementClair()
+        ).rechercheParEmail('jean.dupont@utilisateur-inscrit.com');
+
+        expect(aidantTrouve).rejects.toStrictEqual(
+          new AggregatNonTrouve('aidant')
+        );
+      });
+
+      it("L'aidant n'est pas trouvé", () => {
+        expect(
+          new EntrepotAidantPostgres(
+            new FauxServiceDeChiffrement(new Map())
+          ).rechercheParEmail('identifiant-inconnu')
+        ).rejects.toThrow(new Error("Le aidant demandé n'existe pas."));
+      });
+    });
+
+    describe('Pour le type Aidant', () => {
+      it('Retourne une erreur s’il ne s’agit pas d’un Aidant', async () => {
+        const id = crypto.randomUUID();
+        await knex(knexfile)
+          .insert({
+            id,
+            type: 'UTILISATEUR_INSCRIT',
+            donnees: { email: 'jean.dupont@utilisateur-inscrit.com' },
+          })
+          .into('utilisateurs_mac');
+
+        const aidantTrouve = new EntrepotAidantPostgres(
+          new ServiceDeChiffrementClair()
+        ).lis(id);
+
+        expect(aidantTrouve).rejects.toStrictEqual(
+          new AggregatNonTrouve('aidant')
+        );
+      });
+
+      it('Retourne uniquement les Aidants', async () => {
+        const aidant = unAidant().construis();
+        const serviceDeChiffrement = new ServiceDeChiffrementClair();
+        entrepot = new EntrepotAidantPostgres(serviceDeChiffrement);
+
+        await entrepot.persiste(aidant);
+        await knex(knexfile)
+          .insert({
+            id: crypto.randomUUID(),
+            type: 'UTILISATEUR_INSCRIT',
+            donnees: { email: 'jean.dupont@utilisateur-inscrit.com' },
+          })
+          .into('utilisateurs_mac');
+
+        const aidants = await new EntrepotAidantPostgres(
+          serviceDeChiffrement
+        ).tous();
+
+        expect(aidants).toStrictEqual<Aidant[]>([aidant]);
+      });
+    });
+
+    describe('Recherche les Aidants correspondant aux critères de l’entité à moins de 2 diagnostics sur 30 jours glissant', () => {
+      const creeDeuxDemandesAideEnDatePour = async (
+        aidantAyantPostuleADeuxDemandesAide: Aidant,
+        lesDates: Date[]
+      ) => {
+        const serviceDeChiffrement = new ServiceDeChiffrementClair();
+        const entrepotAideConcret = new EntrepotAideConcret(
+          serviceDeChiffrement,
+          new AdaptateurRepertoireDeContactsMemoire(),
+          new EntrepotAideBrevoMemoire()
+        );
+        const premiereDemande = uneDemandeAide()
+          .avecUneDateDeSignatureDesCGU(lesDates[0])
+          .construis();
+        const secondeDemande = uneDemandeAide()
+          .avecUneDateDeSignatureDesCGU(lesDates[1])
+          .construis();
+        await entrepotAideConcret.persiste(premiereDemande);
+        await entrepotAideConcret.persiste(secondeDemande);
+        const entrepotRelation = new EntrepotRelationPostgres();
+        await entrepotRelation.persiste(
+          unTupleAttributionDemandeAideAAidant(
+            premiereDemande.identifiant,
+            aidantAyantPostuleADeuxDemandesAide.identifiant
+          )
+        );
+        await entrepotRelation.persiste(
+          unTupleAttributionDemandeAideAAidant(
+            secondeDemande.identifiant,
+            aidantAyantPostuleADeuxDemandesAide.identifiant
+          )
+        );
+      };
+
+      it('recherche les Aidants correspondants aux 3 critères', async () => {
+        const unAidantEnGirondeDansLesTransportsAssociatifs = unAidant()
+          .ayantPourDepartements([gironde])
+          .ayantPourSecteursActivite([{ nom: 'Transports' }])
+          .ayantPourTypesEntite([associations])
+          .construis();
+        const unAidantEnAllierPourAdministrationPublique = unAidant()
+          .ayantPourDepartements([allier])
+          .ayantPourTypesEntite([entitesPubliques])
+          .ayantPourSecteursActivite([{ nom: 'Administration' }])
           .construis();
         const entrepotAidant = new EntrepotAidantPostgres(
           new ServiceDeChiffrementClair()
         );
-        await entrepotAidant.persiste(premierAidantAvecConsentement);
-        await entrepotAidant.persiste(secondAidantAvecConsentement);
+        await entrepotAidant.persiste(
+          unAidantEnGirondeDansLesTransportsAssociatifs
+        );
+        await entrepotAidant.persiste(
+          unAidantEnAllierPourAdministrationPublique
+        );
 
-        const tousLesAidants = await new EntrepotAnnuaireAidantsPostgres(
-          new ServiceDeChiffrementClair()
-        ).rechercheParCriteres({ departement: 'Gers' });
+        const aidantsTrouvesEnGironde =
+          await entrepotAidant.lesAidantsCorrespondantAuxCriteresDeEntiteAMoinsDe2DiagsSur30JoursGlissant(
+            {
+              departement: gironde,
+              secteursActivite: [{ nom: 'Transports' }],
+              typeEntite: associations,
+            }
+          );
 
-        expect(tousLesAidants).toStrictEqual<AnnuaireAidant[]>([
-          {
-            identifiant: premierAidantAvecConsentement.identifiant,
-            nomPrenom: premierAidantAvecConsentement.nomPrenom,
-            departements: [departements[0], departements[32]],
-          },
+        expect(aidantsTrouvesEnGironde).toStrictEqual<Aidant[]>([
+          unAidantEnGirondeDansLesTransportsAssociatifs,
         ]);
       });
+
+      it('recherche les Aidants de manière disctincte', async () => {
+        const unAidantEnGirondeDansLesTransportsAssociatifs = unAidant()
+          .ayantPourDepartements([gironde])
+          .ayantPourSecteursActivite([{ nom: 'Transports' }])
+          .ayantPourTypesEntite([associations])
+          .construis();
+        const unAidantEnAllierPourAdministrationPublique = unAidant()
+          .ayantPourDepartements([allier])
+          .ayantPourTypesEntite([entitesPubliques])
+          .ayantPourSecteursActivite([
+            { nom: 'Administration' },
+            { nom: 'Tertiaire' },
+          ])
+          .construis();
+        const entrepotAidant = new EntrepotAidantPostgres(
+          new ServiceDeChiffrementClair()
+        );
+        await entrepotAidant.persiste(
+          unAidantEnGirondeDansLesTransportsAssociatifs
+        );
+        await entrepotAidant.persiste(
+          unAidantEnAllierPourAdministrationPublique
+        );
+
+        const aidantsTrouvesEnGironde =
+          await entrepotAidant.lesAidantsCorrespondantAuxCriteresDeEntiteAMoinsDe2DiagsSur30JoursGlissant(
+            {
+              departement: allier,
+              secteursActivite: [
+                { nom: 'Administration' },
+                { nom: 'Tertiaire' },
+              ],
+              typeEntite: entitesPubliques,
+            }
+          );
+
+        expect(aidantsTrouvesEnGironde).toStrictEqual<Aidant[]>([
+          unAidantEnAllierPourAdministrationPublique,
+        ]);
+      });
+
+      it('Retourne un Aidant parmi 2', async () => {
+        const entrepotAidant = new EntrepotAidantPostgres(
+          new ServiceDeChiffrementClair()
+        );
+        FournisseurHorlogeDeTest.initialise(
+          new Date('2025-03-19T13:50:00.000Z')
+        );
+        const aidantAyantPostuleADeuxDemandesAide = unAidant()
+          .ayantPourDepartements([finistere])
+          .ayantPourSecteursActivite([{ nom: 'Transports' }])
+          .ayantPourTypesEntite([entitesPubliques])
+          .avecUnEmail('aidant-avec-deux-demandes@mail.con')
+          .avecUnNomPrenom('Jean DUPONT')
+          .construis();
+        const secondAidant = unAidant()
+          .ayantPourDepartements([finistere])
+          .ayantPourSecteursActivite([{ nom: 'Transports' }])
+          .ayantPourTypesEntite([entitesPubliques])
+          .avecUnEmail('aidant-qui-matche@mail.con')
+          .avecUnNomPrenom('Jean MARTIN')
+          .construis();
+        await entrepotAidant.persiste(aidantAyantPostuleADeuxDemandesAide);
+        await entrepotAidant.persiste(secondAidant);
+        await creeDeuxDemandesAideEnDatePour(
+          aidantAyantPostuleADeuxDemandesAide,
+          [
+            new Date('2025-02-21T14:50:00.000Z'),
+            new Date('2025-03-15T08:50:00.000Z'),
+          ]
+        );
+
+        const lesAidantsRetournes =
+          await entrepotAidant.lesAidantsCorrespondantAuxCriteresDeEntiteAMoinsDe2DiagsSur30JoursGlissant(
+            {
+              departement: finistere,
+              secteursActivite: [{ nom: 'Transports' }],
+              typeEntite: entitesPubliques,
+            }
+          );
+
+        expect(lesAidantsRetournes).toHaveLength(1);
+        expect(lesAidantsRetournes[0].email).toBe('aidant-qui-matche@mail.con');
+        expect(lesAidantsRetournes[0].nomPrenom).toBe('Jean MARTIN');
+      });
+
+      it('Retourne 2 aidants', async () => {
+        const entrepotAidant = new EntrepotAidantPostgres(
+          new ServiceDeChiffrementClair()
+        );
+        FournisseurHorlogeDeTest.initialise(
+          new Date('2025-03-19T13:50:00.000Z')
+        );
+        const aidantPouvantANouveauMatcher = unAidant()
+          .ayantPourDepartements([finistere])
+          .ayantPourSecteursActivite([{ nom: 'Transports' }])
+          .ayantPourTypesEntite([entitesPubliques])
+          .avecUnEmail('aidant-avec-deux-demandes@mail.con')
+          .avecUnNomPrenom('Jean DUPONT')
+          .construis();
+        const secondAidant = unAidant()
+          .ayantPourDepartements([finistere])
+          .ayantPourSecteursActivite([{ nom: 'Transports' }])
+          .ayantPourTypesEntite([entitesPubliques])
+          .avecUnEmail('aidant-qui-matche@mail.con')
+          .avecUnNomPrenom('Jean MARTIN')
+          .construis();
+        await entrepotAidant.persiste(aidantPouvantANouveauMatcher);
+        await entrepotAidant.persiste(secondAidant);
+        await creeDeuxDemandesAideEnDatePour(aidantPouvantANouveauMatcher, [
+          new Date('2025-02-17T13:49:00.000Z'),
+          new Date('2025-03-15T08:50:00.000Z'),
+        ]);
+
+        const lesAidantsRetournes =
+          await entrepotAidant.lesAidantsCorrespondantAuxCriteresDeEntiteAMoinsDe2DiagsSur30JoursGlissant(
+            {
+              departement: finistere,
+              secteursActivite: [{ nom: 'Transports' }],
+              typeEntite: entitesPubliques,
+            }
+          );
+
+        expect(lesAidantsRetournes).toHaveLength(2);
+        expect(lesAidantsRetournes.map((a) => a.email)).toEqual(
+          expect.arrayContaining([
+            'aidant-qui-matche@mail.con',
+            'aidant-avec-deux-demandes@mail.con',
+          ])
+        );
+      });
+    });
+  });
+
+  describe('EntrepotStatistiquesAidant', () => {
+    const entrepotAidant = new EntrepotAidantPostgres(
+      adaptateurServiceChiffrement()
+    );
+    const entrepotUtilisateurInscritPostgres =
+      new EntrepotUtilisateurInscritPostgres(adaptateurServiceChiffrement());
+
+    beforeEach(async () => {
+      await nettoieLaBaseDeDonneesAidants();
+      await nettoieLaBaseDeDonneesRelations();
+    });
+    const entrepotRelation = new EntrepotRelationPostgres();
+
+    it('Récupère un Aidant ayant plus de 2 diagnostics', async () => {
+      const aidant = unAidant().construis();
+      await entrepotAidant.persiste(aidant);
+      await entrepotRelation.persiste(
+        unTupleAidantInitieDiagnostic(aidant.identifiant, crypto.randomUUID())
+      );
+      await entrepotRelation.persiste(
+        unTupleAidantInitieDiagnostic(aidant.identifiant, crypto.randomUUID())
+      );
+
+      const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
+        adaptateurServiceChiffrement()
+      );
+
+      expect(
+        await entrepotAidantExtraction.rechercheAidantAyantAuMoinsNDiagnostics(
+          2
+        )
+      ).toStrictEqual<AidantExtraction[]>([
+        {
+          identifiant: aidant.identifiant,
+          nomPrenom: aidant.nomPrenom,
+          email: aidant.email,
+          compteCree: aidant.dateSignatureCGU!,
+          departements: aidant.preferences.departements,
+          entite: '',
+        },
+      ]);
     });
 
-    describe('Par nature de l‘entité', () => {
-      it.each(typesEntites)(
-        'Retourne les Aidants pouvant intervenir pour une $nom',
-        async (typeEntite) => {
+    it('Récupère un Aidant sans diagnostic', async () => {
+      const aidant = unAidant().construis();
+      await entrepotAidant.persiste(aidant);
+
+      const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
+        adaptateurServiceChiffrement()
+      );
+
+      expect(
+        await entrepotAidantExtraction.rechercheAidantSansDiagnostic()
+      ).toStrictEqual<AidantExtraction[]>([
+        {
+          identifiant: aidant.identifiant,
+          nomPrenom: aidant.nomPrenom,
+          email: aidant.email,
+          compteCree: aidant.dateSignatureCGU!,
+          departements: aidant.preferences.departements,
+          entite: '',
+        },
+      ]);
+    });
+
+    it('Récupère uniquement les Aidants sans diagnostic', async () => {
+      const utilisateurInscrit = unUtilisateurInscrit().construis();
+      await entrepotUtilisateurInscritPostgres.persiste(utilisateurInscrit);
+      const aidant = unAidant().construis();
+      await entrepotAidant.persiste(aidant);
+
+      const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
+        adaptateurServiceChiffrement()
+      );
+
+      expect(
+        await entrepotAidantExtraction.rechercheAidantSansDiagnostic()
+      ).toStrictEqual<AidantExtraction[]>([
+        {
+          identifiant: aidant.identifiant,
+          nomPrenom: aidant.nomPrenom,
+          email: aidant.email,
+          compteCree: aidant.dateSignatureCGU!,
+          departements: aidant.preferences.departements,
+          entite: '',
+        },
+      ]);
+    });
+
+    it('Récupère un Aidant sans diagnostic avec son entité et ses départements', async () => {
+      const aidant = unAidant()
+        .faisantPartieDeEntite('ServicePublic')
+        .ayantPourDepartements([gironde, allier])
+        .construis();
+      const serviceDeChiffrement = new FauxServiceDeChiffrement(
+        new Map([
+          [aidant.nomPrenom, 'abcd'],
+          [aidant.email, 'efgh'],
+          [aidant.entite!.nom!, 'ijkl'],
+        ])
+      );
+      const entrepotAidant = new EntrepotAidantPostgres(serviceDeChiffrement);
+      await entrepotAidant.persiste(aidant);
+
+      const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
+        serviceDeChiffrement
+      );
+
+      expect(
+        await entrepotAidantExtraction.rechercheAidantSansDiagnostic()
+      ).toStrictEqual<AidantExtraction[]>([
+        {
+          identifiant: aidant.identifiant,
+          nomPrenom: aidant.nomPrenom,
+          email: aidant.email,
+          compteCree: aidant.dateSignatureCGU!,
+          departements: aidant.preferences.departements,
+          entite: aidant.entite!.nom!,
+        },
+      ]);
+    });
+
+    it('Récupère un Aidant avec ses diagnostic, son entité et ses départements', async () => {
+      const aidant = unAidant()
+        .faisantPartieDeEntite('ServicePublic')
+        .ayantPourDepartements([gironde, allier])
+        .construis();
+      const serviceDeChiffrement = new FauxServiceDeChiffrement(
+        new Map([
+          [aidant.nomPrenom, 'mnop'],
+          [aidant.email, 'qrst'],
+          [aidant.entite!.nom!, 'uvwx'],
+        ])
+      );
+      const entrepotAidant = new EntrepotAidantPostgres(serviceDeChiffrement);
+      await entrepotAidant.persiste(aidant);
+
+      const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
+        serviceDeChiffrement
+      );
+
+      expect(
+        await entrepotAidantExtraction.rechercheAidantAvecNombreDeDiagnostics()
+      ).toStrictEqual<AidantExtraction[]>([
+        {
+          identifiant: aidant.identifiant,
+          nomPrenom: aidant.nomPrenom,
+          email: aidant.email,
+          compteCree: aidant.dateSignatureCGU!,
+          departements: aidant.preferences.departements,
+          entite: aidant.entite!.nom!,
+          nombreDiagnostics: 0,
+        },
+      ]);
+    });
+
+    it('Récupère les Aidants ayant fait exactement 1 diagnostic', async () => {
+      const premierAidant = unAidant().construis();
+      const secondAidant = unAidant().construis();
+      await entrepotAidant.persiste(premierAidant);
+      await entrepotAidant.persiste(secondAidant);
+      await entrepotRelation.persiste(
+        unTupleAidantInitieDiagnostic(
+          premierAidant.identifiant,
+          crypto.randomUUID()
+        )
+      );
+      await entrepotRelation.persiste(
+        unTupleAidantInitieDiagnostic(
+          secondAidant.identifiant,
+          crypto.randomUUID()
+        )
+      );
+
+      const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
+        adaptateurServiceChiffrement()
+      );
+
+      assert.sameDeepMembers(
+        await entrepotAidantExtraction.rechercheAidantAyantExactementNDiagnostics(
+          1
+        ),
+        [
+          {
+            identifiant: premierAidant.identifiant,
+            nomPrenom: premierAidant.nomPrenom,
+            email: premierAidant.email,
+            compteCree: premierAidant.dateSignatureCGU!,
+            departements: premierAidant.preferences.departements,
+            entite: '',
+          },
+          {
+            identifiant: secondAidant.identifiant,
+            nomPrenom: secondAidant.nomPrenom,
+            email: secondAidant.email,
+            compteCree: secondAidant.dateSignatureCGU!,
+            departements: premierAidant.preferences.departements,
+            entite: '',
+          },
+        ]
+      );
+    });
+
+    it('Récupère les Aidants avec leur nombre de diagnostics', async () => {
+      const premierAidant = unAidant().construis();
+      const secondAidant = unAidant().construis();
+      const troisiemeAidant = unAidant().construis();
+      await entrepotAidant.persiste(premierAidant);
+      await entrepotAidant.persiste(secondAidant);
+      await entrepotAidant.persiste(troisiemeAidant);
+      await entrepotRelation.persiste(
+        unTupleAidantInitieDiagnostic(
+          premierAidant.identifiant,
+          crypto.randomUUID()
+        )
+      );
+      await entrepotRelation.persiste(
+        unTupleAidantInitieDiagnostic(
+          premierAidant.identifiant,
+          crypto.randomUUID()
+        )
+      );
+      await entrepotRelation.persiste(
+        unTupleAidantInitieDiagnostic(
+          secondAidant.identifiant,
+          crypto.randomUUID()
+        )
+      );
+
+      const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
+        adaptateurServiceChiffrement()
+      );
+
+      assert.sameDeepMembers(
+        await entrepotAidantExtraction.rechercheAidantAvecNombreDeDiagnostics(),
+        [
+          {
+            identifiant: premierAidant.identifiant,
+            nomPrenom: premierAidant.nomPrenom,
+            email: premierAidant.email,
+            nombreDiagnostics: 2,
+            compteCree: premierAidant.dateSignatureCGU!,
+            departements: premierAidant.preferences.departements,
+            entite: '',
+          },
+          {
+            identifiant: secondAidant.identifiant,
+            nomPrenom: secondAidant.nomPrenom,
+            email: secondAidant.email,
+            nombreDiagnostics: 1,
+            compteCree: secondAidant.dateSignatureCGU!,
+            departements: premierAidant.preferences.departements,
+            entite: '',
+          },
+          {
+            identifiant: troisiemeAidant.identifiant,
+            nomPrenom: troisiemeAidant.nomPrenom,
+            email: troisiemeAidant.email,
+            nombreDiagnostics: 0,
+            compteCree: troisiemeAidant.dateSignatureCGU!,
+            departements: premierAidant.preferences.departements,
+            entite: '',
+          },
+        ]
+      );
+    });
+
+    it('Récupère uniquement les Aidants avec leur nombre de diagnostics', async () => {
+      const premierAidant = unAidant().construis();
+      const utilisateurInscrit = unUtilisateurInscrit().construis();
+      await entrepotUtilisateurInscritPostgres.persiste(utilisateurInscrit);
+      await entrepotAidant.persiste(premierAidant);
+      await entrepotRelation.persiste(
+        unTupleAidantInitieDiagnostic(
+          premierAidant.identifiant,
+          crypto.randomUUID()
+        )
+      );
+
+      const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
+        adaptateurServiceChiffrement()
+      );
+
+      assert.sameDeepMembers(
+        await entrepotAidantExtraction.rechercheAidantAvecNombreDeDiagnostics(),
+        [
+          {
+            identifiant: premierAidant.identifiant,
+            nomPrenom: premierAidant.nomPrenom,
+            email: premierAidant.email,
+            nombreDiagnostics: 1,
+            compteCree: premierAidant.dateSignatureCGU!,
+            departements: premierAidant.preferences.departements,
+            entite: '',
+          },
+        ]
+      );
+    });
+
+    it("Ne récupère pas d'Aidant", async () => {
+      const aidant = unAidant().construis();
+      await entrepotAidant.persiste(aidant);
+      await entrepotRelation.persiste(
+        unTupleAidantInitieDiagnostic(aidant.identifiant, crypto.randomUUID())
+      );
+
+      const entrepotAidantExtraction = new EntrepotStatistiquesAidantPostgres(
+        adaptateurServiceChiffrement()
+      );
+
+      expect(
+        await entrepotAidantExtraction.rechercheAidantAyantAuMoinsNDiagnostics(
+          2
+        )
+      ).toStrictEqual<Aidant[]>([]);
+    });
+  });
+
+  describe('Entrepot Annuaire Aidants Postgres', () => {
+    beforeEach(async () => await nettoieLaBaseDeDonneesAidants());
+    it('Retourne les Aidants ayant consenti à apparaître dans l’Annuaire', async () => {
+      const premierAidantSansConsentement = unAidant().construis();
+      const secondAidantSansConsentement = unAidant().construis();
+      const premierAidantAvecConsentement = unAidant()
+        .ayantConsentiPourLAnnuaire()
+        .construis();
+      const secondAidantAvecConsentement = unAidant()
+        .ayantConsentiPourLAnnuaire(TypeAffichageAnnuaire.PRENOM_N)
+        .construis();
+      const entrepotAidant = new EntrepotAidantPostgres(
+        new ServiceDeChiffrementClair()
+      );
+      await entrepotAidant.persiste(premierAidantAvecConsentement);
+      await entrepotAidant.persiste(secondAidantAvecConsentement);
+      await entrepotAidant.persiste(premierAidantSansConsentement);
+      await entrepotAidant.persiste(secondAidantSansConsentement);
+
+      const tousLesAidants = await new EntrepotAnnuaireAidantsPostgres(
+        new ServiceDeChiffrementClair()
+      ).rechercheParCriteres();
+
+      expect(tousLesAidants).toStrictEqual<AnnuaireAidant[]>([
+        {
+          identifiant: premierAidantAvecConsentement.identifiant,
+          nomPrenom: premierAidantAvecConsentement.nomPrenom,
+          departements: premierAidantAvecConsentement.preferences.departements,
+        },
+        {
+          identifiant: secondAidantAvecConsentement.identifiant,
+          nomPrenom:
+            secondAidantAvecConsentement.preferences.nomAffichageAnnuaire,
+          departements: secondAidantAvecConsentement.preferences.departements,
+        },
+      ]);
+    });
+
+    it('Utilise le service de chiffrement pour déchiffrer le nom de l’Aidant', async () => {
+      const aidant = unAidant()
+        .avecUnNomPrenom('Jean Dupont')
+        .ayantConsentiPourLAnnuaire()
+        .construis();
+      const serviceDeChiffrement = new FauxServiceDeChiffrement(
+        new Map([[aidant.nomPrenom, 'ccc']])
+      );
+      const entrepotAidant = new EntrepotAidantPostgres(serviceDeChiffrement);
+      await entrepotAidant.persiste(aidant);
+
+      const tousLesAidants = await new EntrepotAnnuaireAidantsPostgres(
+        serviceDeChiffrement
+      ).rechercheParCriteres();
+
+      expect(tousLesAidants).toStrictEqual<AnnuaireAidant[]>([
+        {
+          identifiant: aidant.identifiant,
+          nomPrenom: 'Jean Dupont',
+          departements: aidant.preferences.departements,
+        },
+      ]);
+    });
+
+    describe('Lorsque l’on filtre', () => {
+      describe('Par territoire', () => {
+        it('Retourne les Aidants pouvant intervenir dans le département', async () => {
           const premierAidantAvecConsentement = unAidant()
             .ayantConsentiPourLAnnuaire()
-            .ayantPourDepartements([gironde])
-            .ayantPourTypesEntite([typeEntite])
+            .ayantPourDepartements([departements[0], departements[32]])
             .construis();
           const secondAidantAvecConsentement = unAidant()
             .ayantConsentiPourLAnnuaire()
-            .ayantPourDepartements([gironde])
+            .ayantPourDepartements([departements[0]])
             .construis();
           const entrepotAidant = new EntrepotAidantPostgres(
             new ServiceDeChiffrementClair()
@@ -1404,55 +1389,63 @@ describe('Entrepot Annuaire Aidants Postgres', () => {
 
           const tousLesAidants = await new EntrepotAnnuaireAidantsPostgres(
             new ServiceDeChiffrementClair()
-          ).rechercheParCriteres({
-            departement: gironde.nom,
-            typeEntite: typeEntite.nom,
-          });
+          ).rechercheParCriteres({ departement: 'Gers' });
 
           expect(tousLesAidants).toStrictEqual<AnnuaireAidant[]>([
             {
               identifiant: premierAidantAvecConsentement.identifiant,
               nomPrenom: premierAidantAvecConsentement.nomPrenom,
-              departements: [gironde],
+              departements: [departements[0], departements[32]],
             },
           ]);
-        }
-      );
+        });
+      });
+
+      describe('Par nature de l‘entité', () => {
+        it.each(typesEntites)(
+          'Retourne les Aidants pouvant intervenir pour une $nom',
+          async (typeEntite) => {
+            const premierAidantAvecConsentement = unAidant()
+              .ayantConsentiPourLAnnuaire()
+              .ayantPourDepartements([gironde])
+              .ayantPourTypesEntite([typeEntite])
+              .construis();
+            const secondAidantAvecConsentement = unAidant()
+              .ayantConsentiPourLAnnuaire()
+              .ayantPourDepartements([gironde])
+              .construis();
+            const entrepotAidant = new EntrepotAidantPostgres(
+              new ServiceDeChiffrementClair()
+            );
+            await entrepotAidant.persiste(premierAidantAvecConsentement);
+            await entrepotAidant.persiste(secondAidantAvecConsentement);
+
+            const tousLesAidants = await new EntrepotAnnuaireAidantsPostgres(
+              new ServiceDeChiffrementClair()
+            ).rechercheParCriteres({
+              departement: gironde.nom,
+              typeEntite: typeEntite.nom,
+            });
+
+            expect(tousLesAidants).toStrictEqual<AnnuaireAidant[]>([
+              {
+                identifiant: premierAidantAvecConsentement.identifiant,
+                nomPrenom: premierAidantAvecConsentement.nomPrenom,
+                departements: [gironde],
+              },
+            ]);
+          }
+        );
+      });
     });
   });
-});
 
-describe('Entrepot Utilisateur', () => {
-  beforeEach(async () => {
-    await nettoieLaBaseDeDonneesUtilisateurs();
-  });
-
-  it('Persiste un utilisateur', async () => {
-    const utilisateur = unUtilisateur().construis();
-    const serviceDeChiffrement = new FauxServiceDeChiffrement(
-      new Map([
-        [utilisateur.identifiantConnexion, 'aaa'],
-        [utilisateur.motDePasse, 'bbb'],
-        [utilisateur.nomPrenom, 'ccc'],
-      ])
-    );
-    const entrepotUtilisateurPostgres = new EntrepotUtilisateurPostgres(
-      serviceDeChiffrement
-    );
-
-    await entrepotUtilisateurPostgres.persiste(utilisateur);
-
-    const utilisateurRecu = await entrepotUtilisateurPostgres.lis(
-      utilisateur.identifiant
-    );
-    expect(utilisateurRecu).toStrictEqual<Utilisateur>({
-      ...utilisateur,
-      motDePasse: 'bbb',
+  describe('Entrepot Utilisateur', () => {
+    beforeEach(async () => {
+      await nettoieLaBaseDeDonneesUtilisateurs();
     });
-  });
 
-  describe('Recherche par identifiant et mot de passe', () => {
-    it("L'utilisateur est trouvé", async () => {
+    it('Persiste un utilisateur', async () => {
       const utilisateur = unUtilisateur().construis();
       const serviceDeChiffrement = new FauxServiceDeChiffrement(
         new Map([
@@ -1464,566 +1457,606 @@ describe('Entrepot Utilisateur', () => {
       const entrepotUtilisateurPostgres = new EntrepotUtilisateurPostgres(
         serviceDeChiffrement
       );
-      await entrepotUtilisateurPostgres.persiste(utilisateur);
 
-      const utilisateurRecu =
-        await entrepotUtilisateurPostgres.rechercheParIdentifiantConnexionEtMotDePasse(
-          utilisateur.identifiantConnexion,
-          utilisateur.motDePasse
-        );
-
-      expect(utilisateurRecu).toStrictEqual<Utilisateur>({
-        ...utilisateur,
-        motDePasse: 'bbb',
-      });
-    });
-
-    it("l'utilisateur n'est pas trouvé", () => {
-      expect(
-        new EntrepotUtilisateurPostgres(
-          new FauxServiceDeChiffrement(new Map())
-        ).rechercheParIdentifiantConnexionEtMotDePasse(
-          'identifiant-inconnu',
-          'mdp'
-        )
-      ).rejects.toThrow(new Error("Le utilisateur demandé n'existe pas."));
-    });
-  });
-
-  describe('Recherche par identifiant', () => {
-    it('L’utilisateur est trouvé', async () => {
-      const utilisateur = unUtilisateur().construis();
-      const serviceDeChiffrement = new FauxServiceDeChiffrement(
-        new Map([
-          [utilisateur.identifiantConnexion, 'aaa'],
-          [utilisateur.motDePasse, 'bbb'],
-          [utilisateur.nomPrenom, 'ccc'],
-        ])
-      );
-      const entrepotUtilisateurPostgres = new EntrepotUtilisateurPostgres(
-        serviceDeChiffrement
-      );
-      await entrepotUtilisateurPostgres.persiste(utilisateur);
-
-      const utilisateurRecu =
-        await entrepotUtilisateurPostgres.rechercheParIdentifiantDeConnexion(
-          utilisateur.identifiantConnexion
-        );
-
-      expect(utilisateurRecu).toStrictEqual<Utilisateur>({
-        ...utilisateur,
-        motDePasse: 'bbb',
-      });
-    });
-
-    it('L’utilisateur n’est pas trouvé', async () => {
-      const entrepotUtilisateurPostgres = new EntrepotUtilisateurPostgres(
-        new ServiceDeChiffrementClair()
-      );
-      expect(
-        entrepotUtilisateurPostgres.rechercheParIdentifiantDeConnexion(
-          'email-inconnu@mail.com'
-        )
-      ).rejects.toThrow(new Error("Le utilisateur demandé n'existe pas."));
-    });
-  });
-
-  describe('Met à jour un utilisateur', () => {
-    it('Met à jour la date de signature des CGU', async () => {
-      const serviceDeChiffrement = new ServiceDeChiffrementClair();
-      const entrepotUtilisateurPostgres = new EntrepotUtilisateurPostgres(
-        serviceDeChiffrement
-      );
-      const dateSignature = new Date(Date.parse('2024-02-04T13:25:17+01:00'));
-      FournisseurHorlogeDeTest.initialise(dateSignature);
-      const utilisateur = unUtilisateur().sansCGUSignees().construis();
-      await entrepotUtilisateurPostgres.persiste(utilisateur);
-
-      utilisateur.dateSignatureCGU = FournisseurHorloge.maintenant();
       await entrepotUtilisateurPostgres.persiste(utilisateur);
 
       const utilisateurRecu = await entrepotUtilisateurPostgres.lis(
         utilisateur.identifiant
       );
-      expect(utilisateurRecu.dateSignatureCGU).toStrictEqual(dateSignature);
-    });
-  });
-});
-
-describe('Entrepot profil aidant', () => {
-  beforeEach(async () => {
-    nettoieLaBaseDeDonneesAidants();
-    nettoieLaBaseDeDonneesUtilisateurs();
-  });
-
-  it('Récupère le profil d’un Aidant', async () => {
-    FournisseurHorlogeDeTest.initialise(new Date());
-    const utilisateur = unUtilisateur().construis();
-    const aidant = unAidant()
-      .avecUnIdentifiant(utilisateur.identifiant)
-      .construis();
-    await new EntrepotUtilisateurPostgres(
-      new ServiceDeChiffrementClair()
-    ).persiste(utilisateur);
-    await new EntrepotAidantPostgres(new ServiceDeChiffrementClair()).persiste(
-      aidant
-    );
-
-    const profilAidant = await new EntrepotProfilAidantPostgres(
-      new ServiceDeChiffrementClair()
-    ).lis(aidant.identifiant);
-
-    expect(profilAidant).toStrictEqual<ProfilAidant>({
-      identifiant: aidant.identifiant,
-      nomPrenom: aidant.nomPrenom,
-      consentementAnnuaire: false,
-      email: aidant.email,
-      dateSignatureCGU: FournisseurHorloge.maintenant(),
-      nomAffichageAnnuaire: aidant.preferences.nomAffichageAnnuaire,
-    });
-  });
-});
-
-describe('Entrepot Utilisateurs MAC', () => {
-  const serviceDeChiffrementClair = new ServiceDeChiffrementClair();
-  const entrepotAidantPostgres = new EntrepotAidantPostgres(
-    new ServiceDeChiffrementClair()
-  );
-  const entrepotUtilisateurInscritPostgres =
-    new EntrepotUtilisateurInscritPostgres(new ServiceDeChiffrementClair());
-  const entrepotUtilisateurMACPostgres = new EntrepotUtilisateurMACPostgres(
-    serviceDeChiffrementClair
-  );
-
-  beforeEach(async () => {
-    nettoieLaBaseDeDonneesAidants();
-  });
-
-  describe('Recherche par identifiant', () => {
-    it('Retourne un utilisateur au profil Aidant', async () => {
-      const aidant = unAidant().construis();
-      await entrepotAidantPostgres.persiste(aidant);
-
-      const utilisateurMAC =
-        await entrepotUtilisateurMACPostgres.rechercheParIdentifiant(
-          aidant.identifiant
-        );
-
-      expect(utilisateurMAC).toStrictEqual<UtilisateurMAC>({
-        identifiant: aidant.identifiant,
-        profil: 'Aidant',
-        email: aidant.email,
-        nomPrenom: aidant.nomPrenom,
-        dateValidationCGU: aidant.dateSignatureCGU!,
-      });
-      expect(serviceDeChiffrementClair.dechiffreAEteAppele()).toBe(true);
-    });
-
-    it('Retourne un utilisateur au profil Gendarme', async () => {
-      const aidant = unAidant().avecUnProfilGendarme().construis();
-      await entrepotAidantPostgres.persiste(aidant);
-
-      const utilisateurMAC =
-        await entrepotUtilisateurMACPostgres.rechercheParIdentifiant(
-          aidant.identifiant
-        );
-
-      expect(utilisateurMAC).toStrictEqual<UtilisateurMAC>({
-        identifiant: aidant.identifiant,
-        profil: 'Gendarme',
-        email: aidant.email,
-        nomPrenom: aidant.nomPrenom,
-        dateValidationCGU: aidant.dateSignatureCGU!,
+      expect(utilisateurRecu).toStrictEqual<Utilisateur>({
+        ...utilisateur,
+        motDePasse: 'bbb',
       });
     });
 
-    it('Retourne un utilisateur au profil Utilisateur Inscrit', async () => {
-      const utilisateurInscrit = unUtilisateurInscrit().construis();
-      await entrepotUtilisateurInscritPostgres.persiste(utilisateurInscrit);
-
-      const utilisateurMAC =
-        await entrepotUtilisateurMACPostgres.rechercheParIdentifiant(
-          utilisateurInscrit.identifiant
+    describe('Recherche par identifiant et mot de passe', () => {
+      it("L'utilisateur est trouvé", async () => {
+        const utilisateur = unUtilisateur().construis();
+        const serviceDeChiffrement = new FauxServiceDeChiffrement(
+          new Map([
+            [utilisateur.identifiantConnexion, 'aaa'],
+            [utilisateur.motDePasse, 'bbb'],
+            [utilisateur.nomPrenom, 'ccc'],
+          ])
         );
+        const entrepotUtilisateurPostgres = new EntrepotUtilisateurPostgres(
+          serviceDeChiffrement
+        );
+        await entrepotUtilisateurPostgres.persiste(utilisateur);
 
-      expect(utilisateurMAC).toStrictEqual<UtilisateurMAC>({
-        identifiant: utilisateurInscrit.identifiant,
-        profil: 'UtilisateurInscrit',
-        nomPrenom: utilisateurInscrit.nomPrenom,
-        email: utilisateurInscrit.email,
-        dateValidationCGU: utilisateurInscrit.dateSignatureCGU!,
+        const utilisateurRecu =
+          await entrepotUtilisateurPostgres.rechercheParIdentifiantConnexionEtMotDePasse(
+            utilisateur.identifiantConnexion,
+            utilisateur.motDePasse
+          );
+
+        expect(utilisateurRecu).toStrictEqual<Utilisateur>({
+          ...utilisateur,
+          motDePasse: 'bbb',
+        });
+      });
+
+      it("l'utilisateur n'est pas trouvé", () => {
+        expect(
+          new EntrepotUtilisateurPostgres(
+            new FauxServiceDeChiffrement(new Map())
+          ).rechercheParIdentifiantConnexionEtMotDePasse(
+            'identifiant-inconnu',
+            'mdp'
+          )
+        ).rejects.toThrow(new Error("Le utilisateur demandé n'existe pas."));
       });
     });
 
-    it("Renvoie une erreur AggregatNonTrouvé si l'utilisateur n'existe pas", async () => {
-      expect(
-        entrepotUtilisateurMACPostgres.rechercheParIdentifiant(
-          crypto.randomUUID()
-        )
-      ).rejects.toThrowError(new AggregatNonTrouve('utilisateur MAC'));
+    describe('Recherche par identifiant', () => {
+      it('L’utilisateur est trouvé', async () => {
+        const utilisateur = unUtilisateur().construis();
+        const serviceDeChiffrement = new FauxServiceDeChiffrement(
+          new Map([
+            [utilisateur.identifiantConnexion, 'aaa'],
+            [utilisateur.motDePasse, 'bbb'],
+            [utilisateur.nomPrenom, 'ccc'],
+          ])
+        );
+        const entrepotUtilisateurPostgres = new EntrepotUtilisateurPostgres(
+          serviceDeChiffrement
+        );
+        await entrepotUtilisateurPostgres.persiste(utilisateur);
+
+        const utilisateurRecu =
+          await entrepotUtilisateurPostgres.rechercheParIdentifiantDeConnexion(
+            utilisateur.identifiantConnexion
+          );
+
+        expect(utilisateurRecu).toStrictEqual<Utilisateur>({
+          ...utilisateur,
+          motDePasse: 'bbb',
+        });
+      });
+
+      it('L’utilisateur n’est pas trouvé', async () => {
+        const entrepotUtilisateurPostgres = new EntrepotUtilisateurPostgres(
+          new ServiceDeChiffrementClair()
+        );
+        expect(
+          entrepotUtilisateurPostgres.rechercheParIdentifiantDeConnexion(
+            'email-inconnu@mail.com'
+          )
+        ).rejects.toThrow(new Error("Le utilisateur demandé n'existe pas."));
+      });
     });
 
-    it('Renvoie la date de validation des CGU', async () => {
-      const dateValidationCGU = new Date(Date.parse('2025-02-04T14:37:22'));
-      const utilisateurInscrit = unUtilisateurInscrit()
-        .avecUneDateDeSignatureDeCGU(dateValidationCGU)
+    describe('Met à jour un utilisateur', () => {
+      it('Met à jour la date de signature des CGU', async () => {
+        const serviceDeChiffrement = new ServiceDeChiffrementClair();
+        const entrepotUtilisateurPostgres = new EntrepotUtilisateurPostgres(
+          serviceDeChiffrement
+        );
+        const dateSignature = new Date(Date.parse('2024-02-04T13:25:17+01:00'));
+        FournisseurHorlogeDeTest.initialise(dateSignature);
+        const utilisateur = unUtilisateur().sansCGUSignees().construis();
+        await entrepotUtilisateurPostgres.persiste(utilisateur);
+
+        utilisateur.dateSignatureCGU = FournisseurHorloge.maintenant();
+        await entrepotUtilisateurPostgres.persiste(utilisateur);
+
+        const utilisateurRecu = await entrepotUtilisateurPostgres.lis(
+          utilisateur.identifiant
+        );
+        expect(utilisateurRecu.dateSignatureCGU).toStrictEqual(dateSignature);
+      });
+    });
+  });
+
+  describe('Entrepot profil aidant', () => {
+    beforeEach(async () => {
+      await nettoieLaBaseDeDonneesAidants();
+      await nettoieLaBaseDeDonneesUtilisateurs();
+    });
+
+    it('Récupère le profil d’un Aidant', async () => {
+      FournisseurHorlogeDeTest.initialise(new Date());
+      const utilisateur = unUtilisateur().construis();
+      const aidant = unAidant()
+        .avecUnIdentifiant(utilisateur.identifiant)
         .construis();
-      await entrepotUtilisateurInscritPostgres.persiste(utilisateurInscrit);
+      await new EntrepotUtilisateurPostgres(
+        new ServiceDeChiffrementClair()
+      ).persiste(utilisateur);
+      await new EntrepotAidantPostgres(
+        new ServiceDeChiffrementClair()
+      ).persiste(aidant);
 
-      const utilisateurMAC =
-        await entrepotUtilisateurMACPostgres.rechercheParIdentifiant(
-          utilisateurInscrit.identifiant
-        );
+      const profilAidant = await new EntrepotProfilAidantPostgres(
+        new ServiceDeChiffrementClair()
+      ).lis(aidant.identifiant);
 
-      expect(utilisateurMAC.dateValidationCGU).toStrictEqual(dateValidationCGU);
+      expect(profilAidant).toStrictEqual<ProfilAidant>({
+        identifiant: aidant.identifiant,
+        nomPrenom: aidant.nomPrenom,
+        consentementAnnuaire: false,
+        email: aidant.email,
+        dateSignatureCGU: FournisseurHorloge.maintenant(),
+        nomAffichageAnnuaire: aidant.preferences.nomAffichageAnnuaire,
+      });
     });
   });
 
-  describe('Recherche par mail', () => {
-    const email = 'jean.dupont@email.com';
-    const nomPrenom = 'Jean Dupont';
-    const fauxServiceDeChiffrement = new FauxServiceDeChiffrement(
-      new Map([
-        [email, 'ccc'],
-        [nomPrenom, 'ddd'],
-      ])
-    );
-    const entrepotUtilisateurMACPostgres = new EntrepotUtilisateurMACPostgres(
-      fauxServiceDeChiffrement
-    );
+  describe('Entrepot Utilisateurs MAC', () => {
+    const serviceDeChiffrementClair = new ServiceDeChiffrementClair();
     const entrepotAidantPostgres = new EntrepotAidantPostgres(
-      fauxServiceDeChiffrement
+      new ServiceDeChiffrementClair()
     );
     const entrepotUtilisateurInscritPostgres =
-      new EntrepotUtilisateurInscritPostgres(fauxServiceDeChiffrement);
+      new EntrepotUtilisateurInscritPostgres(new ServiceDeChiffrementClair());
+    const entrepotUtilisateurMACPostgres = new EntrepotUtilisateurMACPostgres(
+      serviceDeChiffrementClair
+    );
 
-    it('Retourne un utilisateur au profil Aidant', async () => {
-      const aidant = unAidant()
-        .avecUnEmail(email)
-        .avecUnNomPrenom(nomPrenom)
-        .construis();
-      await entrepotAidantPostgres.persiste(aidant);
-
-      const utilisateurMAC =
-        await entrepotUtilisateurMACPostgres.rechercheParMail(aidant.email);
-
-      expect(utilisateurMAC).toStrictEqual<UtilisateurMAC>({
-        identifiant: aidant.identifiant,
-        profil: 'Aidant',
-        nomPrenom: aidant.nomPrenom,
-        email: aidant.email,
-        dateValidationCGU: aidant.dateSignatureCGU!,
-      });
+    beforeEach(async () => {
+      await nettoieLaBaseDeDonneesAidants();
     });
 
-    it('Retourne un utilisateur au profil Gendarme', async () => {
-      const aidant = unAidant()
-        .avecUnEmail(email)
-        .avecUnNomPrenom(nomPrenom)
-        .avecUnProfilGendarme()
-        .construis();
-      await entrepotAidantPostgres.persiste(aidant);
+    describe('Recherche par identifiant', () => {
+      it('Retourne un utilisateur au profil Aidant', async () => {
+        const aidant = unAidant().construis();
+        await entrepotAidantPostgres.persiste(aidant);
 
-      const utilisateurMAC =
-        await entrepotUtilisateurMACPostgres.rechercheParMail(aidant.email);
+        const utilisateurMAC =
+          await entrepotUtilisateurMACPostgres.rechercheParIdentifiant(
+            aidant.identifiant
+          );
 
-      expect(utilisateurMAC).toStrictEqual<UtilisateurMAC>({
-        identifiant: aidant.identifiant,
-        profil: 'Gendarme',
-        nomPrenom: aidant.nomPrenom,
-        email: aidant.email,
-        dateValidationCGU: aidant.dateSignatureCGU!,
+        expect(utilisateurMAC).toStrictEqual<UtilisateurMAC>({
+          identifiant: aidant.identifiant,
+          profil: 'Aidant',
+          email: aidant.email,
+          nomPrenom: aidant.nomPrenom,
+          dateValidationCGU: aidant.dateSignatureCGU!,
+        });
+        expect(serviceDeChiffrementClair.dechiffreAEteAppele()).toBe(true);
       });
-    });
 
-    it('Retourne un utilisateur au profil Utilisateur Inscrit', async () => {
-      const utilisateurInscrit = unUtilisateurInscrit()
-        .avecUnEmail(email)
-        .avecUnNomPrenom(nomPrenom)
-        .construis();
-      await entrepotUtilisateurInscritPostgres.persiste(utilisateurInscrit);
+      it('Retourne un utilisateur au profil Gendarme', async () => {
+        const aidant = unAidant().avecUnProfilGendarme().construis();
+        await entrepotAidantPostgres.persiste(aidant);
 
-      const utilisateurMAC =
-        await entrepotUtilisateurMACPostgres.rechercheParMail(
-          utilisateurInscrit.email
+        const utilisateurMAC =
+          await entrepotUtilisateurMACPostgres.rechercheParIdentifiant(
+            aidant.identifiant
+          );
+
+        expect(utilisateurMAC).toStrictEqual<UtilisateurMAC>({
+          identifiant: aidant.identifiant,
+          profil: 'Gendarme',
+          email: aidant.email,
+          nomPrenom: aidant.nomPrenom,
+          dateValidationCGU: aidant.dateSignatureCGU!,
+        });
+      });
+
+      it('Retourne un utilisateur au profil Utilisateur Inscrit', async () => {
+        const utilisateurInscrit = unUtilisateurInscrit().construis();
+        await entrepotUtilisateurInscritPostgres.persiste(utilisateurInscrit);
+
+        const utilisateurMAC =
+          await entrepotUtilisateurMACPostgres.rechercheParIdentifiant(
+            utilisateurInscrit.identifiant
+          );
+
+        expect(utilisateurMAC).toStrictEqual<UtilisateurMAC>({
+          identifiant: utilisateurInscrit.identifiant,
+          profil: 'UtilisateurInscrit',
+          nomPrenom: utilisateurInscrit.nomPrenom,
+          email: utilisateurInscrit.email,
+          dateValidationCGU: utilisateurInscrit.dateSignatureCGU!,
+        });
+      });
+
+      it("Renvoie une erreur AggregatNonTrouvé si l'utilisateur n'existe pas", async () => {
+        expect(
+          entrepotUtilisateurMACPostgres.rechercheParIdentifiant(
+            crypto.randomUUID()
+          )
+        ).rejects.toThrowError(new AggregatNonTrouve('utilisateur MAC'));
+      });
+
+      it('Renvoie la date de validation des CGU', async () => {
+        const dateValidationCGU = new Date(Date.parse('2025-02-04T14:37:22'));
+        const utilisateurInscrit = unUtilisateurInscrit()
+          .avecUneDateDeSignatureDeCGU(dateValidationCGU)
+          .construis();
+        await entrepotUtilisateurInscritPostgres.persiste(utilisateurInscrit);
+
+        const utilisateurMAC =
+          await entrepotUtilisateurMACPostgres.rechercheParIdentifiant(
+            utilisateurInscrit.identifiant
+          );
+
+        expect(utilisateurMAC.dateValidationCGU).toStrictEqual(
+          dateValidationCGU
         );
-
-      expect(utilisateurMAC).toStrictEqual<UtilisateurMAC>({
-        identifiant: utilisateurInscrit.identifiant,
-        profil: 'UtilisateurInscrit',
-        nomPrenom: utilisateurInscrit.nomPrenom,
-        email: utilisateurInscrit.email,
-        dateValidationCGU: utilisateurInscrit.dateSignatureCGU!,
       });
     });
 
-    it("Renvoie une erreur AggregatNonTrouvé si l'utilisateur n'existe pas", async () => {
-      expect(
-        entrepotUtilisateurMACPostgres.rechercheParMail(
-          'utilisateur-inconnu@email.com'
-        )
-      ).rejects.toThrowError(new AggregatNonTrouve('utilisateur MAC'));
-    });
-
-    it('Renvoie la date de validation des CGU', async () => {
-      const dateValidationCGU = new Date(Date.parse('2025-02-04T14:37:22'));
-      const utilisateurInscrit = unUtilisateurInscrit()
-        .avecUneDateDeSignatureDeCGU(dateValidationCGU)
-        .avecUnEmail(email)
-        .avecUnNomPrenom(nomPrenom)
-        .construis();
-      await entrepotUtilisateurInscritPostgres.persiste(utilisateurInscrit);
-
-      const utilisateurMAC =
-        await entrepotUtilisateurMACPostgres.rechercheParMail(
-          utilisateurInscrit.email
-        );
-
-      expect(utilisateurMAC.dateValidationCGU).toStrictEqual(dateValidationCGU);
-    });
-  });
-
-  describe('Déchiffre', () => {
-    it('Retourne un utilisateur au profil Aidant', async () => {
-      const aidant = unAidant().construis();
-      const fauxServiceChiffrement = new FauxServiceDeChiffrement(
+    describe('Recherche par mail', () => {
+      const email = 'jean.dupont@email.com';
+      const nomPrenom = 'Jean Dupont';
+      const fauxServiceDeChiffrement = new FauxServiceDeChiffrement(
         new Map([
-          [aidant.nomPrenom, 'bbb'],
-          [aidant.email, 'ccc'],
+          [email, 'ccc'],
+          [nomPrenom, 'ddd'],
         ])
       );
-      const entrepotAidantPostgres = new EntrepotAidantPostgres(
-        fauxServiceChiffrement
-      );
       const entrepotUtilisateurMACPostgres = new EntrepotUtilisateurMACPostgres(
-        fauxServiceChiffrement
+        fauxServiceDeChiffrement
       );
-      await entrepotAidantPostgres.persiste(aidant);
+      const entrepotAidantPostgres = new EntrepotAidantPostgres(
+        fauxServiceDeChiffrement
+      );
+      const entrepotUtilisateurInscritPostgres =
+        new EntrepotUtilisateurInscritPostgres(fauxServiceDeChiffrement);
 
-      const utilisateurMAC =
-        await entrepotUtilisateurMACPostgres.rechercheParIdentifiant(
-          aidant.identifiant
+      it('Retourne un utilisateur au profil Aidant', async () => {
+        const aidant = unAidant()
+          .avecUnEmail(email)
+          .avecUnNomPrenom(nomPrenom)
+          .construis();
+        await entrepotAidantPostgres.persiste(aidant);
+
+        const utilisateurMAC =
+          await entrepotUtilisateurMACPostgres.rechercheParMail(aidant.email);
+
+        expect(utilisateurMAC).toStrictEqual<UtilisateurMAC>({
+          identifiant: aidant.identifiant,
+          profil: 'Aidant',
+          nomPrenom: aidant.nomPrenom,
+          email: aidant.email,
+          dateValidationCGU: aidant.dateSignatureCGU!,
+        });
+      });
+
+      it('Retourne un utilisateur au profil Gendarme', async () => {
+        const aidant = unAidant()
+          .avecUnEmail(email)
+          .avecUnNomPrenom(nomPrenom)
+          .avecUnProfilGendarme()
+          .construis();
+        await entrepotAidantPostgres.persiste(aidant);
+
+        const utilisateurMAC =
+          await entrepotUtilisateurMACPostgres.rechercheParMail(aidant.email);
+
+        expect(utilisateurMAC).toStrictEqual<UtilisateurMAC>({
+          identifiant: aidant.identifiant,
+          profil: 'Gendarme',
+          nomPrenom: aidant.nomPrenom,
+          email: aidant.email,
+          dateValidationCGU: aidant.dateSignatureCGU!,
+        });
+      });
+
+      it('Retourne un utilisateur au profil Utilisateur Inscrit', async () => {
+        const utilisateurInscrit = unUtilisateurInscrit()
+          .avecUnEmail(email)
+          .avecUnNomPrenom(nomPrenom)
+          .construis();
+        await entrepotUtilisateurInscritPostgres.persiste(utilisateurInscrit);
+
+        const utilisateurMAC =
+          await entrepotUtilisateurMACPostgres.rechercheParMail(
+            utilisateurInscrit.email
+          );
+
+        expect(utilisateurMAC).toStrictEqual<UtilisateurMAC>({
+          identifiant: utilisateurInscrit.identifiant,
+          profil: 'UtilisateurInscrit',
+          nomPrenom: utilisateurInscrit.nomPrenom,
+          email: utilisateurInscrit.email,
+          dateValidationCGU: utilisateurInscrit.dateSignatureCGU!,
+        });
+      });
+
+      it("Renvoie une erreur AggregatNonTrouvé si l'utilisateur n'existe pas", async () => {
+        expect(
+          entrepotUtilisateurMACPostgres.rechercheParMail(
+            'utilisateur-inconnu@email.com'
+          )
+        ).rejects.toThrowError(new AggregatNonTrouve('utilisateur MAC'));
+      });
+
+      it('Renvoie la date de validation des CGU', async () => {
+        const dateValidationCGU = new Date(Date.parse('2025-02-04T14:37:22'));
+        const utilisateurInscrit = unUtilisateurInscrit()
+          .avecUneDateDeSignatureDeCGU(dateValidationCGU)
+          .avecUnEmail(email)
+          .avecUnNomPrenom(nomPrenom)
+          .construis();
+        await entrepotUtilisateurInscritPostgres.persiste(utilisateurInscrit);
+
+        const utilisateurMAC =
+          await entrepotUtilisateurMACPostgres.rechercheParMail(
+            utilisateurInscrit.email
+          );
+
+        expect(utilisateurMAC.dateValidationCGU).toStrictEqual(
+          dateValidationCGU
         );
+      });
+    });
 
-      expect(utilisateurMAC).toStrictEqual<UtilisateurMAC>({
-        identifiant: aidant.identifiant,
-        profil: 'Aidant',
-        nomPrenom: aidant.nomPrenom,
-        email: aidant.email,
-        dateValidationCGU: aidant.dateSignatureCGU!,
+    describe('Déchiffre', () => {
+      it('Retourne un utilisateur au profil Aidant', async () => {
+        const aidant = unAidant().construis();
+        const fauxServiceChiffrement = new FauxServiceDeChiffrement(
+          new Map([
+            [aidant.nomPrenom, 'bbb'],
+            [aidant.email, 'ccc'],
+          ])
+        );
+        const entrepotAidantPostgres = new EntrepotAidantPostgres(
+          fauxServiceChiffrement
+        );
+        const entrepotUtilisateurMACPostgres =
+          new EntrepotUtilisateurMACPostgres(fauxServiceChiffrement);
+        await entrepotAidantPostgres.persiste(aidant);
+
+        const utilisateurMAC =
+          await entrepotUtilisateurMACPostgres.rechercheParIdentifiant(
+            aidant.identifiant
+          );
+
+        expect(utilisateurMAC).toStrictEqual<UtilisateurMAC>({
+          identifiant: aidant.identifiant,
+          profil: 'Aidant',
+          nomPrenom: aidant.nomPrenom,
+          email: aidant.email,
+          dateValidationCGU: aidant.dateSignatureCGU!,
+        });
       });
     });
   });
-});
 
-describe('Entrepot Utilisateur Inscrit', () => {
-  const serviceDeChiffrement: FauxServiceDeChiffrement =
-    new FauxServiceDeChiffrement(new Map());
-  let entrepot = new EntrepotUtilisateurInscritPostgres(serviceDeChiffrement);
+  describe('Entrepot Utilisateur Inscrit', () => {
+    const serviceDeChiffrement: FauxServiceDeChiffrement =
+      new FauxServiceDeChiffrement(new Map());
+    let entrepot = new EntrepotUtilisateurInscritPostgres(serviceDeChiffrement);
 
-  beforeEach(async () => {
-    await nettoieLaBaseDeDonneesUtilisateursInscrits();
-    serviceDeChiffrement.nettoie();
-  });
-
-  it('Persiste un utilisateur inscrit', async () => {
-    const utilisateurInscrit = unUtilisateurInscrit().construis();
-    serviceDeChiffrement.ajoute(utilisateurInscrit.email, 'aaa');
-    serviceDeChiffrement.ajoute(utilisateurInscrit.nomPrenom, 'ccc');
-
-    await entrepot.persiste(utilisateurInscrit);
-
-    const utilisateurInscritRecu = await new EntrepotUtilisateurInscritPostgres(
-      serviceDeChiffrement
-    ).lis(utilisateurInscrit.identifiant);
-    expect(utilisateurInscritRecu).toStrictEqual<UtilisateurInscrit>(
-      utilisateurInscrit
-    );
-  });
-
-  it('Persiste un utilisateur sans entité', async () => {
-    const utilisateurInscrit = unUtilisateurInscrit().sansEntite().construis();
-    serviceDeChiffrement.ajoute(utilisateurInscrit.email, 'aaa');
-    serviceDeChiffrement.ajoute(utilisateurInscrit.nomPrenom, 'ccc');
-
-    await entrepot.persiste(utilisateurInscrit);
-
-    const utilisateurInscritRecu = await new EntrepotUtilisateurInscritPostgres(
-      serviceDeChiffrement
-    ).lis(utilisateurInscrit.identifiant);
-    expect(utilisateurInscritRecu).toStrictEqual<UtilisateurInscrit>(
-      utilisateurInscrit
-    );
-  });
-
-  it('Persiste un utilisateur inscrit avec son Siret', async () => {
-    const aidant = unUtilisateurInscrit().avecLeSiret('1234567891').construis();
-    serviceDeChiffrement.ajoute(aidant.entite!.siret!, 'cccc');
-
-    await entrepot.persiste(aidant);
-
-    const utilisateurInscritRecu = await new EntrepotUtilisateurInscritPostgres(
-      serviceDeChiffrement
-    ).lis(aidant.identifiant);
-    expect(
-      utilisateurInscritRecu.entite
-    ).toStrictEqual<EntiteUtilisateurInscrit>({
-      siret: aidant.entite!.siret!,
-    });
-  });
-
-  it('Persiste un utilisateur inscrit avec la date de signature des CGU', async () => {
-    const dateSignatureCGU = new Date();
-    const aidant = unUtilisateurInscrit()
-      .avecUneDateDeSignatureDeCGU(dateSignatureCGU)
-      .construis();
-    const serviceDeChiffrement = new FauxServiceDeChiffrement(new Map());
-
-    await entrepot.persiste(aidant);
-
-    const utilisateurInscritRecu = await new EntrepotUtilisateurInscritPostgres(
-      serviceDeChiffrement
-    ).lis(aidant.identifiant);
-    expect(utilisateurInscritRecu.dateSignatureCGU).toStrictEqual(
-      dateSignatureCGU
-    );
-  });
-
-  it('Passe un Aidant en utilisateur inscrit', async () => {
-    const aidant = unAidant().construis();
-    await new EntrepotAidantPostgres(serviceDeChiffrement).persiste(aidant);
-    const utilisateurInscrit = unUtilisateurInscrit()
-      .avecUnIdentifiant(aidant.identifiant)
-      .construis();
-    serviceDeChiffrement.ajoute(utilisateurInscrit.email, 'aaa');
-    serviceDeChiffrement.ajoute(utilisateurInscrit.nomPrenom, 'ccc');
-
-    await entrepot.persiste(utilisateurInscrit);
-
-    const utilisateurInscritRecu = await new EntrepotUtilisateurInscritPostgres(
-      serviceDeChiffrement
-    ).lis(utilisateurInscrit.identifiant);
-    expect(utilisateurInscritRecu).toStrictEqual<UtilisateurInscrit>(
-      utilisateurInscrit
-    );
-  });
-
-  describe('Pour le type Utilisateur inscrit', () => {
-    it('Retourne une erreur s’il ne s’agit pas d’un Utilisateur inscrit', async () => {
-      const id = crypto.randomUUID();
-      await knex(knexfile)
-        .insert({
-          id,
-          type: 'AIDANT',
-          donnees: { email: 'jean.dupont@aidant.com' },
-        })
-        .into('utilisateurs_mac');
-
-      const utilisateurInscritTrouve = new EntrepotUtilisateurInscritPostgres(
-        new ServiceDeChiffrementClair()
-      ).lis(id);
-
-      expect(utilisateurInscritTrouve).rejects.toStrictEqual(
-        new AggregatNonTrouve('utilisateur inscrit')
-      );
+    beforeEach(async () => {
+      await nettoieLaBaseDeDonneesUtilisateursInscrits();
+      serviceDeChiffrement.nettoie();
     });
 
-    it('Retourne uniquement les utilisateurs inscrits', async () => {
+    it('Persiste un utilisateur inscrit', async () => {
       const utilisateurInscrit = unUtilisateurInscrit().construis();
-      const serviceDeChiffrement = new ServiceDeChiffrementClair();
-      entrepot = new EntrepotUtilisateurInscritPostgres(serviceDeChiffrement);
+      serviceDeChiffrement.ajoute(utilisateurInscrit.email, 'aaa');
+      serviceDeChiffrement.ajoute(utilisateurInscrit.nomPrenom, 'ccc');
 
       await entrepot.persiste(utilisateurInscrit);
-      await knex(knexfile)
-        .insert({
-          id: crypto.randomUUID(),
-          type: 'AIDANT',
-          donnees: { email: 'jean.dupont@aidant.com' },
-        })
-        .into('utilisateurs_mac');
 
-      const aidants = await new EntrepotUtilisateurInscritPostgres(
-        serviceDeChiffrement
-      ).tous();
-      expect(aidants).toStrictEqual<UtilisateurInscrit[]>([utilisateurInscrit]);
+      const utilisateurInscritRecu =
+        await new EntrepotUtilisateurInscritPostgres(serviceDeChiffrement).lis(
+          utilisateurInscrit.identifiant
+        );
+      expect(utilisateurInscritRecu).toStrictEqual<UtilisateurInscrit>(
+        utilisateurInscrit
+      );
+    });
+
+    it('Persiste un utilisateur sans entité', async () => {
+      const utilisateurInscrit = unUtilisateurInscrit()
+        .sansEntite()
+        .construis();
+      serviceDeChiffrement.ajoute(utilisateurInscrit.email, 'aaa');
+      serviceDeChiffrement.ajoute(utilisateurInscrit.nomPrenom, 'ccc');
+
+      await entrepot.persiste(utilisateurInscrit);
+
+      const utilisateurInscritRecu =
+        await new EntrepotUtilisateurInscritPostgres(serviceDeChiffrement).lis(
+          utilisateurInscrit.identifiant
+        );
+      expect(utilisateurInscritRecu).toStrictEqual<UtilisateurInscrit>(
+        utilisateurInscrit
+      );
+    });
+
+    it('Persiste un utilisateur inscrit avec son Siret', async () => {
+      const aidant = unUtilisateurInscrit()
+        .avecLeSiret('1234567891')
+        .construis();
+      serviceDeChiffrement.ajoute(aidant.entite!.siret!, 'cccc');
+
+      await entrepot.persiste(aidant);
+
+      const utilisateurInscritRecu =
+        await new EntrepotUtilisateurInscritPostgres(serviceDeChiffrement).lis(
+          aidant.identifiant
+        );
+      expect(
+        utilisateurInscritRecu.entite
+      ).toStrictEqual<EntiteUtilisateurInscrit>({
+        siret: aidant.entite!.siret!,
+      });
+    });
+
+    it('Persiste un utilisateur inscrit avec la date de signature des CGU', async () => {
+      const dateSignatureCGU = new Date();
+      const aidant = unUtilisateurInscrit()
+        .avecUneDateDeSignatureDeCGU(dateSignatureCGU)
+        .construis();
+      const serviceDeChiffrement = new FauxServiceDeChiffrement(new Map());
+
+      await entrepot.persiste(aidant);
+
+      const utilisateurInscritRecu =
+        await new EntrepotUtilisateurInscritPostgres(serviceDeChiffrement).lis(
+          aidant.identifiant
+        );
+      expect(utilisateurInscritRecu.dateSignatureCGU).toStrictEqual(
+        dateSignatureCGU
+      );
+    });
+
+    it('Passe un Aidant en utilisateur inscrit', async () => {
+      const aidant = unAidant().construis();
+      await new EntrepotAidantPostgres(serviceDeChiffrement).persiste(aidant);
+      const utilisateurInscrit = unUtilisateurInscrit()
+        .avecUnIdentifiant(aidant.identifiant)
+        .construis();
+      serviceDeChiffrement.ajoute(utilisateurInscrit.email, 'aaa');
+      serviceDeChiffrement.ajoute(utilisateurInscrit.nomPrenom, 'ccc');
+
+      await entrepot.persiste(utilisateurInscrit);
+
+      const utilisateurInscritRecu =
+        await new EntrepotUtilisateurInscritPostgres(serviceDeChiffrement).lis(
+          utilisateurInscrit.identifiant
+        );
+      expect(utilisateurInscritRecu).toStrictEqual<UtilisateurInscrit>(
+        utilisateurInscrit
+      );
+    });
+
+    describe('Pour le type Utilisateur inscrit', () => {
+      it('Retourne une erreur s’il ne s’agit pas d’un Utilisateur inscrit', async () => {
+        const id = crypto.randomUUID();
+        await knex(knexfile)
+          .insert({
+            id,
+            type: 'AIDANT',
+            donnees: { email: 'jean.dupont@aidant.com' },
+          })
+          .into('utilisateurs_mac');
+
+        const utilisateurInscritTrouve = new EntrepotUtilisateurInscritPostgres(
+          new ServiceDeChiffrementClair()
+        ).lis(id);
+
+        expect(utilisateurInscritTrouve).rejects.toStrictEqual(
+          new AggregatNonTrouve('utilisateur inscrit')
+        );
+      });
+
+      it('Retourne uniquement les utilisateurs inscrits', async () => {
+        const utilisateurInscrit = unUtilisateurInscrit().construis();
+        const serviceDeChiffrement = new ServiceDeChiffrementClair();
+        entrepot = new EntrepotUtilisateurInscritPostgres(serviceDeChiffrement);
+
+        await entrepot.persiste(utilisateurInscrit);
+        await knex(knexfile)
+          .insert({
+            id: crypto.randomUUID(),
+            type: 'AIDANT',
+            donnees: { email: 'jean.dupont@aidant.com' },
+          })
+          .into('utilisateurs_mac');
+
+        const aidants = await new EntrepotUtilisateurInscritPostgres(
+          serviceDeChiffrement
+        ).tous();
+        expect(aidants).toStrictEqual<UtilisateurInscrit[]>([
+          utilisateurInscrit,
+        ]);
+      });
     });
   });
-});
 
-describe('EntrepoStatistiquesUtilisateurInscrit', () => {
-  beforeEach(async () => {
-    await nettoieLaBaseDeDonneesAidants();
-    await nettoieLaBaseDeDonneesRelations();
-  });
-  const entrepotRelation = new EntrepotRelationPostgres();
+  describe('EntrepoStatistiquesUtilisateurInscrit', () => {
+    beforeEach(async () => {
+      await nettoieLaBaseDeDonneesAidants();
+      await nettoieLaBaseDeDonneesRelations();
+    });
+    const entrepotRelation = new EntrepotRelationPostgres();
 
-  it('Récupère les Aidants avec leur nombre de diagnostics', async () => {
-    const premierUtilisateur = unUtilisateurInscrit().construis();
-    const secondUtilisateur = unUtilisateurInscrit().construis();
-    const troisiemeUtilisateur = unUtilisateurInscrit().construis();
-    const serviceDeChiffrement = new FauxServiceDeChiffrement(
-      new Map([
-        [premierUtilisateur.nomPrenom, 'abcd'],
-        [premierUtilisateur.email, 'efgh'],
-        [secondUtilisateur.nomPrenom, 'ijkl'],
-        [secondUtilisateur.email, 'mnop'],
-        [troisiemeUtilisateur.nomPrenom, 'qrst'],
-        [troisiemeUtilisateur.email, 'uvwx'],
-      ])
-    );
-    const entrepotAidant = new EntrepotAidantPostgres(serviceDeChiffrement);
-    const entrepotUtilisateurInscritPostgres =
-      new EntrepotUtilisateurInscritPostgres(serviceDeChiffrement);
-    await entrepotUtilisateurInscritPostgres.persiste(premierUtilisateur);
-    await entrepotUtilisateurInscritPostgres.persiste(secondUtilisateur);
-    await entrepotUtilisateurInscritPostgres.persiste(troisiemeUtilisateur);
-    await entrepotRelation.persiste(
-      unTupleUtilisateurInscritInitieDiagnostic(
-        premierUtilisateur.identifiant,
-        crypto.randomUUID()
-      )
-    );
-    await entrepotRelation.persiste(
-      unTupleUtilisateurInscritInitieDiagnostic(
-        premierUtilisateur.identifiant,
-        crypto.randomUUID()
-      )
-    );
-    await entrepotRelation.persiste(
-      unTupleUtilisateurInscritInitieDiagnostic(
-        secondUtilisateur.identifiant,
-        crypto.randomUUID()
-      )
-    );
-    await entrepotAidant.persiste(unAidant().construis());
-
-    const entrepotStatistiquesUtilisateurInscrit =
-      new EntrepotStatistiquesUtilisateursInscritsPostgres(
-        serviceDeChiffrement
+    it('Récupère les Aidants avec leur nombre de diagnostics', async () => {
+      const premierUtilisateur = unUtilisateurInscrit().construis();
+      const secondUtilisateur = unUtilisateurInscrit().construis();
+      const troisiemeUtilisateur = unUtilisateurInscrit().construis();
+      const serviceDeChiffrement = new FauxServiceDeChiffrement(
+        new Map([
+          [premierUtilisateur.nomPrenom, 'abcd'],
+          [premierUtilisateur.email, 'efgh'],
+          [secondUtilisateur.nomPrenom, 'ijkl'],
+          [secondUtilisateur.email, 'mnop'],
+          [troisiemeUtilisateur.nomPrenom, 'qrst'],
+          [troisiemeUtilisateur.email, 'uvwx'],
+        ])
       );
+      const entrepotAidant = new EntrepotAidantPostgres(serviceDeChiffrement);
+      const entrepotUtilisateurInscritPostgres =
+        new EntrepotUtilisateurInscritPostgres(serviceDeChiffrement);
+      await entrepotUtilisateurInscritPostgres.persiste(premierUtilisateur);
+      await entrepotUtilisateurInscritPostgres.persiste(secondUtilisateur);
+      await entrepotUtilisateurInscritPostgres.persiste(troisiemeUtilisateur);
+      await entrepotRelation.persiste(
+        unTupleUtilisateurInscritInitieDiagnostic(
+          premierUtilisateur.identifiant,
+          crypto.randomUUID()
+        )
+      );
+      await entrepotRelation.persiste(
+        unTupleUtilisateurInscritInitieDiagnostic(
+          premierUtilisateur.identifiant,
+          crypto.randomUUID()
+        )
+      );
+      await entrepotRelation.persiste(
+        unTupleUtilisateurInscritInitieDiagnostic(
+          secondUtilisateur.identifiant,
+          crypto.randomUUID()
+        )
+      );
+      await entrepotAidant.persiste(unAidant().construis());
 
-    assert.sameDeepMembers(
-      await entrepotStatistiquesUtilisateurInscrit.rechercheUtilisateursInscritsAvecNombreDeDiagnostics(),
-      [
-        {
-          identifiant: premierUtilisateur.identifiant,
-          nomPrenom: premierUtilisateur.nomPrenom,
-          email: premierUtilisateur.email,
-          nombreDiagnostics: 2,
-        },
-        {
-          identifiant: secondUtilisateur.identifiant,
-          nomPrenom: secondUtilisateur.nomPrenom,
-          email: secondUtilisateur.email,
-          nombreDiagnostics: 1,
-        },
-        {
-          identifiant: troisiemeUtilisateur.identifiant,
-          nomPrenom: troisiemeUtilisateur.nomPrenom,
-          email: troisiemeUtilisateur.email,
-          nombreDiagnostics: 0,
-        },
-      ]
-    );
+      const entrepotStatistiquesUtilisateurInscrit =
+        new EntrepotStatistiquesUtilisateursInscritsPostgres(
+          serviceDeChiffrement
+        );
+
+      assert.sameDeepMembers(
+        await entrepotStatistiquesUtilisateurInscrit.rechercheUtilisateursInscritsAvecNombreDeDiagnostics(),
+        [
+          {
+            identifiant: premierUtilisateur.identifiant,
+            nomPrenom: premierUtilisateur.nomPrenom,
+            email: premierUtilisateur.email,
+            nombreDiagnostics: 2,
+          },
+          {
+            identifiant: secondUtilisateur.identifiant,
+            nomPrenom: secondUtilisateur.nomPrenom,
+            email: secondUtilisateur.email,
+            nombreDiagnostics: 1,
+          },
+          {
+            identifiant: troisiemeUtilisateur.identifiant,
+            nomPrenom: troisiemeUtilisateur.nomPrenom,
+            email: troisiemeUtilisateur.email,
+            nombreDiagnostics: 0,
+          },
+        ]
+      );
+    });
   });
 });

--- a/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/aideAuxTests/DictionnaireDeChiffrementAide.ts
+++ b/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/aideAuxTests/DictionnaireDeChiffrementAide.ts
@@ -1,0 +1,35 @@
+import {
+  Dictionnaire,
+  DictionnaireDeChiffrement,
+} from '../../../../constructeurs/DictionnaireDeChiffrement';
+import { DemandeAide } from '../../../../../src/gestion-demandes/aide/DemandeAide';
+import { fakerFR } from '@faker-js/faker';
+
+export class DictionnaireDeChiffrementAide
+  implements DictionnaireDeChiffrement<DemandeAide>
+{
+  private _dictionnaire: Dictionnaire = new Map();
+  private _avecSIRET = true;
+  private aide: DemandeAide | undefined = undefined;
+
+  avec(aide: DemandeAide): DictionnaireDeChiffrementAide {
+    this.aide = aide;
+    return this;
+  }
+
+  sansSIRET(): DictionnaireDeChiffrementAide {
+    this._avecSIRET = false;
+    return this;
+  }
+
+  construis(): Dictionnaire {
+    const valeurEnClair = JSON.stringify({
+      identifiantMAC: this.aide!.identifiant,
+      departement: this.aide!.departement.nom,
+      raisonSociale: this.aide!.raisonSociale,
+      ...(this._avecSIRET && { siret: this.aide!.siret }),
+    });
+    this._dictionnaire.set(valeurEnClair, fakerFR.string.alpha(10));
+    return this._dictionnaire;
+  }
+}

--- a/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/aideAuxTests/EntrepotAideBrevoMemoire.ts
+++ b/mon-aide-cyber-api/test/infrastructure/entrepots/postgres/aideAuxTests/EntrepotAideBrevoMemoire.ts
@@ -1,0 +1,54 @@
+import crypto from 'crypto';
+import {
+  AideDistant,
+  AideDistantBrevoDTO,
+  AideDistantDTO,
+  EntrepotAideDistant,
+} from '../../../../../src/infrastructure/entrepots/postgres/EntrepotAideConcret';
+export class EntrepotAideBrevoMemoire implements EntrepotAideDistant {
+  protected entites: Map<string, AideDistantBrevoDTO> = new Map();
+  private avecMetaDonnees = true;
+
+  async persiste(
+    entite: AideDistant,
+    chiffrement: (
+      identifiantMAC: crypto.UUID,
+      departement: string,
+      siret: string,
+      raisonSociale?: string
+    ) => string
+  ): Promise<void> {
+    const contactBrevo: Omit<AideDistantBrevoDTO, 'attributes'> & {
+      attributes: { METADONNEES?: string };
+    } = {
+      email: entite.email,
+      attributes: {
+        ...(this.avecMetaDonnees && {
+          METADONNEES: chiffrement(
+            entite.identifiantMAC,
+            entite.departement.nom,
+            entite.siret,
+            entite.raisonSociale
+          ),
+        }),
+      },
+    };
+    this.entites.set(entite.email, contactBrevo as AideDistantBrevoDTO);
+  }
+
+  async rechercheParEmail(email: string): Promise<AideDistantDTO | undefined> {
+    const aideDistantDTO = this.entites.get(email);
+    if (aideDistantDTO === undefined) {
+      return undefined;
+    }
+    return {
+      email: aideDistantDTO.email,
+      metaDonnees: aideDistantDTO.attributes.METADONNEES,
+    };
+  }
+
+  sansMetadonnees(): EntrepotAideBrevoMemoire {
+    this.avecMetaDonnees = false;
+    return this;
+  }
+}


### PR DESCRIPTION


Afin de permettre à tous les Aidants de pouvoir participer et s’assurer que les entités Aidées peuvent obtenir un diagnostic dans un temps raisonnable, nous limitons le nombre de diagnostics par Aidant à 2 sur 30 jours glissant