### PR TITLE
[AIDANT][GENDARMERIE] Ajoute l'entité dans la commande d'administration de recherche par domaine

### DIFF
--- a/mon-aide-cyber-api/src/administration/aidants/par-domaine/commande.ts
+++ b/mon-aide-cyber-api/src/administration/aidants/par-domaine/commande.ts
@@ -28,6 +28,7 @@ program
           .createHash('sha256')
           .update(aidant.identifiant)
           .digest('hex'),
+        entite: aidant.entite,
         email: aidant.email,
       }));
     console.log(


### PR DESCRIPTION
Afin de pouvoir distinguer les Aidants sans SIRET

Il suffit par la suite de récupérer la sortie de la commande dans un fichier et exécuter la commande suivante :
`cat MON_FICHIER.json | jq '[.[] | select(.entite == null) | {idHashe}]` 

Cela produira la sortie suivante :
```json
[
  {
    "idHashe": "UN_ID"
  }
]
```
