### PR TITLE
[CORRECTION][WEBHOOK LIVESTORM] Autorise uniquement un événement Livestorm voulu à exécuter l'activation d'un compte Aidant

### DIFF
--- a/mon-aide-cyber-api/.env.template
+++ b/mon-aide-cyber-api/.env.template
@@ -151,7 +151,7 @@ PRO_CONNECT_CLIENT_SECRET=
 #########################################################
 # SIGNATURE_TALLY_FORMULAIRE_SUIVI_DIAGNOSTIC= #La clé de signature pour vérifier que c’est bien Tally qui nous envoie la réponse (optionnel en local, car on peut configurer un webhook sans signature)
 # SIGNATURE_LIVESTORM_FIN_ATELIER=
-
+LIVESTORM_ID_EVENEMENT_ATELIERS_DEVENIR_AIDANT=
 # WEBHOOK_MATTERMOST_ACTIVATION_COMPTE_AIDANT=
 
 #########################################################

--- a/mon-aide-cyber-api/src/adaptateurs/adaptateurEnvironnement.ts
+++ b/mon-aide-cyber-api/src/adaptateurs/adaptateurEnvironnement.ts
@@ -158,6 +158,20 @@ const signatures = (): SignaturesHTTP => {
   };
 };
 
+type IdentifiantsWebinaires = {
+  livestorm: () => {
+    idEvenementAteliersDevenirAidant: string | undefined;
+  };
+};
+const webinaires = (): IdentifiantsWebinaires => {
+  return {
+    livestorm: () => ({
+      idEvenementAteliersDevenirAidant:
+        process.env.LIVESTORM_ID_EVENEMENT_ATELIERS_DEVENIR_AIDANT || undefined,
+    }),
+  };
+};
+
 const ipAutorisees = (): false | string[] =>
   process.env.RESEAU_ADRESSES_IP_AUTORISEES?.split(',') ?? false;
 
@@ -204,6 +218,7 @@ const adaptateurEnvironnement = {
   crisp,
   signatures,
   metabase,
+  webinaires,
 };
 
 export { sentry, adaptateurEnvironnement };

--- a/mon-aide-cyber-api/src/adaptateurs/adaptateurEnvironnement.ts
+++ b/mon-aide-cyber-api/src/adaptateurs/adaptateurEnvironnement.ts
@@ -160,15 +160,21 @@ const signatures = (): SignaturesHTTP => {
 
 type IdentifiantsWebinaires = {
   livestorm: () => {
-    idEvenementAteliersDevenirAidant: string | undefined;
+    idEvenementAteliersDevenirAidant: string;
   };
 };
 const webinaires = (): IdentifiantsWebinaires => {
   return {
-    livestorm: () => ({
-      idEvenementAteliersDevenirAidant:
-        process.env.LIVESTORM_ID_EVENEMENT_ATELIERS_DEVENIR_AIDANT || undefined,
-    }),
+    livestorm: () => {
+      const idEvenementAteliersDevenirAidant =
+        process.env.LIVESTORM_ID_EVENEMENT_ATELIERS_DEVENIR_AIDANT;
+      if (!idEvenementAteliersDevenirAidant)
+        throw new Error(
+          'Il manque la variable d‘environnement LIVESTORM_ID_EVENEMENT_ATELIERS_DEVENIR_AIDANT'
+        );
+
+      return { idEvenementAteliersDevenirAidant };
+    },
   };
 };
 

--- a/mon-aide-cyber-api/src/api/webhooks/routesAPIWebhooks.livestorm.ts
+++ b/mon-aide-cyber-api/src/api/webhooks/routesAPIWebhooks.livestorm.ts
@@ -6,12 +6,14 @@ import {
   ActivationCompteAidantFaite,
   SagaActivationCompteAidant,
 } from '../../gestion-demandes/devenir-aidant/CapteurSagaActivationCompteAidant';
+import { adaptateurEnvironnement } from '../../adaptateurs/adaptateurEnvironnement';
 
 export type CorpsParticipantFinAtelierLivestorm = {
   data: {
     type: 'people';
     attributes: {
       registrant_detail: {
+        event_id?: string;
         fields: {
           id: string;
           value: string;
@@ -38,6 +40,16 @@ export const routesAPILiveStorm = (configuration: ConfigurationServeur) => {
     ) => {
       const corpsParticipantFinAtelierLivestorm: CorpsParticipantFinAtelierLivestorm =
         requete.body;
+
+      const pasNotreWebinaire =
+        corpsParticipantFinAtelierLivestorm.data.attributes.registrant_detail
+          .event_id !==
+        adaptateurEnvironnement.webinaires().livestorm()
+          .idEvenementAteliersDevenirAidant;
+
+      if (pasNotreWebinaire) {
+        return reponse.sendStatus(204);
+      }
 
       if (corpsParticipantFinAtelierLivestorm.data.type !== 'people') {
         return reponse.sendStatus(204);

--- a/mon-aide-cyber-api/test/api/webhooks/constructeursDeWebhooks.ts
+++ b/mon-aide-cyber-api/test/api/webhooks/constructeursDeWebhooks.ts
@@ -48,6 +48,7 @@ class ConstructeurDeParticipantFinAtelierLivestorm
 {
   private type = 'people' as const;
   private fields: { id: string; value: string }[] = [];
+  private event_id = '12345';
 
   emailParticipant(
     email: string
@@ -74,11 +75,17 @@ class ConstructeurDeParticipantFinAtelierLivestorm
         type: this.type,
         attributes: {
           registrant_detail: {
+            event_id: this.event_id,
             fields: this.fields,
           },
         },
       },
     };
+  }
+
+  pourUnIdEvenement(idEvement: string) {
+    this.event_id = idEvement;
+    return this;
   }
 }
 

--- a/mon-aide-cyber-api/test/api/webhooks/routesAPIWebhooks.livestorm.spec.ts
+++ b/mon-aide-cyber-api/test/api/webhooks/routesAPIWebhooks.livestorm.spec.ts
@@ -5,6 +5,7 @@ import { unConstructeurDeParticipantFinAtelierLivestorm } from './constructeursD
 import testeurIntegration from '../testeurIntegration';
 import { Express } from 'express';
 import { AdaptateurSignatureRequeteDeTest } from '../../adaptateurs/AdaptateurSignatureRequeteDeTest';
+import { adaptateurEnvironnement } from '../../../src/adaptateurs/adaptateurEnvironnement';
 
 describe('Route Webhook livestorm', () => {
   const testeurMAC = testeurIntegration();
@@ -22,6 +23,11 @@ describe('Route Webhook livestorm', () => {
 
   describe("Lorsqu'une requête POST est reçue sur /webhooks/livestorm/activation-compte-aidant", () => {
     it('active le compte Aidant', async () => {
+      adaptateurEnvironnement.webinaires = () => ({
+        livestorm: () => ({
+          idEvenementAteliersDevenirAidant: '12345',
+        }),
+      });
       const demandeDevenirAidant = uneDemandeDevenirAidant()
         .ayantPourMail('jean.dupont@email.com')
         .construis();
@@ -47,6 +53,11 @@ describe('Route Webhook livestorm', () => {
     });
 
     it('active le compte Aidant avec l‘email du participant', async () => {
+      adaptateurEnvironnement.webinaires = () => ({
+        livestorm: () => ({
+          idEvenementAteliersDevenirAidant: '12345',
+        }),
+      });
       const demandeDevenirAidant = uneDemandeDevenirAidant()
         .ayantPourMail('jean.dupont@email.com')
         .construis();
@@ -85,6 +96,25 @@ describe('Route Webhook livestorm', () => {
             type: 'session',
           },
         }
+      );
+
+      expect(reponse.statusCode).toBe(204);
+    });
+
+    it('renvoie une réponse HTTP 204 si la requête Livestorm ne comporte pas un bon event_id (correspond à l‘événement people.attended)', async () => {
+      adaptateurEnvironnement.webinaires = () => ({
+        livestorm: () => ({
+          idEvenementAteliersDevenirAidant: '12345',
+        }),
+      });
+
+      const reponse = await executeRequete(
+        donneesServeur.app,
+        'POST',
+        `/api/webhooks/livestorm/activation-compte-aidant`,
+        unConstructeurDeParticipantFinAtelierLivestorm()
+          .pourUnIdEvenement('faux_id')
+          .construis()
       );
 
       expect(reponse.statusCode).toBe(204);

--- a/mon-aide-cyber-api/test/api/webhooks/routesAPIWebhooks.livestorm.spec.ts
+++ b/mon-aide-cyber-api/test/api/webhooks/routesAPIWebhooks.livestorm.spec.ts
@@ -22,12 +22,15 @@ describe('Route Webhook livestorm', () => {
   });
 
   describe("Lorsqu'une requête POST est reçue sur /webhooks/livestorm/activation-compte-aidant", () => {
-    it('active le compte Aidant', async () => {
+    beforeEach(() => {
       adaptateurEnvironnement.webinaires = () => ({
         livestorm: () => ({
           idEvenementAteliersDevenirAidant: '12345',
         }),
       });
+    });
+
+    it('active le compte Aidant', async () => {
       const demandeDevenirAidant = uneDemandeDevenirAidant()
         .ayantPourMail('jean.dupont@email.com')
         .construis();
@@ -53,11 +56,6 @@ describe('Route Webhook livestorm', () => {
     });
 
     it('active le compte Aidant avec l‘email du participant', async () => {
-      adaptateurEnvironnement.webinaires = () => ({
-        livestorm: () => ({
-          idEvenementAteliersDevenirAidant: '12345',
-        }),
-      });
       const demandeDevenirAidant = uneDemandeDevenirAidant()
         .ayantPourMail('jean.dupont@email.com')
         .construis();
@@ -102,12 +100,6 @@ describe('Route Webhook livestorm', () => {
     });
 
     it('renvoie une réponse HTTP 204 si la requête Livestorm ne comporte pas un bon event_id (correspond à l‘événement people.attended)', async () => {
-      adaptateurEnvironnement.webinaires = () => ({
-        livestorm: () => ({
-          idEvenementAteliersDevenirAidant: '12345',
-        }),
-      });
-
       const reponse = await executeRequete(
         donneesServeur.app,
         'POST',


### PR DESCRIPTION
On a découvert que MAC se faisait appeler par l'intégralité des événements présents dans notre organisation sur Livestorm. Afin que l'on ne traite que les appels qui nous concernent (les sessions données par l'événement Atelier devenir Aidant)

Maintenant, on vérifie que l'id de l'événement qui nous appelle correspond à la valeur que l'on possède.