### PR TITLE
[AIDANT][GENDARMERIE] Créé la commande d'administration pour le rattrapage des gendarmes non identifiés

### DIFF
--- a/mon-aide-cyber-api/package.json
+++ b/mon-aide-cyber-api/package.json
@@ -18,6 +18,7 @@
     "administration:recherche-utilisateurs": "ts-node --transpile-only --require dotenv/config src/administration/utilisateurs/recherche/commande.ts",
     "administration:extraction-aidants": "ts-node --transpile-only --require dotenv/config src/administration/aidants/extraction-aidants/commande.ts",
     "administration:recupere-aidants-par-domaine": "ts-node --transpile-only --require dotenv/config src/administration/aidants/par-domaine/commande.ts",
+    "administration:rattrapage-gendarmes": "ts-node --transpile-only --require dotenv/config src/administration/gendarmes/rattrapage/commande.ts",
     "administration:chiffrement": "ts-node --transpile-only --require dotenv/config src/administration/chiffrement/commande.ts",
     "administration:lie-diagnostics": "ts-node --transpile-only --require dotenv/config src/administration/lie-diagnostics/commande.ts",
     "administration:challenge-mars": "ts-node --transpile-only --require dotenv/config src/administration/aidants/challenge-mars/commande.ts",

--- a/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/commande.ts
+++ b/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/commande.ts
@@ -4,43 +4,111 @@ import { adaptateurServiceChiffrement } from '../../../infrastructure/adaptateur
 import { trouveLesAidantsGendarmes } from './trouveLesAidantsGendarmes';
 import { Aidant } from '../../../espace-aidant/Aidant';
 import { metAJourLesGendarmesSansEntite } from './metAJourLesGendarmesSansEntite';
+import configurationJournalisation from '../../../infrastructure/entrepots/postgres/configurationJournalisation';
+import { knex } from 'knex';
+import crypto from 'crypto';
+
+type ResultatCommandeAdministration = {
+  nombreEvenementsAModifier: number;
+  nombreTotalGendarmes: number;
+  identifiantsGendarmesAModifier: string[];
+};
 
 program
   .description('Rattrape les gendarmes')
   .option('--dry-run <dryRun>', 'Exécute en mode dry-run', 'true')
   .action(async (options) => {
     const dryRunActif = options.dryRun !== 'false';
-    console.log(
-      `Le script tourne en mode : ${dryRunActif ? 'DRY-RUN' : 'SANS-DRY-RUN'}`
-    );
+
+    const resultatCommandeAdministration: ResultatCommandeAdministration = {
+      nombreTotalGendarmes: 0,
+      identifiantsGendarmesAModifier: [],
+      nombreEvenementsAModifier: 0,
+    };
 
     const serviceDeChiffrement = adaptateurServiceChiffrement();
     const entrepotAidants = new EntrepotAidantPostgres(serviceDeChiffrement);
+    const connexionKnexJournal = knex(configurationJournalisation);
 
     const gendarmesExistants: Aidant[] =
       await trouveLesAidantsGendarmes(entrepotAidants);
+    resultatCommandeAdministration.nombreTotalGendarmes =
+      gendarmesExistants.length;
 
     const gendarmesSansEntite = gendarmesExistants.filter(
       (g) => !g.entite || !g.entite.siret
     );
 
-    console.log(
-      `Nombre de comptes gendarmes à modifier : ${gendarmesSansEntite?.length} / ${gendarmesExistants.length} gendarmes`
-    );
-
     if (gendarmesSansEntite.length > 0) {
-      console.log({
-        gendarmesSansEntite: gendarmesSansEntite.map((gse) => gse.identifiant),
-      });
+      resultatCommandeAdministration.identifiantsGendarmesAModifier =
+        gendarmesSansEntite.map((gse) =>
+          crypto.createHash('sha256').update(gse.identifiant).digest('hex')
+        );
     }
 
-    if (!dryRunActif && gendarmesSansEntite.length > 0) {
-      await metAJourLesGendarmesSansEntite(
-        gendarmesSansEntite,
-        entrepotAidants
+    if (!dryRunActif) {
+      try {
+        console.log(
+          `Nombre de comptes gendarmes à modifier : ${resultatCommandeAdministration.identifiantsGendarmesAModifier.length} / ${resultatCommandeAdministration.nombreTotalGendarmes} gendarmes`
+        );
+        await metAJourLesGendarmesSansEntite(
+          gendarmesSansEntite,
+          entrepotAidants
+        );
+      } catch (e) {
+        console.error(
+          "Une erreur est survenue lors de la mise à jour de l'entité pour les gendarmes concernés",
+          e
+        );
+      }
+    }
+
+    try {
+      const tousLesIdentifiantsDeGendarmesHashes = gendarmesExistants.map(
+        (ge) => crypto.createHash('sha256').update(ge.identifiant).digest('hex')
       );
-      console.log(
-        'Entité correcte désormais rattachée aux gendarmes concernés'
+
+      await connexionKnexJournal.transaction(async (trx) => {
+        const evenementsAidantCree = await trx(
+          'journal_mac.evenements'
+        ).whereRaw(
+          `type = 'AIDANT_CREE' AND donnees->>'identifiant' = ANY(?) AND (donnees->>'typeAidant' is null OR donnees->>'typeAidant' <> 'Gendarme')`,
+          [tousLesIdentifiantsDeGendarmesHashes]
+        );
+
+        resultatCommandeAdministration.nombreEvenementsAModifier =
+          evenementsAidantCree.length;
+
+        if (dryRunActif) {
+          await trx.rollback();
+          console.log(JSON.stringify(resultatCommandeAdministration));
+          return;
+        }
+
+        console.log(
+          `Il y a ${resultatCommandeAdministration.nombreEvenementsAModifier} événements de création d'Aidants à modifier`
+        );
+
+        return evenementsAidantCree.map(async ({ id, donnees }, index) => {
+          const nouvellesDonnees = {
+            ...donnees,
+            typeAidant: 'Gendarme',
+          };
+
+          return trx('journal_mac.evenements')
+            .where({ id })
+            .update({ donnees: nouvellesDonnees })
+            .then(() => {
+              console.log(
+                `${((index + 1) / evenementsAidantCree.length) * 100}% (${index + 1} / ${evenementsAidantCree.length}) des événements modifiés`
+              );
+            });
+        });
+      });
+    } catch (e) {
+      console.error(
+        'Une erreur est survenue lors de la récupération des événements',
+        e
       );
     }
 

--- a/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/commande.ts
+++ b/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/commande.ts
@@ -1,0 +1,39 @@
+import { program } from 'commander';
+import { EntrepotAidantPostgres } from '../../../infrastructure/entrepots/postgres/EntrepotAidantPostgres';
+import { adaptateurServiceChiffrement } from '../../../infrastructure/adaptateurs/adaptateurServiceChiffrement';
+import { trouveLesAidantsGendarmes } from './trouveLesAidantsGendarmes';
+import { Aidant } from '../../../espace-aidant/Aidant';
+
+program
+  .description('Rattrape les gendarmes')
+  .option('--dry-run <dryRun>', 'Exécute en mode dry-run', 'true')
+  .action(async (options) => {
+    const dryRunActif = options.dryRun !== 'false';
+    console.log(
+      `Le script tourne en mode : ${dryRunActif ? 'dry-run' : 'sans-dry-run'}`
+    );
+
+    const serviceDeChiffrement = adaptateurServiceChiffrement();
+    const entrepotAidants = new EntrepotAidantPostgres(serviceDeChiffrement);
+
+    const gendarmesExistants: Aidant[] =
+      await trouveLesAidantsGendarmes(entrepotAidants);
+
+    const gendarmesSansEntite = gendarmesExistants.filter(
+      (g) => !g.entite || !g.entite.siret
+    );
+
+    console.log(
+      `Nombre de comptes gendarmes à modifier : ${gendarmesSansEntite?.length} / ${gendarmesExistants.length} gendarmes`
+    );
+
+    if (gendarmesSansEntite.length > 0) {
+      console.log({
+        gendarmesSansEntite: gendarmesSansEntite.map((gse) => gse.identifiant),
+      });
+    }
+
+    process.exit(0);
+  });
+
+program.parse();

--- a/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/commande.ts
+++ b/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/commande.ts
@@ -100,7 +100,7 @@ program
             .update({ donnees: nouvellesDonnees })
             .then(() => {
               console.log(
-                `${((index + 1) / evenementsAidantCree.length) * 100}% (${index + 1} / ${evenementsAidantCree.length}) des événements modifiés`
+                `${Math.ceil(((index + 1) / evenementsAidantCree.length) * 100)}% (${index + 1} / ${evenementsAidantCree.length}) des événements modifiés`
               );
             });
         });

--- a/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/commande.ts
+++ b/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/commande.ts
@@ -3,6 +3,7 @@ import { EntrepotAidantPostgres } from '../../../infrastructure/entrepots/postgr
 import { adaptateurServiceChiffrement } from '../../../infrastructure/adaptateurs/adaptateurServiceChiffrement';
 import { trouveLesAidantsGendarmes } from './trouveLesAidantsGendarmes';
 import { Aidant } from '../../../espace-aidant/Aidant';
+import { metAJourLesGendarmesSansEntite } from './metAJourLesGendarmesSansEntite';
 
 program
   .description('Rattrape les gendarmes')
@@ -10,7 +11,7 @@ program
   .action(async (options) => {
     const dryRunActif = options.dryRun !== 'false';
     console.log(
-      `Le script tourne en mode : ${dryRunActif ? 'dry-run' : 'sans-dry-run'}`
+      `Le script tourne en mode : ${dryRunActif ? 'DRY-RUN' : 'SANS-DRY-RUN'}`
     );
 
     const serviceDeChiffrement = adaptateurServiceChiffrement();
@@ -31,6 +32,16 @@ program
       console.log({
         gendarmesSansEntite: gendarmesSansEntite.map((gse) => gse.identifiant),
       });
+    }
+
+    if (!dryRunActif && gendarmesSansEntite.length > 0) {
+      await metAJourLesGendarmesSansEntite(
+        gendarmesSansEntite,
+        entrepotAidants
+      );
+      console.log(
+        'Entité correcte désormais rattachée aux gendarmes concernés'
+      );
     }
 
     process.exit(0);

--- a/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/metAJourLesGendarmesSansEntite.ts
+++ b/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/metAJourLesGendarmesSansEntite.ts
@@ -5,14 +5,20 @@ export async function metAJourLesGendarmesSansEntite(
   gendarmesSansEntite: Aidant[],
   entrepotAidants: EntrepotAidant
 ) {
-  return gendarmesSansEntite.map(async (gendarmeSansEntite) => {
-    return entrepotAidants.persiste({
-      ...gendarmeSansEntite,
-      entite: {
-        nom: 'DIRECTION GENERALE DE LA GENDARMERIE NATIONALE (DGGN)',
-        siret: adaptateurEnvironnement.siretsEntreprise().gendarmerie()!,
-        type: 'ServiceEtat',
-      },
-    });
+  return gendarmesSansEntite.map(async (gendarmeSansEntite, index) => {
+    return entrepotAidants
+      .persiste({
+        ...gendarmeSansEntite,
+        entite: {
+          nom: 'DIRECTION GENERALE DE LA GENDARMERIE NATIONALE (DGGN)',
+          siret: adaptateurEnvironnement.siretsEntreprise().gendarmerie()!,
+          type: 'ServiceEtat',
+        },
+      })
+      .then(() => {
+        console.log(
+          `${((index + 1) / gendarmesSansEntite.length) * 100}% (${index + 1} / ${gendarmesSansEntite.length}) des utilisateurs_mac modifiés`
+        );
+      });
   });
 }

--- a/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/metAJourLesGendarmesSansEntite.ts
+++ b/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/metAJourLesGendarmesSansEntite.ts
@@ -17,7 +17,7 @@ export async function metAJourLesGendarmesSansEntite(
       })
       .then(() => {
         console.log(
-          `${((index + 1) / gendarmesSansEntite.length) * 100}% (${index + 1} / ${gendarmesSansEntite.length}) des utilisateurs_mac modifiés`
+          `${Math.ceil(((index + 1) / gendarmesSansEntite.length) * 100)}% (${index + 1} / ${gendarmesSansEntite.length}) des utilisateurs_mac modifiés`
         );
       });
   });

--- a/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/metAJourLesGendarmesSansEntite.ts
+++ b/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/metAJourLesGendarmesSansEntite.ts
@@ -1,0 +1,18 @@
+import { Aidant, EntrepotAidant } from '../../../espace-aidant/Aidant';
+import { adaptateurEnvironnement } from '../../../adaptateurs/adaptateurEnvironnement';
+
+export async function metAJourLesGendarmesSansEntite(
+  gendarmesSansEntite: Aidant[],
+  entrepotAidants: EntrepotAidant
+) {
+  return gendarmesSansEntite.map(async (gendarmeSansEntite) => {
+    return entrepotAidants.persiste({
+      ...gendarmeSansEntite,
+      entite: {
+        nom: 'DIRECTION GENERALE DE LA GENDARMERIE NATIONALE (DGGN)',
+        siret: adaptateurEnvironnement.siretsEntreprise().gendarmerie()!,
+        type: 'ServiceEtat',
+      },
+    });
+  });
+}

--- a/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/trouveLesAidantsGendarmes.ts
+++ b/mon-aide-cyber-api/src/administration/gendarmes/rattrapage/trouveLesAidantsGendarmes.ts
@@ -1,0 +1,10 @@
+import { Aidant, EntrepotAidant } from '../../../espace-aidant/Aidant';
+
+export async function trouveLesAidantsGendarmes(
+  entrepotAidants: EntrepotAidant
+): Promise<Aidant[]> {
+  const nomDomaineGendarmes = 'gendarmerie.interieur.gouv.fr';
+  const aidants = await entrepotAidants.tous();
+
+  return aidants.filter((aidant) => aidant.email.endsWith(nomDomaineGendarmes));
+}

--- a/mon-aide-cyber-api/test/administration/gendarmes/rattrapage/metAJourLesGendarmesSansEntite.spec.ts
+++ b/mon-aide-cyber-api/test/administration/gendarmes/rattrapage/metAJourLesGendarmesSansEntite.spec.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { EntrepotAidantMemoire } from '../../../../src/infrastructure/entrepots/memoire/EntrepotMemoire';
+import { unAidant } from '../../../constructeurs/constructeursAidantUtilisateurInscritUtilisateur';
+import { metAJourLesGendarmesSansEntite } from '../../../../src/administration/gendarmes/rattrapage/metAJourLesGendarmesSansEntite';
+import { adaptateurEnvironnement } from '../../../../src/adaptateurs/adaptateurEnvironnement';
+import { EntiteAidant } from '../../../../src/espace-aidant/Aidant';
+
+describe('Rattrapage des gendarmes sans entité', () => {
+  let entrepotAidant: EntrepotAidantMemoire;
+
+  beforeEach(() => {
+    entrepotAidant = new EntrepotAidantMemoire();
+    adaptateurEnvironnement.siretsEntreprise().gendarmerie = () =>
+      'GENDARMERIE';
+  });
+
+  it('Précise l‘entité de la gendarmerie quand le gendarme n‘en a pas', async () => {
+    const unGendarmeSansEntite = unAidant()
+      .avecUnEmail('aidant1@gendarmerie.interieur.gouv.fr')
+      .construis();
+    await entrepotAidant.persiste(unGendarmeSansEntite);
+
+    await metAJourLesGendarmesSansEntite(
+      [unGendarmeSansEntite],
+      entrepotAidant
+    );
+
+    const aidants = await entrepotAidant.tous();
+    expect(
+      aidants.filter(
+        (a) => a.email === 'aidant1@gendarmerie.interieur.gouv.fr'
+      )[0].entite
+    ).toStrictEqual<EntiteAidant>({
+      type: 'ServiceEtat',
+      nom: 'DIRECTION GENERALE DE LA GENDARMERIE NATIONALE (DGGN)',
+      siret: 'GENDARMERIE',
+    });
+  });
+});

--- a/mon-aide-cyber-api/test/administration/gendarmes/rattrapage/trouveLesAidantsGendarmes.spec.ts
+++ b/mon-aide-cyber-api/test/administration/gendarmes/rattrapage/trouveLesAidantsGendarmes.spec.ts
@@ -1,0 +1,43 @@
+import {
+  desAidants,
+  unAidant,
+} from '../../../constructeurs/constructeursAidantUtilisateurInscritUtilisateur';
+import { EntrepotAidantMemoire } from '../../../../src/infrastructure/entrepots/memoire/EntrepotMemoire';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { adaptateurEnvironnement } from '../../../../src/adaptateurs/adaptateurEnvironnement';
+import { trouveLesAidantsGendarmes } from '../../../../src/administration/gendarmes/rattrapage/trouveLesAidantsGendarmes';
+
+describe('Récupération des Aidants gendarmes', () => {
+  let entrepotAidant: EntrepotAidantMemoire;
+
+  beforeEach(() => {
+    entrepotAidant = new EntrepotAidantMemoire();
+    adaptateurEnvironnement.siretsEntreprise().gendarmerie = () =>
+      'GENDARMERIE';
+  });
+
+  it("S'assure de ne retrouver que des Aidants avec le bon nom de domaine (gendarmerie.interieur.gouv.fr)", async () => {
+    const unGendarmeSansEntite = unAidant()
+      .avecUnEmail('aidant1@gendarmerie.interieur.gouv.fr')
+      .construis();
+    const unSecondGendarmeAvecLeBonSiret = unAidant()
+      .avecUnEmail('aidant2@gendarmerie.interieur.gouv.fr')
+      .avecUnProfilGendarme()
+      .construis();
+    const dAutresAidants = desAidants()
+      .auNombreDe(3)
+      .enGironde()
+      .dansLeServicePublic()
+      .pourLesSecteursActivite([{ nom: 'Administration' }])
+      .construis();
+    await entrepotAidant.persiste(unGendarmeSansEntite);
+    await entrepotAidant.persiste(unSecondGendarmeAvecLeBonSiret);
+    for await (const aidant of dAutresAidants) {
+      await entrepotAidant.persiste(aidant);
+    }
+
+    const gendarmesTrouves = await trouveLesAidantsGendarmes(entrepotAidant);
+
+    expect(gendarmesTrouves.length).toBe(2);
+  });
+});

--- a/mon-aide-cyber-api/test/administration/gendarmes/rattrapage/trouveLesAidantsGendarmes.spec.ts
+++ b/mon-aide-cyber-api/test/administration/gendarmes/rattrapage/trouveLesAidantsGendarmes.spec.ts
@@ -1,10 +1,6 @@
-import {
-  desAidants,
-  unAidant,
-} from '../../../constructeurs/constructeursAidantUtilisateurInscritUtilisateur';
+import { unAidant } from '../../../constructeurs/constructeursAidantUtilisateurInscritUtilisateur';
 import { EntrepotAidantMemoire } from '../../../../src/infrastructure/entrepots/memoire/EntrepotMemoire';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { adaptateurEnvironnement } from '../../../../src/adaptateurs/adaptateurEnvironnement';
 import { trouveLesAidantsGendarmes } from '../../../../src/administration/gendarmes/rattrapage/trouveLesAidantsGendarmes';
 
 describe('Récupération des Aidants gendarmes', () => {
@@ -12,8 +8,6 @@ describe('Récupération des Aidants gendarmes', () => {
 
   beforeEach(() => {
     entrepotAidant = new EntrepotAidantMemoire();
-    adaptateurEnvironnement.siretsEntreprise().gendarmerie = () =>
-      'GENDARMERIE';
   });
 
   it("S'assure de ne retrouver que des Aidants avec le bon nom de domaine (gendarmerie.interieur.gouv.fr)", async () => {
@@ -24,16 +18,14 @@ describe('Récupération des Aidants gendarmes', () => {
       .avecUnEmail('aidant2@gendarmerie.interieur.gouv.fr')
       .avecUnProfilGendarme()
       .construis();
-    const dAutresAidants = desAidants()
-      .auNombreDe(3)
-      .enGironde()
-      .dansLeServicePublic()
-      .pourLesSecteursActivite([{ nom: 'Administration' }])
-      .construis();
     await entrepotAidant.persiste(unGendarmeSansEntite);
     await entrepotAidant.persiste(unSecondGendarmeAvecLeBonSiret);
-    for await (const aidant of dAutresAidants) {
-      await entrepotAidant.persiste(aidant);
+
+    for (let i = 0; i < 3; i++) {
+      const aidantPasGendarme = unAidant()
+        .avecUnEmail(`aidant${i}@email.com`)
+        .construis();
+      await entrepotAidant.persiste(aidantPasGendarme);
     }
 
     const gendarmesTrouves = await trouveLesAidantsGendarmes(entrepotAidant);


### PR DESCRIPTION
A l'heure actuelle, seules actions réalisées :
- liste uniquement les identifiants à modifier sans faire de persistance