### PR TITLE
[MON ESPACE][PAGE RESSOURCES] Utilise les sous-titres par défaut lors du lancement des vidéos

### DIFF
--- a/mon-aide-cyber-ui/src/domaine/espace-aidant/ecran-ressources/composants/EncartContenu.tsx
+++ b/mon-aide-cyber-ui/src/domaine/espace-aidant/ecran-ressources/composants/EncartContenu.tsx
@@ -31,6 +31,7 @@ const EncartContenu = ({
           >
             <source src={video.source} type="video/mp4" />
             <track
+              default
               src={video.sousTitres}
               kind="captions"
               srcLang="fr"


### PR DESCRIPTION
Active par défaut le sous-titrage des vidéos de la page /mon-espace/ressources

<img width="1152" height="631" alt="image" src="https://github.com/user-attachments/assets/ff73d942-33d8-4713-a6cc-f539961f40e0" />
