### PR TITLE
[SOIN] Corrige la durée du cooldown `pnpm`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 # _c.f._ https://pnpm.io/settings
 
-minimumReleaseAge: 7200 # 7 jours (exprimé en minutes)
+minimumReleaseAge: 10080 # 7 jours (exprimé en minutes)
 preferFrozenLockfile: true
 
 packages:


### PR DESCRIPTION
Pour repasser à 7 jours (au lieu de 5), comme l'indique le commentaire.