### PR TITLE
Supprime l’envoi en copie à MAC lors de la demande devenir Aidant·e

### DIFF
--- a/mon-aide-cyber-api/src/adaptateurs/AdaptateurEnvoiMail.ts
+++ b/mon-aide-cyber-api/src/adaptateurs/AdaptateurEnvoiMail.ts
@@ -59,14 +59,12 @@ export interface AdaptateurEnvoiMail {
 
   envoieMailParticipationAUnAtelier(
     demande: DemandeDevenirAidant,
-    emailCOT: string,
-    emailMAC: string
+    emailCOT: string
   ): Promise<void>;
 
   envoieMailMiseAJourParticipationAUnAtelier(
     demandeDevenirAidant: DemandeDevenirAidant,
-    emailCOT: string,
-    emailMAC: string
+    emailCOT: string
   ): Promise<void>;
 
   envoieConfirmationUtilisateurInscritCree(utilisateurInscrit: {

--- a/mon-aide-cyber-api/src/gestion-demandes/devenir-aidant/CapteurCommandeDevenirAidant.ts
+++ b/mon-aide-cyber-api/src/gestion-demandes/devenir-aidant/CapteurCommandeDevenirAidant.ts
@@ -135,8 +135,7 @@ export class CapteurCommandeDevenirAidant
         demandeDevenirAidant,
         this.annuaireCOT().rechercheEmailParDepartement(
           demandeDevenirAidant.departement
-        ),
-        adaptateurEnvironnement.messagerie().brevo().emailMAC()
+        )
       );
       return;
     }
@@ -144,8 +143,7 @@ export class CapteurCommandeDevenirAidant
       demandeDevenirAidant,
       this.annuaireCOT().rechercheEmailParDepartement(
         demandeDevenirAidant.departement
-      ),
-      adaptateurEnvironnement.messagerie().brevo().emailMAC()
+      )
     );
   }
 

--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailBrevo.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailBrevo.ts
@@ -83,8 +83,7 @@ export class AdaptateurEnvoiMailBrevo implements AdaptateurEnvoiMail {
 
   async envoieMailMiseAJourParticipationAUnAtelier(
     demandeDevenirAidant: DemandeDevenirAidant,
-    emailCOT: string,
-    emailMAC: string
+    emailCOT: string
   ): Promise<void> {
     const futurAidant: Destinataire = {
       email: demandeDevenirAidant.mail,
@@ -92,7 +91,6 @@ export class AdaptateurEnvoiMailBrevo implements AdaptateurEnvoiMail {
     const cot: Destinataire = {
       email: emailCOT,
     };
-    const mac: Destinataire = { email: emailMAC };
 
     const constructeurBrevoEnvoiMailAvecTemplate =
       unConstructeurEnvoiDeMailAvecTemplate().ayantPourTemplate(
@@ -100,18 +98,12 @@ export class AdaptateurEnvoiMailBrevo implements AdaptateurEnvoiMail {
           .brevo()
           .templateMiseAJourParticipationAtelierAidant()
       );
-    await this.envoieParticipationAtelierAidant(
-      constructeurBrevoEnvoiMailAvecTemplate,
-      futurAidant,
-      cot,
-      mac
-    );
+    await this.envoieParticipationAtelierAidant(constructeurBrevoEnvoiMailAvecTemplate, futurAidant, cot);
   }
 
   async envoieMailParticipationAUnAtelier(
     demande: DemandeDevenirAidant,
-    emailCOT: string,
-    emailMAC: string
+    emailCOT: string
   ): Promise<void> {
     const futurAidant: Destinataire = {
       email: demande.mail,
@@ -119,7 +111,6 @@ export class AdaptateurEnvoiMailBrevo implements AdaptateurEnvoiMail {
     const cot: Destinataire = {
       email: emailCOT,
     };
-    const mac: Destinataire = { email: emailMAC };
 
     const constructeurBrevoEnvoiMailAvecTemplate =
       unConstructeurEnvoiDeMailAvecTemplate().ayantPourTemplate(
@@ -128,22 +119,19 @@ export class AdaptateurEnvoiMailBrevo implements AdaptateurEnvoiMail {
     await this.envoieParticipationAtelierAidant(
       constructeurBrevoEnvoiMailAvecTemplate,
       futurAidant,
-      cot,
-      mac
+      cot
     );
   }
 
   private async envoieParticipationAtelierAidant(
     constructeurBrevoEnvoiMailAvecTemplate: ConstructeurBrevoEnvoiMailAvecTemplate,
     futurAidant: Destinataire,
-    cot: Destinataire,
-    mac: Destinataire
+    cot: Destinataire
   ) {
     await this.envoieMailAvecTemplate(
       constructeurBrevoEnvoiMailAvecTemplate
         .ayantPourDestinataires([[futurAidant.email, futurAidant.nom]])
         .ayantPourDestinatairesEnCopie([[cot.email, cot.nom]])
-        .ayantPourDestinatairesEnCopieInvisible([[mac.email, mac.nom]])
         .ayantPourParametres({
           urls: {
             connexion: new URL(

--- a/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailMemoire.ts
+++ b/mon-aide-cyber-api/src/infrastructure/adaptateurs/AdaptateurEnvoiMailMemoire.ts
@@ -57,26 +57,24 @@ export class AdaptateurEnvoiMailMemoire implements AdaptateurEnvoiMail {
 
   async envoieMailMiseAJourParticipationAUnAtelier(
     demandeDevenirAidant: DemandeDevenirAidant,
-    emailCOT: string,
-    emailMAC: string
+    emailCOT: string
   ): Promise<void> {
     this._envoieMailMiseAJourParticipationAUnAtelier = true;
     if (this._genereErreur) {
       throw new Error('Erreur');
     }
-    this.destinataires.push(...[demandeDevenirAidant.mail, emailCOT, emailMAC]);
+    this.destinataires.push(...[demandeDevenirAidant.mail, emailCOT]);
   }
 
   async envoieMailParticipationAUnAtelier(
     demande: DemandeDevenirAidant,
-    emailCOT: string,
-    emailMAC: string
+    emailCOT: string
   ): Promise<void> {
     this._envoieMailParticipationAUnAtelier = true;
     if (this._genereErreur) {
       throw new Error('Erreur');
     }
-    this.destinataires.push(...[demande.mail, emailCOT, emailMAC]);
+    this.destinataires.push(...[demande.mail, emailCOT]);
   }
 
   async envoieActivationCompteAidantFaite(mail: string): Promise<void> {

--- a/mon-aide-cyber-api/test/gestion-demandes/devenir-aidant/CapteurCommandeDevenirAidant.spec.ts
+++ b/mon-aide-cyber-api/test/gestion-demandes/devenir-aidant/CapteurCommandeDevenirAidant.spec.ts
@@ -218,25 +218,6 @@ describe('Capteur de commande demande devenir aidant', () => {
       ).toBe(true);
     });
 
-    it('Envoie le mail récapitulatif en copie invisible à MonAideCyber', async () => {
-      adaptateurEnvironnement.messagerie = () =>
-        adaptateursEnvironnementDeTest.messagerie();
-      const adaptateurEnvoiMail = new AdaptateurEnvoiMailMemoire();
-      const entrepots = new EntrepotsMemoire();
-
-      await new CapteurCommandeDevenirAidant(
-        entrepots,
-        new BusEvenementDeTest(),
-        adaptateurEnvoiMail,
-        annuaireCot,
-        unServiceAidant(entrepots.aidants())
-      ).execute(uneCommandeDevenirAidant());
-
-      expect(
-        adaptateurEnvoiMail.mailDeParticipationAUnAtelierEnvoye('mac@email.com')
-      ).toBe(true);
-    });
-
     it('Remonte une erreur en cas d’échec de l’envoi du mail de mise en relation', async () => {
       adaptateurEnvironnement.messagerie = () =>
         adaptateursEnvironnementDeTest.messagerie();


### PR DESCRIPTION
Les COT nous ont demandé à plusieurs reprises de supprimer l’adresse mail MAC en copie des demandes devenir Aidant·e.
Cette PR supprime donc l’envoi en copie pour MAC lors de cette demande