### PR TITLE
Ajoute le détail d’une réponse

### DIFF
--- a/mon-aide-cyber-api/src/api/representateurs/types.ts
+++ b/mon-aide-cyber-api/src/api/representateurs/types.ts
@@ -19,6 +19,7 @@ export type RepresentationDiagnostic = {
 export type RepresentationReponsePossible = {
   identifiant: string;
   libelle: string;
+  detail?: string;
   ordre: number;
   questions?: RepresentationQuestion[];
 };

--- a/mon-aide-cyber-api/src/diagnostic/Referentiel.ts
+++ b/mon-aide-cyber-api/src/diagnostic/Referentiel.ts
@@ -14,6 +14,7 @@ type Resultat = {
 type ReponsePossible = {
   identifiant: string;
   libelle: string;
+  detail?: string;
   ordre: number;
   questions?: QuestionATiroir[];
   resultat?: Resultat;

--- a/mon-aide-cyber-api/test/api/routesAPIDiagnostic.spec.ts
+++ b/mon-aide-cyber-api/test/api/routesAPIDiagnostic.spec.ts
@@ -101,6 +101,39 @@ describe('Le serveur MAC sur les routes /api/diagnostic', () => {
       );
     });
 
+    it('Retourne le référentiel du diagnostic avec le détail d’une réponse', async () => {
+      connecteUtilisateur(crypto.randomUUID());
+      const diagnostic = unDiagnostic()
+        .avecUnReferentiel(
+          unReferentiel()
+            .ajouteUneQuestionAuContexte(
+              uneQuestion()
+                .avecReponsesPossibles([
+                  uneReponsePossible()
+                    .avecLibelle('Le libellé')
+                    .avecDetail('Le détail')
+                    .construis(),
+                ])
+                .construis()
+            )
+            .construis()
+        )
+        .construis();
+      await testeurMAC.entrepots.diagnostic().persiste(diagnostic);
+
+      const reponse = await executeRequete(
+        donneesServeur.app,
+        'GET',
+        `/api/diagnostic/${diagnostic.identifiant}`
+      );
+
+      const diagnosticRecu: RepresentationDiagnostic = await reponse.json();
+      expect(
+        diagnosticRecu.referentiel['contexte'].groupes[0].questions[0]
+          .reponsesPossibles[0].detail
+      ).toStrictEqual('Le détail');
+    });
+
     it("Renvoie une erreur HTTP 404 diagnostic non trouvé si le diagnostic n'existe pas", async () => {
       connecteUtilisateur(crypto.randomUUID());
 

--- a/mon-aide-cyber-api/test/constructeurs/constructeurReferentiel.ts
+++ b/mon-aide-cyber-api/test/constructeurs/constructeurReferentiel.ts
@@ -247,6 +247,7 @@ class ConstructeurReponsePossible implements Constructeur<ReponsePossible> {
     indice: Indice;
   };
   private regleDeGestion: RegleDeGestionAjouteReponse | undefined = undefined;
+  private detail?: string;
 
   ajouteUneQuestionATiroir(
     question: QuestionATiroir
@@ -261,6 +262,11 @@ class ConstructeurReponsePossible implements Constructeur<ReponsePossible> {
   avecLibelle(libelle: string): ConstructeurReponsePossible {
     this.libelle = libelle;
     this.identifiant = aseptise(libelle);
+    return this;
+  }
+
+  avecDetail(detail: string): ConstructeurReponsePossible {
+    this.detail = detail;
     return this;
   }
 
@@ -309,6 +315,7 @@ class ConstructeurReponsePossible implements Constructeur<ReponsePossible> {
       }),
       ...(this.questions && { questions: this.questions }),
       ...(this.regleDeGestion !== undefined && { regle: this.regleDeGestion }),
+      ...(this.detail !== undefined && { detail: this.detail }),
     };
   }
 }

--- a/mon-aide-cyber-api/test/diagnostic/CapteurCommandeLanceDiagnostic.spec.ts
+++ b/mon-aide-cyber-api/test/diagnostic/CapteurCommandeLanceDiagnostic.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   uneQuestion,
+  uneReponsePossible,
   unReferentiel,
 } from '../constructeurs/constructeurReferentiel';
 import { BusEvenementDeTest } from '../infrastructure/bus/BusEvenementDeTest';
@@ -63,6 +64,38 @@ describe('Capteur pour lancer un diagnostic', () => {
         reponseDonnee: { reponseUnique: null, reponsesMultiples: [] },
       },
     ]);
+  });
+
+  it('copie le référentiel disponible contenant le détail d’une réponse possible', async () => {
+    const referentiel = unReferentiel()
+      .ajouteUneQuestionAuContexte(
+        uneQuestion()
+          .avecReponsesPossibles([
+            uneReponsePossible().avecDetail('Le détail').construis(),
+          ])
+          .construis()
+      )
+      .construis();
+    adaptateurReferentiel.ajoute(referentiel);
+
+    const diagnostic = await new CapteurCommandeLanceDiagnostic(
+      entrepots,
+      new BusEvenementDeTest(),
+      adaptateurReferentiel,
+      adaptateurMesures
+    ).execute({
+      type: 'CommandeLanceDiagnostic',
+      identifiantAidant: crypto.randomUUID(),
+      emailEntite: 'betagouv@beta.gouv.fr',
+    });
+
+    const diagnosticRetourne = await entrepots
+      .diagnostic()
+      .lis(diagnostic.identifiant);
+    expect(
+      diagnosticRetourne.referentiel['contexte'].questions[0]
+        .reponsesPossibles[0].detail
+    ).toStrictEqual('Le détail');
   });
 
   it('les dates de création et modification sont initialisées', async () => {

--- a/mon-aide-cyber-ui/src/assets/styles/_diagnostic.scss
+++ b/mon-aide-cyber-ui/src/assets/styles/_diagnostic.scss
@@ -76,6 +76,10 @@
     background-color: rgba(#fdc82e, 0.1);
   }
 
+  .fr-highlight {
+    background-image: linear-gradient(0deg, var(--couleurs-mac-violet-fonce), var(--couleurs-mac-violet-fonce));
+  }
+
   @media screen and (max-width: 768px) {
 
     .contexte {

--- a/mon-aide-cyber-ui/src/composants/diagnostic/ConteneurReponsePossible.tsx
+++ b/mon-aide-cyber-ui/src/composants/diagnostic/ConteneurReponsePossible.tsx
@@ -159,6 +159,9 @@ export const ConteneurReponsePossible = ({
           })}
         </div>
       ))}
+      {reponse.detail && (
+        <div className="fr-highlight fr-text--sm">{reponse.detail}</div>
+      )}
     </ComposantReponsePossible>
   );
 };

--- a/mon-aide-cyber-ui/src/domaine/diagnostic/Referentiel.ts
+++ b/mon-aide-cyber-ui/src/domaine/diagnostic/Referentiel.ts
@@ -28,6 +28,7 @@ export type QuestionATiroir = Omit<Question, 'reponseDonnee'>;
 export type ReponsePossible = {
   identifiant: string;
   libelle: string;
+  detail?: string;
   ordre: number;
   questions?: QuestionATiroir[];
 };


### PR DESCRIPTION
Avec la mise en place du questionnaire au format RECYF, certaines réponses fournies dans le référentiel sont très longues et ne facilite pas la compréhension.
Cet encart placé sous la réponse à une question donne le détail de la réponse.
<img width="640"  alt="detail" src="https://github.com/user-attachments/assets/684965f5-0782-4416-91b5-28a4c2896185" />
