### PR TITLE
[DEMANDE DEVENIR AIDANT] Modifie le texte relatif à la signature de la charte Aidant

### DIFF
--- a/mon-aide-cyber-ui/src/vues/CharteAidant.tsx
+++ b/mon-aide-cyber-ui/src/vues/CharteAidant.tsx
@@ -23,10 +23,7 @@ const ContenuCharteAidant = () => (
         </p>
       </li>
       <li>
-        <p dir="auto">
-          Signer la présente Charte et la communiquer à l’équipe MonAideCyber ou
-          à un agent de l’ANSSI.&nbsp;
-        </p>
+        <p dir="auto">Signer la présente Charte.</p>
       </li>
       <li>
         <p dir="auto">


### PR DESCRIPTION


Il n'est plus la peine de demander la transmission de la charte signée depuis que nous conservons l'information depuis le formulaire