### PR TITLE
Valide la sécurité de l'environnement d'Intégration Continue

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/deploiement.yml
+++ b/.github/workflows/deploiement.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # Cloner l'intégralité du dépôt, pour ne pas avoir de « shallow repo » rejeté par Clever
+          persist-credentials: false
 
       - name: Installer la CLI Clever Cloud
         shell: bash
@@ -41,6 +42,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # Cloner l'intégralité du dépôt, pour ne pas avoir de « shallow repo » rejeté par Clever
+          persist-credentials: false
 
       - name: Installer la CLI Clever Cloud
         shell: bash

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          persist-credentials: false
       - name: Configurer Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/securite-ci.yml
+++ b/.github/workflows/securite-ci.yml
@@ -1,6 +1,7 @@
 # Vérification des recommandations CIS et autres sur les configurations GitHub
 # https://www.checkov.io/1.Welcome/What%20is%20Checkov.html
 # https://github.com/bridgecrewio/checkov-action
+# https://docs.zizmor.sh/
 ---
 name: Sécurité de la CI
 permissions: {}
@@ -38,3 +39,18 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: results.sarif
+
+  zizmor:
+    name: zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: zizmor GitHub Action
+        uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
+        with:
+          advanced-security: true

--- a/.github/workflows/securite-ci.yml
+++ b/.github/workflows/securite-ci.yml
@@ -2,7 +2,7 @@
 # https://www.checkov.io/1.Welcome/What%20is%20Checkov.html
 # https://github.com/bridgecrewio/checkov-action
 ---
-name: checkov
+name: Sécurité de la CI
 permissions: {}
 on:
   push:
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  scan:
+  checkov:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results

--- a/.github/workflows/securite-ci.yml
+++ b/.github/workflows/securite-ci.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
 
       - name: Checkov GitHub Action
         uses: bridgecrewio/checkov-action@fa9edf8f0a491c59a924ea6accd5bdcf07752cff # v12.3107.0

--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
       - name: Configurer Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
On ajoute zizmor, qui a des tests complémentaires à checkov, notamment sur la gestion des dépendances.

On en profite pour apporter les corrections proposées par l'outil, histoire de commencer avec une CI verte.